### PR TITLE
Errata 02 updates based on TC meeting 9 May 2017

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -239,15 +239,6 @@
                                                   numbered.<?datatype CDATA?><?default #IMPLIED?></dd>
                                         </dlentry>
                                 </dl>
-                                <dl>
-                                        <dlentry id="lomdatatype">
-                                                <dt><xmlatt>datatype</xmlatt></dt>
-                                                <dd>Available for describing the type of data
-                                                  contained in the value attribute for this metadata
-                                                  element. The default value is the empty string
-                                                  "".</dd>
-                                        </dlentry>
-                                </dl>
                         </sectiondiv><sectiondiv id="author-attributes">
                                 <p>The following attributes are available on this element: <xref
                                                 href="../langRef/attributes/universalAttributes.dita"

--- a/specification/errata-01/grammar-files.dita
+++ b/specification/errata-01/grammar-files.dita
@@ -9,14 +9,16 @@
       <p>The following changes were made:</p>
       <ul>
         <li>Restored certain public identifiers for grammar files to the catalog files. These
-          identifiers, which specify the latest in the 1.x releases of DITA, had been left out of
-          the DITA 1.3 and DITA 1.3, errata 01, catalog files.</li>
+          identifiers, which specify the latest in the 1.x releases of DITA, were left out of the
+          DITA 1.3 and DITA 1.3, errata 01, catalog files.</li>
         <li>Corrected typographic errors in the RNG catalog files for DITAVAL and
           subjectScheme.</li>
       </ul>
     </section>
     <section>
       <title>Document-type shells and module files</title>
+      <p>Corrected the content model of <xmlelement>ditavalref</xmlelement> so that it allows
+          <xmlelement>ditavalmeta</xmlelement> to appear zero-or-one times.</p>
     </section>
   </refbody>
 </reference>

--- a/specification/errata-01/written-spec.dita
+++ b/specification/errata-01/written-spec.dita
@@ -21,6 +21,19 @@
             it is a type of therapist.</stentry>
         </strow>
         <strow>
+          <stentry>3.2.2.16 <xmlelement>fn</xmlelement></stentry>
+          <stentry>
+            <dl>
+              <dlentry id="lomdatatype">
+                <dt><xmlatt>datatype</xmlatt></dt>
+                <dd>Available for describing the type of data contained in the value attribute for
+                  this metadata element. The default value is the empty string "".</dd>
+              </dlentry>
+            </dl>
+          </stentry>
+          <stentry>[Attribute description removed]</stentry>
+        </strow>
+        <strow>
           <stentry>3.4.2 Indexing group elements</stentry>
           <stentry>
             <lines><b>Related reference</b>
@@ -79,6 +92,19 @@
                 <ph>can</ph> be used with specialization.</line-through></p>
             <p><u><i>This element is not intended to be used in source files.</i></u></p>
           </stentry>
+        </strow>
+        <strow>
+          <stentry>3.10.7.4.19 <xmlelement>synnote</xmlelement></stentry>
+          <stentry>
+            <dl>
+              <dlentry>
+                <dt><xmlatt>datatype</xmlatt></dt>
+                <dd>Available for describing the type of data contained in the value attribute for
+                  this metadata element. The default value is the empty string "".</dd>
+              </dlentry>
+            </dl>
+          </stentry>
+          <stentry>[Attribute description removed]</stentry>
         </strow>
       </simpletable>
     </section>


### PR DESCRIPTION
* Removed attribute description for datatype from the conref used by fn and synnote