### PR TITLE
Update headers for Errata 02 public review

### DIFF
--- a/doctypes/README.md
+++ b/doctypes/README.md
@@ -1,7 +1,7 @@
-# DITA 1.3 Errata 01 Grammar files
+# DITA 1.3 Errata 02 Grammar files
 
 This directory contains the Relax NG, DTD, and XML Schema versions of the DITA Version 1.3 grammar files. 
-These grammar files are based on DITA Version 1.3 Part 3: All-Inclusive Edition Plus Errata 01:
-http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/dita-v1.3-errata01-os-part3-all-inclusive-complete.html
+These grammar files are based on DITA Version 1.3 Part 3: All-Inclusive Edition Plus Errata 02:
+http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 This directory also contains extra catalog files used to generate Base and Technical Content editions of the grammar files.

--- a/doctypes/dtd/base/dtd/basemap.dtd
+++ b/doctypes/dtd/base/dtd/basemap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                               HEADER                          -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Base MAP (only base domains)                 -->

--- a/doctypes/dtd/base/dtd/basemap.dtd
+++ b/doctypes/dtd/base/dtd/basemap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/base/dtd/basetopic.dtd
+++ b/doctypes/dtd/base/dtd/basetopic.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/base/dtd/basetopic.dtd
+++ b/doctypes/dtd/base/dtd/basetopic.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Topic Base (only base domains)               -->

--- a/doctypes/dtd/base/dtd/map.mod
+++ b/doctypes/dtd/base/dtd/map.mod
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Map                                          -->

--- a/doctypes/dtd/base/dtd/map.mod
+++ b/doctypes/dtd/base/dtd/map.mod
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/base/dtd/topic.mod
+++ b/doctypes/dtd/base/dtd/topic.mod
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA DITA Topic                                   -->

--- a/doctypes/dtd/base/dtd/topic.mod
+++ b/doctypes/dtd/base/dtd/topic.mod
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Bookmap                                      -->

--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/ditaval/dtd/ditaval.dtd
+++ b/doctypes/dtd/ditaval/dtd/ditaval.dtd
@@ -4,7 +4,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/ditaval/dtd/ditaval.dtd
+++ b/doctypes/dtd/ditaval/dtd/ditaval.dtd
@@ -1,11 +1,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA DITAVAL DTD                                  -->

--- a/doctypes/dtd/learning/dtd/learningAssessment.dtd
+++ b/doctypes/dtd/learning/dtd/learningAssessment.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Learning Assessment Shell                    -->

--- a/doctypes/dtd/learning/dtd/learningAssessment.dtd
+++ b/doctypes/dtd/learning/dtd/learningAssessment.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningBookmap.dtd
+++ b/doctypes/dtd/learning/dtd/learningBookmap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Learning Bookmap                             -->

--- a/doctypes/dtd/learning/dtd/learningBookmap.dtd
+++ b/doctypes/dtd/learning/dtd/learningBookmap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningContent.dtd
+++ b/doctypes/dtd/learning/dtd/learningContent.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Learning Content DTD                         -->

--- a/doctypes/dtd/learning/dtd/learningContent.dtd
+++ b/doctypes/dtd/learning/dtd/learningContent.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningGroupMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningGroupMap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA learningGroupMap                              -->

--- a/doctypes/dtd/learning/dtd/learningGroupMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningGroupMap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningMap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA learningMap                                  -->

--- a/doctypes/dtd/learning/dtd/learningMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningMap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningObjectMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningObjectMap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA learningObjectMap                            -->

--- a/doctypes/dtd/learning/dtd/learningObjectMap.dtd
+++ b/doctypes/dtd/learning/dtd/learningObjectMap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningOverview.dtd
+++ b/doctypes/dtd/learning/dtd/learningOverview.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Learning Overview DTD                         -->

