### PR TITLE
Fix typos in two entity declarations

### DIFF
--- a/doctypes/dtd/base/dtd/commonElements.mod
+++ b/doctypes/dtd/base/dtd/commonElements.mod
@@ -73,7 +73,7 @@
 <!-- ============================================================= -->
 
 <!ENTITY % basic.ph
-              "%%cite; |
+              "%cite; |
                %keyword; |
                %ph; |
                %q; |
@@ -105,7 +105,7 @@
                %basic.ph;"
 >
 <!ENTITY % basic.ph.noxref.nocite
-              "%%keyword; |
+              "%keyword; |
                %ph; |
                %q; |
                %term; |


### PR DESCRIPTION
Two entities in `commonElements.mod` include `%%` at the start - noticed while trying to set up a test area for doctype changes.