### PR TITLE
Correct error that Tom Magliery identified

### DIFF
--- a/specification/archSpec/base/processing-controlled-attribute-values.dita
+++ b/specification/archSpec/base/processing-controlled-attribute-values.dita
@@ -3,8 +3,7 @@
 <concept xml:lang="en-us" id="concept_afh_lx1_wp">
  <title>Processing controlled attribute values</title>
  <shortdesc>An enumeration of controlled values can be defined with hierarchical levels by nesting
-    subject definitions. This <ph >affects</ph> how processors perform
-    filtering and flagging.</shortdesc>
+    subject definitions. This affects how processors perform filtering and flagging.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -80,9 +79,9 @@
         <li >If "therapist" is excluded, both "novice-therapist" and
           "expert-therapist" are by default excluded (unless they are explicitly set to be
           included).</li>
-        <li>If "therapist" is flagged and "novice<ph rev="errata-02">-therapist</ph>" is not
-          explicitly flagged, processors automatically should flag "novice" since it is a type of
-          therapist.</li>
+        <li>If "therapist" is flagged and "novice-therapist" is not explicitly flagged, processors
+          automatically should flag "novice<ph rev="errata-02">-therapist</ph>" since it is a type
+          of therapist.</li>
       </ul>
       <!--<draft-comment author="Kristen Eberlein" time="5 February 2015"><p>Comment by Dick Hamilton in the targeted review:</p><p>"One thing that's not 100% clear to me is whether "therapist" is a valid value for an attribute bound to the "users" set. I know "users" isn't, but I couldn't tell whether "therapist" is considered a category name, and thus invalid, or not. I'm guessing it's not, but it's at least possible that only the top level category name is considered invalid. </p><p>UPDATE: I see from the first example in the example topic below that "therapist" would be a valid name. Since that's in a non-normative part, it might be a good idea to make this point in a normative section."</p></draft-comment>-->
       <!--<p><term outputclass="RFC-2119">SHOULD</term> apply filtering to all subsets of therapist. If filtering includes "novice" but does not explicitly exclude "therapist", processing <term outputclass="RFC-2119">SHOULD</term> include the general therapist content because it applies to "novice". If flagging explicity includes "therapist" but is not set explicitly for "novice", processing <term outputclass="RFC-2119">SHOULD</term> apply the "therapist" flag to the "novice" content as a special type of therapist.</p>-->


### PR DESCRIPTION
Ensure that the sentence includes two instances of "novice-therapist"