--- a/doctypes/dtd/learning/dtd/learningOverview.dtd
+++ b/doctypes/dtd/learning/dtd/learningOverview.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningPlan.dtd
+++ b/doctypes/dtd/learning/dtd/learningPlan.dtd
@@ -2,11 +2,11 @@
 <!--  ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Learning Plan DTD                            -->

--- a/doctypes/dtd/learning/dtd/learningPlan.dtd
+++ b/doctypes/dtd/learning/dtd/learningPlan.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/learning/dtd/learningSummary.dtd
+++ b/doctypes/dtd/learning/dtd/learningSummary.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Learning Summary                             -->

--- a/doctypes/dtd/learning/dtd/learningSummary.dtd
+++ b/doctypes/dtd/learning/dtd/learningSummary.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
+++ b/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Machinery Task                               -->

--- a/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
+++ b/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/subjectScheme/dtd/classifyMap.dtd
+++ b/doctypes/dtd/subjectScheme/dtd/classifyMap.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Classification Map                           -->

--- a/doctypes/dtd/subjectScheme/dtd/classifyMap.dtd
+++ b/doctypes/dtd/subjectScheme/dtd/classifyMap.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/subjectScheme/dtd/subjectScheme.dtd
+++ b/doctypes/dtd/subjectScheme/dtd/subjectScheme.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Subject Scheme Map                           -->

--- a/doctypes/dtd/subjectScheme/dtd/subjectScheme.dtd
+++ b/doctypes/dtd/subjectScheme/dtd/subjectScheme.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/concept.dtd
+++ b/doctypes/dtd/technicalContent/dtd/concept.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Concept Shell                                -->

--- a/doctypes/dtd/technicalContent/dtd/concept.dtd
+++ b/doctypes/dtd/technicalContent/dtd/concept.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA BASE DTD                                     -->

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/dtd/generalTask.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA General Task Shell                           -->

--- a/doctypes/dtd/technicalContent/dtd/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/dtd/generalTask.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/glossary.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossary.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Glossary DTD                                 -->

--- a/doctypes/dtd/technicalContent/dtd/glossary.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossary.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Glossary Entry Shell                         -->

--- a/doctypes/dtd/technicalContent/dtd/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
@@ -2,11 +2,11 @@
 <!--  ============================================================ -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Glossary Group Shell                         -->

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA MAP Shell                                    -->

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/reference.dtd
+++ b/doctypes/dtd/technicalContent/dtd/reference.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Reference DTD                                -->

--- a/doctypes/dtd/technicalContent/dtd/reference.dtd
+++ b/doctypes/dtd/technicalContent/dtd/reference.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/task.dtd
+++ b/doctypes/dtd/technicalContent/dtd/task.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Task Shell                                   -->

--- a/doctypes/dtd/technicalContent/dtd/task.dtd
+++ b/doctypes/dtd/technicalContent/dtd/task.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/topic.dtd
+++ b/doctypes/dtd/technicalContent/dtd/topic.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Topic                                        -->

--- a/doctypes/dtd/technicalContent/dtd/topic.dtd
+++ b/doctypes/dtd/technicalContent/dtd/topic.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Troubleshooting Shell                        -->

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/rng/base/rng/basemap.rng
+++ b/doctypes/rng/base/rng/basemap.rng
@@ -11,11 +11,11 @@
 =============================================================
                               HEADER
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Base MAP (only base domains)

--- a/doctypes/rng/base/rng/basemap.rng
+++ b/doctypes/rng/base/rng/basemap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/base/rng/basetopic.rng
+++ b/doctypes/rng/base/rng/basetopic.rng
@@ -12,7 +12,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/base/rng/basetopic.rng
+++ b/doctypes/rng/base/rng/basetopic.rng
@@ -9,11 +9,11 @@
 =============================================================
                    HEADER
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Topic Base (only base domains)

--- a/doctypes/rng/base/rng/mapMod.rng
+++ b/doctypes/rng/base/rng/mapMod.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 ============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 =============================================================
  MODULE:    DITA Map                                         
  VERSION:   1.3                                              

