### PR TITLE
Feature/remove rowheaders default, add @format to image

### DIFF
--- a/doctypes/dtd/base/dtd/commonElements.mod
+++ b/doctypes/dtd/base/dtd/commonElements.mod
@@ -1369,6 +1369,9 @@
                            inline |
                            -dita-use-conref-target)
                                     'inline'
+               format
+                          CDATA
+                                    #IMPLIED
                %univ-atts;
                outputclass
                           CDATA

--- a/doctypes/dtd/base/dtd/tblDecl.mod
+++ b/doctypes/dtd/base/dtd/tblDecl.mod
@@ -322,7 +322,7 @@
                            headers |
                            norowheader |
                            -dita-use-conref-target)
-                                    'headers'
+                                    #IMPLIED
                %tbl.colspec.att;
                %dita.colspec.attributes;"
 >

--- a/doctypes/rng/base/rng/commonElementsMod.rng
+++ b/doctypes/rng/base/rng/commonElementsMod.rng
@@ -2385,6 +2385,9 @@ ORIGINAL CREATION DATE:
               </choice>
             </attribute>
           </optional>
+          <optional>
+            <attribute name="format" dita:since="1.3 errata 02"/>
+          </optional>
           <ref name="univ-atts"/>
           <optional>
             <attribute name="outputclass"/>

--- a/doctypes/rng/base/rng/tblDeclMod.rng
+++ b/doctypes/rng/base/rng/tblDeclMod.rng
@@ -439,8 +439,7 @@ For <entry>, add:
       </attribute>
     </optional>
     <optional>
-      <attribute name="rowheader" dita:since="1.3"
-        a:defaultValue="headers">
+      <attribute name="rowheader" dita:since="1.3">
         <choice>
           <value>firstcol</value>
           <value dita:since="1.3">headers</value>

--- a/doctypes/schema-url/base/xsd/commonElementMod.xsd
+++ b/doctypes/schema-url/base/xsd/commonElementMod.xsd
@@ -2099,7 +2099,8 @@
             </xs:restriction>
          </xs:simpleType>
       </xs:attribute>
-      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="format" type="xs:string"/>
+     <xs:attributeGroup ref="univ-atts"/>
       <xs:attribute name="outputclass" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>

--- a/doctypes/schema-url/base/xsd/tblDeclMod.xsd
+++ b/doctypes/schema-url/base/xsd/tblDeclMod.xsd
@@ -350,7 +350,7 @@
       </xs:attribute>
       <xs:attribute name="char" type="xs:string"/>
       <xs:attribute name="charoff" type="xs:NMTOKEN"/>
-      <xs:attribute name="rowheader" default="headers">
+      <xs:attribute name="rowheader">
          <xs:simpleType>
             <xs:restriction base="xs:string">
                <xs:enumeration value="firstcol"/>

--- a/doctypes/schema/base/xsd/commonElementMod.xsd
+++ b/doctypes/schema/base/xsd/commonElementMod.xsd
@@ -2099,7 +2099,8 @@
             </xs:restriction>
          </xs:simpleType>
       </xs:attribute>
-      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="format" type="xs:string"/>
+     <xs:attributeGroup ref="univ-atts"/>
       <xs:attribute name="outputclass" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>

--- a/doctypes/schema/base/xsd/tblDeclMod.xsd
+++ b/doctypes/schema/base/xsd/tblDeclMod.xsd
@@ -350,7 +350,7 @@
       </xs:attribute>
       <xs:attribute name="char" type="xs:string"/>
       <xs:attribute name="charoff" type="xs:NMTOKEN"/>
-      <xs:attribute name="rowheader" default="headers">
+      <xs:attribute name="rowheader">
          <xs:simpleType>
             <xs:restriction base="xs:string">
                <xs:enumeration value="firstcol"/>


### PR DESCRIPTION
Add @format to image, remove "headers" default for @rowheaders on colspec