### PR TITLE
Create automated test for DITA 2.0 doctypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: java
+jdk:
+- oraclejdk8
+env:
+  global:
+  - DITA_OT_VERSION=3.0.2
+script: 
+- curl -L https://github.com/dita-ot/dita-ot/releases/download/$DITA_OT_VERSION/dita-ot-$DITA_OT_VERSION.zip -o dita-ot-$DITA_OT_VERSION.zip
+- unzip dita-ot-$DITA_OT_VERSION.zip
+- export DITA_HOME=$PWD/dita-ot-$DITA_OT_VERSION
+# Create and install plugin for 2.0 with latest doctypes
+- mkdir $DITA_HOME/plugins/org.oasis-open.dita.v2_0/
+- cp -a ./doctypes/. $DITA_HOME/plugins/org.oasis-open.dita.v2_0/
+- cp .travis/ditaotplugin.xml $DITA_HOME/plugins/org.oasis-open.dita.v2_0/plugin.xml
+- $DITA_HOME/bin/dita -install
+# Install RNG support
+- curl -L https://github.com/oxygenxml/dita-relaxng-defaults/archive/master.zip -o dita-ng.zip
+- $DITA_HOME/bin/dita -install dita-ng.zip -v
+# Grab test files
+- curl -L https://github.com/robander/metadita-sampledocs/archive/master.zip -o testfiles.zip
+- unzip testfiles.zip
+# Build 1.3 doctype to ensure builds working properly
+#- $DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita1.3/dtd/base/basemap.ditamap -f html5
+# Build beta 2.0 doctype
+#- $DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/dtd/base/basetopic.dita -f html5
+#- $DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/dtd/base/basemap.ditamap -f html5
+#- $DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/dtd/2.0.versionSpecificDTD.ditamap -f html5
+- $DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/2.0grammars.ditamap -f html5

--- a/.travis/ditaotplugin.xml
+++ b/.travis/ditaotplugin.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+See the accompanying LICENSE file for applicable license.
+-->
+<plugin id="org.oasis-open.dita.v2_0">
+  <feature extension="dita.specialization.catalog.relative" file="catalog.xml"/>
+</plugin>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Add automated testing with Travis to DITA 2.0 branch.

Currently only tests the doctypes by running a sample base map, base topic, and subject scheme using both DTD and RNG; it does not test XSD.

Once this is up and running, we'll want to add in a test to verify that the specification itself builds without error.