--- a/doctypes/rng/base/rng/mapMod.rng
+++ b/doctypes/rng/base/rng/mapMod.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 =============================================================
  MODULE:    DITA Map                                         

--- a/doctypes/rng/base/rng/topicMod.rng
+++ b/doctypes/rng/base/rng/topicMod.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/base/rng/topicMod.rng
+++ b/doctypes/rng/base/rng/topicMod.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA DITA Topic                                  

--- a/doctypes/rng/bookmap/rng/bookmap.rng
+++ b/doctypes/rng/bookmap/rng/bookmap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/bookmap/rng/bookmap.rng
+++ b/doctypes/rng/bookmap/rng/bookmap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Bookmap                                 

--- a/doctypes/rng/ditaval/rng/ditaval.rng
+++ b/doctypes/rng/ditaval/rng/ditaval.rng
@@ -10,11 +10,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA DITAVAL DTD                                 

--- a/doctypes/rng/ditaval/rng/ditaval.rng
+++ b/doctypes/rng/ditaval/rng/ditaval.rng
@@ -13,7 +13,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningAssessment.rng
+++ b/doctypes/rng/learning/rng/learningAssessment.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningAssessment.rng
+++ b/doctypes/rng/learning/rng/learningAssessment.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Learning Assessment Shell                     

--- a/doctypes/rng/learning/rng/learningBookmap.rng
+++ b/doctypes/rng/learning/rng/learningBookmap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningBookmap.rng
+++ b/doctypes/rng/learning/rng/learningBookmap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Learning Bookmap                        

--- a/doctypes/rng/learning/rng/learningContent.rng
+++ b/doctypes/rng/learning/rng/learningContent.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Learning Content                        

--- a/doctypes/rng/learning/rng/learningContent.rng
+++ b/doctypes/rng/learning/rng/learningContent.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningGroupMap.rng
+++ b/doctypes/rng/learning/rng/learningGroupMap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningGroupMap.rng
+++ b/doctypes/rng/learning/rng/learningGroupMap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA learningGroupMap                             

--- a/doctypes/rng/learning/rng/learningMap.rng
+++ b/doctypes/rng/learning/rng/learningMap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA learningMap

--- a/doctypes/rng/learning/rng/learningMap.rng
+++ b/doctypes/rng/learning/rng/learningMap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningObjectMap.rng
+++ b/doctypes/rng/learning/rng/learningObjectMap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningObjectMap.rng
+++ b/doctypes/rng/learning/rng/learningObjectMap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA learningObjectMap                             

--- a/doctypes/rng/learning/rng/learningOverview.rng
+++ b/doctypes/rng/learning/rng/learningOverview.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningOverview.rng
+++ b/doctypes/rng/learning/rng/learningOverview.rng
@@ -11,11 +11,11 @@
 =============================================================
                   HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
 MODULE:    DITA Learning Overview DTD                       

--- a/doctypes/rng/learning/rng/learningPlan.rng
+++ b/doctypes/rng/learning/rng/learningPlan.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningPlan.rng
+++ b/doctypes/rng/learning/rng/learningPlan.rng
@@ -11,11 +11,11 @@
  =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Learning Plan DTD                           

--- a/doctypes/rng/learning/rng/learningSummary.rng
+++ b/doctypes/rng/learning/rng/learningSummary.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/learning/rng/learningSummary.rng
+++ b/doctypes/rng/learning/rng/learningSummary.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Learning Summary                            

--- a/doctypes/rng/machineryIndustry/rng/machineryTask.rng
+++ b/doctypes/rng/machineryIndustry/rng/machineryTask.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Machinery Task

