### PR TITLE
Cover: specification-level key no longer contains the revision number

### DIFF
--- a/specification/dita-1.3-errata01-specification-base.ditamap
+++ b/specification/dita-1.3-errata01-specification-base.ditamap
@@ -6,9 +6,9 @@
 <bookmap outputclass="specification" xml:lang="en-us">
 	<booktitle outputclass="specificationTitles">
 		<mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
-			Version 1.3 Part 1: Base Edition <ph rev="errata-02">Plus Errata 02</ph></mainbooktitle>
+			Version 1.3 Part 1: Base Edition <ph rev="errata-02">Plus Errata <keyword keyref="errata-num"/></ph></mainbooktitle>
 		<booktitlealt outputclass="specificationSubtitle1"><keyword keyref="specification-level"
-			/></booktitlealt>
+			/> <keyword keyref="revision-num"/></booktitlealt>
 		<booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"
 			/></booktitlealt>
 		<booktitlealt outputclass="specificationShorttitle">DITA Version 1.3

--- a/specification/dita-1.3-errata01-specification-learningTraining.ditamap
+++ b/specification/dita-1.3-errata01-specification-learningTraining.ditamap
@@ -6,9 +6,9 @@
 <bookmap outputclass="specification" xml:lang="en-us">
  <booktitle outputclass="specificationTitles">
   <mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
-   Version 1.3 Part 3: All-Inclusive Edition <ph rev="errata-02">Plus Errata 02</ph></mainbooktitle>
+   Version 1.3 Part 3: All-Inclusive Edition <ph rev="errata-02">Plus <keyword keyref="errata-num"/></ph></mainbooktitle>
   <booktitlealt outputclass="specificationSubtitle1"><keyword keyref="specification-level"
-   /></booktitlealt>
+   /> <keyword keyref="revision-num"/></booktitlealt>
   <booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"/></booktitlealt>
   <booktitlealt outputclass="specificationShorttitle">DITA Version 1.3 Specification</booktitlealt>
  </booktitle>

--- a/specification/dita-1.3-errata01-specification-overview.ditamap
+++ b/specification/dita-1.3-errata01-specification-overview.ditamap
@@ -2,17 +2,17 @@
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA BookMap//EN" "bookmap.dtd">
 
 <bookmap outputclass="specification" xml:lang="en-us">
- <booktitle outputclass="specificationTitles">
-  <!-- For non-OASIS publishing: Ensure that you include platform="external-publishing-engine"
+  <booktitle outputclass="specificationTitles">
+    <!-- For non-OASIS publishing: Ensure that you include platform="external-publishing-engine"
      and exclude platform="dita-tc-publishing". This will ensure that specification URIs and
      OASIS notices are rendered. -->
-  <mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
-   Version 1.3 Part 0: Overview <ph rev="errata-02">Plus Errata 02</ph></mainbooktitle>
-  <booktitlealt outputclass="specificationSubtitle1"><keyword keyref="specification-level"
-   /></booktitlealt>
-  <booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"/></booktitlealt>
-  <booktitlealt outputclass="specificationShorttitle">DITA Version 1.3 Specification</booktitlealt>
- </booktitle>
+    <mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
+      Version 1.3 Part 0: Overview <ph rev="errata-02">Plus Errata <keyword keyref="errata-num"/></ph></mainbooktitle>
+    <booktitlealt outputclass="specificationSubtitle1">
+      <keyword keyref="specification-level"/> <keyword keyref="revision-num"/></booktitlealt>
+    <booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"/></booktitlealt>
+    <booktitlealt outputclass="specificationShorttitle">DITA Version 1.3 Specification</booktitlealt>
+  </booktitle>
  <bookmeta>
   <shortdesc>DITA 1.3 specification</shortdesc>
   <author>OASIS DITA Technical Committee</author>

--- a/specification/dita-1.3-errata01-specification-technicalContent.ditamap
+++ b/specification/dita-1.3-errata01-specification-technicalContent.ditamap
@@ -6,10 +6,9 @@
 <bookmap outputclass="specification" xml:lang="en-us">
  <booktitle outputclass="specificationTitles">
   <mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
-   Version 1.3 Part 2: Technical Content Edition <ph rev="errata-02">Plus Errata
-   02</ph></mainbooktitle>
+   Version 1.3 Part 2: Technical Content Edition <ph rev="errata-02">Plus Errata <keyword keyref="errata-num"/></ph></mainbooktitle>
   <booktitlealt outputclass="specificationSubtitle1"><keyword keyref="specification-level"
-   /></booktitlealt>
+  /> <keyword keyref="revision-num"/></booktitlealt>
   <booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"/></booktitlealt>
   <booktitlealt outputclass="specificationShorttitle">DITA Version 1.3 Specification</booktitlealt>
  </booktitle>

--- a/specification/dita-1.3-errata01-specification.ditamap
+++ b/specification/dita-1.3-errata01-specification.ditamap
@@ -6,9 +6,9 @@
 <bookmap outputclass="specification" xml:lang="en-us">
 	<booktitle outputclass="specificationTitles">
 		<mainbooktitle outputclass="specificationTitle">Darwin Information Typing Architecture (DITA)
-			Version 1.3 Errata 02</mainbooktitle>
+			Version 1.3 Errata <keyword keyref="errata-num"/></mainbooktitle>
 		<booktitlealt outputclass="specificationSubtitle1"><keyword keyref="specification-level"
-			/></booktitlealt>
+			/>  <keyword keyref="revision-num"/></booktitlealt>
 		<booktitlealt outputclass="specificationApproved"><keyword keyref="approval-date"
 			/></booktitlealt>
 		<booktitlealt outputclass="specificationShorttitle">DITA Version 1.3 Specification Errata

--- a/specification/dita-13-key-definitions-common-metadata.ditamap
+++ b/specification/dita-13-key-definitions-common-metadata.ditamap
@@ -28,7 +28,7 @@
   <keydef keys="stage-abbrev">
    <topicmeta>
     <keywords>
-     <keyword>csprd</keyword>
+     <keyword>wd</keyword>
     </keywords>
    </topicmeta>
   </keydef>

--- a/specification/dita-13-key-definitions-cover-pages.ditamap
+++ b/specification/dita-13-key-definitions-cover-pages.ditamap
@@ -18,7 +18,8 @@
     <keydef keys="specification-level">
       <topicmeta>
         <keywords>
-          <keyword>Working Draft 01</keyword>
+          <!-- The stylesheet will add the revision number -->
+          <keyword>Working Draft</keyword>
         </keywords>
       </topicmeta>
     </keydef>


### PR DESCRIPTION
This pull request replaces the revision number in other keys and in bookmaps with the revision-number keyword.