--- a/doctypes/rng/machineryIndustry/rng/machineryTask.rng
+++ b/doctypes/rng/machineryIndustry/rng/machineryTask.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/subjectScheme/rng/classifyMap.rng
+++ b/doctypes/rng/subjectScheme/rng/classifyMap.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/subjectScheme/rng/classifyMap.rng
+++ b/doctypes/rng/subjectScheme/rng/classifyMap.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Classification Map

--- a/doctypes/rng/subjectScheme/rng/subjectScheme.rng
+++ b/doctypes/rng/subjectScheme/rng/subjectScheme.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Subject Scheme Map                      

--- a/doctypes/rng/subjectScheme/rng/subjectScheme.rng
+++ b/doctypes/rng/subjectScheme/rng/subjectScheme.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -9,11 +9,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Concept Shell                                 

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -12,7 +12,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA BASE DTD                                    

--- a/doctypes/rng/technicalContent/rng/generalTask.rng
+++ b/doctypes/rng/technicalContent/rng/generalTask.rng
@@ -12,7 +12,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/generalTask.rng
+++ b/doctypes/rng/technicalContent/rng/generalTask.rng
@@ -9,11 +9,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA General Task Shell                        

--- a/doctypes/rng/technicalContent/rng/glossary.rng
+++ b/doctypes/rng/technicalContent/rng/glossary.rng
@@ -8,11 +8,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Glossary DTD                                

--- a/doctypes/rng/technicalContent/rng/glossary.rng
+++ b/doctypes/rng/technicalContent/rng/glossary.rng
@@ -11,7 +11,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/glossentry.rng
+++ b/doctypes/rng/technicalContent/rng/glossentry.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Glossary Entry Shell                 

--- a/doctypes/rng/technicalContent/rng/glossentry.rng
+++ b/doctypes/rng/technicalContent/rng/glossentry.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/glossgroup.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroup.rng
@@ -12,7 +12,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/glossgroup.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroup.rng
@@ -9,11 +9,11 @@
  =============================================================
                    HEADER                                     
 ============================================================= 
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Glossary Group Shell                         

--- a/doctypes/rng/technicalContent/rng/map.rng
+++ b/doctypes/rng/technicalContent/rng/map.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/map.rng
+++ b/doctypes/rng/technicalContent/rng/map.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA MAP Shell                              

--- a/doctypes/rng/technicalContent/rng/reference.rng
+++ b/doctypes/rng/technicalContent/rng/reference.rng
@@ -9,11 +9,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Reference DTD                               

--- a/doctypes/rng/technicalContent/rng/reference.rng
+++ b/doctypes/rng/technicalContent/rng/reference.rng
@@ -12,7 +12,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/task.rng
+++ b/doctypes/rng/technicalContent/rng/task.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Task Shell                                  

--- a/doctypes/rng/technicalContent/rng/task.rng
+++ b/doctypes/rng/technicalContent/rng/task.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/topic.rng
+++ b/doctypes/rng/technicalContent/rng/topic.rng
@@ -10,11 +10,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Topic                                  

--- a/doctypes/rng/technicalContent/rng/topic.rng
+++ b/doctypes/rng/technicalContent/rng/topic.rng
@@ -13,7 +13,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshooting.rng
@@ -14,7 +14,7 @@
 Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
 16 January 2018 
-Copyright (c) OASIS Open 2016. All rights reserved. 
+Copyright (c) OASIS Open 2018. All rights reserved. 
 Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================

--- a/doctypes/rng/technicalContent/rng/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshooting.rng
@@ -11,11 +11,11 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
 OASIS Standard
-25 October 2016 
+16 January 2018 
 Copyright (c) OASIS Open 2016. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
 
 ============================================================
  MODULE:    DITA Troubleshooting Shell                                  

--- a/doctypes/schema-url/base/xsd/basemap.xsd
+++ b/doctypes/schema-url/base/xsd/basemap.xsd
@@ -2,11 +2,11 @@
 <!--=============================================================-->
 <!--                              HEADER                         -->
 <!--=============================================================-->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Base MAP (only base domains)                -->

--- a/doctypes/schema-url/base/xsd/basemap.xsd
+++ b/doctypes/schema-url/base/xsd/basemap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/base/xsd/basetopic.xsd
+++ b/doctypes/schema-url/base/xsd/basetopic.xsd
@@ -2,11 +2,11 @@
 <!--=============================================================-->
 <!--                   HEADER                                    -->
 <!--=============================================================-->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Topic Base (only base domains)              -->

--- a/doctypes/schema-url/base/xsd/basetopic.xsd
+++ b/doctypes/schema-url/base/xsd/basetopic.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/base/xsd/mapMod.xsd
+++ b/doctypes/schema-url/base/xsd/mapMod.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                             -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA MAP XSD Module                               -->

--- a/doctypes/schema-url/base/xsd/mapMod.xsd
+++ b/doctypes/schema-url/base/xsd/mapMod.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                             -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/base/xsd/topicMod.xsd
+++ b/doctypes/schema-url/base/xsd/topicMod.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA Topic XSD Module                             -->

--- a/doctypes/schema-url/base/xsd/topicMod.xsd
+++ b/doctypes/schema-url/base/xsd/topicMod.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA Topic XSD Module                             -->
 <!--  VERSION:   1.3                                               -->

--- a/doctypes/schema-url/bookmap/xsd/bookmap.xsd
+++ b/doctypes/schema-url/bookmap/xsd/bookmap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                             -->
 <!--=============================================================-->

--- a/doctypes/schema-url/bookmap/xsd/bookmap.xsd
+++ b/doctypes/schema-url/bookmap/xsd/bookmap.xsd
@@ -2,11 +2,11 @@
 <!--=============================================================-->
 <!--                   HEADER                                    -->
 <!--=============================================================-->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                             -->
 <!--=============================================================-->
 <!--=============================================================-->

--- a/doctypes/schema-url/ditaval/xsd/ditaval.xsd
+++ b/doctypes/schema-url/ditaval/xsd/ditaval.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA  DITAVAL XML Schema                           -->

--- a/doctypes/schema-url/ditaval/xsd/ditaval.xsd
+++ b/doctypes/schema-url/ditaval/xsd/ditaval.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningAssessment.xsd
+++ b/doctypes/schema-url/learning/xsd/learningAssessment.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- MODULE:    DITA learningAssessment XSD                        -->
 <!-- VERSION:   1.3                                                -->

--- a/doctypes/schema-url/learning/xsd/learningAssessment.xsd
+++ b/doctypes/schema-url/learning/xsd/learningAssessment.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- MODULE:    DITA learningAssessment XSD                        -->

--- a/doctypes/schema-url/learning/xsd/learningContent.xsd
+++ b/doctypes/schema-url/learning/xsd/learningContent.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA learningContent XSD                          -->

--- a/doctypes/schema-url/learning/xsd/learningContent.xsd
+++ b/doctypes/schema-url/learning/xsd/learningContent.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningMap.xsd
+++ b/doctypes/schema-url/learning/xsd/learningMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Learning  Map                                 -->

--- a/doctypes/schema-url/learning/xsd/learningMap.xsd
+++ b/doctypes/schema-url/learning/xsd/learningMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningObjectMap.xsd
+++ b/doctypes/schema-url/learning/xsd/learningObjectMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningObjectMap                             -->

--- a/doctypes/schema-url/learning/xsd/learningObjectMap.xsd
+++ b/doctypes/schema-url/learning/xsd/learningObjectMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningOverview.xsd
+++ b/doctypes/schema-url/learning/xsd/learningOverview.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningOverview XSD                          -->

--- a/doctypes/schema-url/learning/xsd/learningOverview.xsd
+++ b/doctypes/schema-url/learning/xsd/learningOverview.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningPlan.xsd
+++ b/doctypes/schema-url/learning/xsd/learningPlan.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningPlan XSD                              -->

--- a/doctypes/schema-url/learning/xsd/learningPlan.xsd
+++ b/doctypes/schema-url/learning/xsd/learningPlan.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/learning/xsd/learningSummary.xsd
+++ b/doctypes/schema-url/learning/xsd/learningSummary.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningSummary XSD                           -->

--- a/doctypes/schema-url/learning/xsd/learningSummary.xsd
+++ b/doctypes/schema-url/learning/xsd/learningSummary.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/machineryIndustry/xsd/machineryTask.xsd
+++ b/doctypes/schema-url/machineryIndustry/xsd/machineryTask.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Machinery Task XSD                            -->

--- a/doctypes/schema-url/machineryIndustry/xsd/machineryTask.xsd
+++ b/doctypes/schema-url/machineryIndustry/xsd/machineryTask.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/subjectScheme/xsd/classifyMap.xsd
+++ b/doctypes/schema-url/subjectScheme/xsd/classifyMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Classification Map XSD                        -->

--- a/doctypes/schema-url/subjectScheme/xsd/classifyMap.xsd
+++ b/doctypes/schema-url/subjectScheme/xsd/classifyMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/subjectScheme/xsd/subjectScheme.xsd
+++ b/doctypes/schema-url/subjectScheme/xsd/subjectScheme.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Subject Scheme Map XSD                        -->

--- a/doctypes/schema-url/subjectScheme/xsd/subjectScheme.xsd
+++ b/doctypes/schema-url/subjectScheme/xsd/subjectScheme.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/concept.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/concept.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Concept XSD                                   -->

--- a/doctypes/schema-url/technicalContent/xsd/concept.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/concept.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/ditabase.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/ditabase.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA BASE XSD                                      -->

--- a/doctypes/schema-url/technicalContent/xsd/ditabase.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/ditabase.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/generalTask.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/generalTask.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA General Task Shell                            -->

--- a/doctypes/schema-url/technicalContent/xsd/generalTask.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/generalTask.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/glossary.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossary.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Glossary XSD                                  -->

--- a/doctypes/schema-url/technicalContent/xsd/glossary.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossary.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/glossentry.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossentry.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Glossary XSD                                  -->

--- a/doctypes/schema-url/technicalContent/xsd/glossentry.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossentry.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/glossgroup.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossgroup.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Concept XSD                                   -->

--- a/doctypes/schema-url/technicalContent/xsd/glossgroup.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/glossgroup.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/map.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/map.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA MAP XSD                                       -->

--- a/doctypes/schema-url/technicalContent/xsd/map.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/map.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/reference.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/reference.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Reference XSD                                 -->

--- a/doctypes/schema-url/technicalContent/xsd/reference.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/reference.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/task.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/task.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Task XSD                                      -->

--- a/doctypes/schema-url/technicalContent/xsd/task.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/task.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/topic.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/topic.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Topic XSD                                     -->

--- a/doctypes/schema-url/technicalContent/xsd/topic.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/topic.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/troubleshooting.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/troubleshooting.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema-url/technicalContent/xsd/troubleshooting.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/troubleshooting.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Troubleshooting Shell                         -->

--- a/doctypes/schema/base/xsd/basemap.xsd
+++ b/doctypes/schema/base/xsd/basemap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/base/xsd/basemap.xsd
+++ b/doctypes/schema/base/xsd/basemap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                              HEADER                           -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Base MAP (only base domains)                  -->

--- a/doctypes/schema/base/xsd/basetopic.xsd
+++ b/doctypes/schema/base/xsd/basetopic.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/base/xsd/basetopic.xsd
+++ b/doctypes/schema/base/xsd/basetopic.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Topic Base (only base domains)               -->

--- a/doctypes/schema/base/xsd/mapMod.xsd
+++ b/doctypes/schema/base/xsd/mapMod.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA MAP XSD Module                               -->

--- a/doctypes/schema/base/xsd/mapMod.xsd
+++ b/doctypes/schema/base/xsd/mapMod.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/base/xsd/topicMod.xsd
+++ b/doctypes/schema/base/xsd/topicMod.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA Topic XSD Module                             -->

--- a/doctypes/schema/base/xsd/topicMod.xsd
+++ b/doctypes/schema/base/xsd/topicMod.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA Topic XSD Module                             -->
 <!--  VERSION:   1.3                                               -->

--- a/doctypes/schema/bookmap/xsd/bookmap.xsd
+++ b/doctypes/schema/bookmap/xsd/bookmap.xsd
@@ -2,11 +2,11 @@
 <!--=============================================================-->
 <!--                     HEADER                                    -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->

--- a/doctypes/schema/bookmap/xsd/bookmap.xsd
+++ b/doctypes/schema/bookmap/xsd/bookmap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/ditaval/xsd/ditaval.xsd
+++ b/doctypes/schema/ditaval/xsd/ditaval.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                     HEADER                                    -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA  DITAVAL XML Schema                          -->

--- a/doctypes/schema/ditaval/xsd/ditaval.xsd
+++ b/doctypes/schema/ditaval/xsd/ditaval.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningAssessment.xsd
+++ b/doctypes/schema/learning/xsd/learningAssessment.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA learningAssessment XSD                       -->

--- a/doctypes/schema/learning/xsd/learningAssessment.xsd
+++ b/doctypes/schema/learning/xsd/learningAssessment.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!--  MODULE:    DITA learningAssessment XSD                       -->
 <!--  VERSION:   1.3                                               -->

--- a/doctypes/schema/learning/xsd/learningBookmap.xsd
+++ b/doctypes/schema/learning/xsd/learningBookmap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA BOOKMAP XSD                                  -->

--- a/doctypes/schema/learning/xsd/learningBookmap.xsd
+++ b/doctypes/schema/learning/xsd/learningBookmap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningContent.xsd
+++ b/doctypes/schema/learning/xsd/learningContent.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA learningContent XSD                          -->

--- a/doctypes/schema/learning/xsd/learningContent.xsd
+++ b/doctypes/schema/learning/xsd/learningContent.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningMap.xsd
+++ b/doctypes/schema/learning/xsd/learningMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Learning  Map                                 -->

--- a/doctypes/schema/learning/xsd/learningMap.xsd
+++ b/doctypes/schema/learning/xsd/learningMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningObjectMap.xsd
+++ b/doctypes/schema/learning/xsd/learningObjectMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningObjectMap                             -->

--- a/doctypes/schema/learning/xsd/learningObjectMap.xsd
+++ b/doctypes/schema/learning/xsd/learningObjectMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningOverview.xsd
+++ b/doctypes/schema/learning/xsd/learningOverview.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningOverview XSD                          -->

--- a/doctypes/schema/learning/xsd/learningOverview.xsd
+++ b/doctypes/schema/learning/xsd/learningOverview.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningPlan.xsd
+++ b/doctypes/schema/learning/xsd/learningPlan.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningPlan XSD                              -->

--- a/doctypes/schema/learning/xsd/learningPlan.xsd
+++ b/doctypes/schema/learning/xsd/learningPlan.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/learning/xsd/learningSummary.xsd
+++ b/doctypes/schema/learning/xsd/learningSummary.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA learningSummary XSD                           -->

--- a/doctypes/schema/learning/xsd/learningSummary.xsd
+++ b/doctypes/schema/learning/xsd/learningSummary.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/machineryIndustry/xsd/machineryTask.xsd
+++ b/doctypes/schema/machineryIndustry/xsd/machineryTask.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Machinery Task XSD                            -->

--- a/doctypes/schema/machineryIndustry/xsd/machineryTask.xsd
+++ b/doctypes/schema/machineryIndustry/xsd/machineryTask.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/subjectScheme/xsd/classifyMap.xsd
+++ b/doctypes/schema/subjectScheme/xsd/classifyMap.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Classification Map XSD                        -->

--- a/doctypes/schema/subjectScheme/xsd/classifyMap.xsd
+++ b/doctypes/schema/subjectScheme/xsd/classifyMap.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/subjectScheme/xsd/subjectScheme.xsd
+++ b/doctypes/schema/subjectScheme/xsd/subjectScheme.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Subject Scheme Map XSD                        -->

--- a/doctypes/schema/subjectScheme/xsd/subjectScheme.xsd
+++ b/doctypes/schema/subjectScheme/xsd/subjectScheme.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/concept.xsd
+++ b/doctypes/schema/technicalContent/xsd/concept.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Concept XSD                                   -->

--- a/doctypes/schema/technicalContent/xsd/concept.xsd
+++ b/doctypes/schema/technicalContent/xsd/concept.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/ditabase.xsd
+++ b/doctypes/schema/technicalContent/xsd/ditabase.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA BASE XSD                                      -->

--- a/doctypes/schema/technicalContent/xsd/ditabase.xsd
+++ b/doctypes/schema/technicalContent/xsd/ditabase.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/generalTask.xsd
+++ b/doctypes/schema/technicalContent/xsd/generalTask.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA General Task Shell                            -->

--- a/doctypes/schema/technicalContent/xsd/generalTask.xsd
+++ b/doctypes/schema/technicalContent/xsd/generalTask.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/glossary.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossary.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Glossary XSD                                  -->

--- a/doctypes/schema/technicalContent/xsd/glossary.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossary.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/glossentry.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossentry.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Glossary XSD                                  -->

--- a/doctypes/schema/technicalContent/xsd/glossentry.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossentry.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/glossgroup.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossgroup.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                   HEADER                                      -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Concept XSD                                   -->

--- a/doctypes/schema/technicalContent/xsd/glossgroup.xsd
+++ b/doctypes/schema/technicalContent/xsd/glossgroup.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/map.xsd
+++ b/doctypes/schema/technicalContent/xsd/map.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA MAP XSD                                       -->

--- a/doctypes/schema/technicalContent/xsd/map.xsd
+++ b/doctypes/schema/technicalContent/xsd/map.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/reference.xsd
+++ b/doctypes/schema/technicalContent/xsd/reference.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Reference XSD                                 -->

--- a/doctypes/schema/technicalContent/xsd/reference.xsd
+++ b/doctypes/schema/technicalContent/xsd/reference.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/task.xsd
+++ b/doctypes/schema/technicalContent/xsd/task.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Task XSD                                      -->

--- a/doctypes/schema/technicalContent/xsd/task.xsd
+++ b/doctypes/schema/technicalContent/xsd/task.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/topic.xsd
+++ b/doctypes/schema/technicalContent/xsd/topic.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Topic XSD                                     -->

--- a/doctypes/schema/technicalContent/xsd/topic.xsd
+++ b/doctypes/schema/technicalContent/xsd/topic.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/troubleshooting.xsd
+++ b/doctypes/schema/technicalContent/xsd/troubleshooting.xsd
@@ -5,7 +5,7 @@
 <!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
 <!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
 <!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->

--- a/doctypes/schema/technicalContent/xsd/troubleshooting.xsd
+++ b/doctypes/schema/technicalContent/xsd/troubleshooting.xsd
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 01     -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
 <!-- OASIS Standard                                           -->
-<!-- 25 October 2016                                           -->
+<!-- 16 January 2018                                           -->
 <!-- Copyright (c) OASIS Open 2016. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part0-overview/dita-v1.3-errata01-os-part0-overview-complete.html                                -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- MODULE:    DITA Troubleshooting Shell                         -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Updates headers to reference Errata 02, date expected to approve for public review, and link to be used for public review:

```
<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
<!-- OASIS Standard                                           -->
<!-- 16 January 2018                                           -->
<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
```