### PR TITLE
Make outputclass attribute universal

### DIFF
--- a/doctypes/dtd/base/dtd/commonElements.mod
+++ b/doctypes/dtd/base/dtd/commonElements.mod
@@ -558,12 +558,18 @@
 <!ENTITY % univ-atts
               "%id-atts;
                %select-atts;
-               %localization-atts;"
+               %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!ENTITY % univ-atts-translate-no
               "%id-atts;
                %select-atts;
-               %localization-atts-translate-no;"
+               %localization-atts-translate-no;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!--                    LONG NAME: Data About                      -->
 <!ENTITY % data-about.content
@@ -590,9 +596,6 @@
                            local |
                            peer |
                            -dita-use-conref-target)
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!ELEMENT  data-about %data-about.content;>
@@ -627,9 +630,6 @@
                            local |
                            peer |
                            -dita-use-conref-target)
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!--                    LONG NAME: Data                            -->
@@ -648,10 +648,7 @@
                        "ANY "
 >
 <!ENTITY % unknown.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  unknown %unknown.content;>
 <!ATTLIST  unknown %unknown.attributes;>
@@ -662,10 +659,7 @@
                        "ANY "
 >
 <!ENTITY % foreign.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  foreign %foreign.content;>
 <!ATTLIST  foreign %foreign.attributes;>
@@ -712,10 +706,7 @@
                        "(%desc.cnt;)*"
 >
 <!ENTITY % desc.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  desc %desc.content;>
 <!ATTLIST  desc %desc.attributes;>
@@ -726,10 +717,7 @@
                        "(%para.cnt;)*"
 >
 <!ENTITY % p.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  p %p.content;>
 <!ATTLIST  p %p.attributes;>
@@ -762,10 +750,7 @@
                othertype
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  note %note.content;>
 <!ATTLIST  note %note.attributes;>
@@ -794,10 +779,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  longquoteref %longquoteref.content;>
 <!ATTLIST  longquoteref %longquoteref.attributes;>
@@ -829,10 +811,7 @@
                reftitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  lq %lq.content;>
 <!ATTLIST  lq %lq.attributes;>
@@ -843,10 +822,7 @@
                        "(%shortquote.cnt;)*"
 >
 <!ENTITY % q.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  q %q.content;>
 <!ATTLIST  q %q.attributes;>
@@ -867,10 +843,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  sl %sl.content;>
 <!ATTLIST  sl %sl.attributes;>
@@ -881,10 +854,7 @@
                        "(%ph.cnt;)*"
 >
 <!ENTITY % sli.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  sli %sli.content;>
 <!ATTLIST  sli %sli.attributes;>
@@ -905,10 +875,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  ul %ul.content;>
 <!ATTLIST  ul %ul.attributes;>
@@ -929,10 +896,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  ol %ol.content;>
 <!ATTLIST  ol %ol.attributes;>
@@ -943,10 +907,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % li.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  li %li.content;>
 <!ATTLIST  li %li.attributes;>
@@ -957,10 +918,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % itemgroup.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  itemgroup %itemgroup.content;>
 <!ATTLIST  itemgroup %itemgroup.attributes;>
@@ -982,10 +940,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  dl %dl.content;>
 <!ATTLIST  dl %dl.attributes;>
@@ -997,10 +952,7 @@
                          (%ddhd;)?)"
 >
 <!ENTITY % dlhead.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  dlhead %dlhead.content;>
 <!ATTLIST  dlhead %dlhead.attributes;>
@@ -1011,10 +963,7 @@
                        "(%title.cnt;)*"
 >
 <!ENTITY % dthd.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  dthd %dthd.content;>
 <!ATTLIST  dthd %dthd.attributes;>
@@ -1025,10 +974,7 @@
                        "(%title.cnt;)*"
 >
 <!ENTITY % ddhd.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  ddhd %ddhd.content;>
 <!ATTLIST  ddhd %ddhd.attributes;>
@@ -1040,10 +986,7 @@
                          (%dd;)+)"
 >
 <!ENTITY % dlentry.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  dlentry %dlentry.content;>
 <!ATTLIST  dlentry %dlentry.attributes;>
@@ -1057,10 +1000,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  dt %dt.content;>
 <!ATTLIST  dt %dt.attributes;>
@@ -1071,10 +1011,7 @@
                        "(%defn.cnt;)*"
 >
 <!ENTITY % dd.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  dd %dd.content;>
 <!ATTLIST  dd %dd.attributes;>
@@ -1092,10 +1029,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  fig %fig.content;>
 <!ATTLIST  fig %fig.attributes;>
@@ -1108,10 +1042,7 @@
                           %figgroup.cnt;)*)"
 >
 <!ENTITY % figgroup.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  figgroup %figgroup.content;>
 <!ATTLIST  figgroup %figgroup.attributes;>
@@ -1130,10 +1061,7 @@
                           (preserve)
                                     #FIXED 
                                     'preserve'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  pre %pre.content;>
 <!ATTLIST  pre %pre.attributes;>
@@ -1152,10 +1080,7 @@
                           (preserve)
                                     #FIXED 
                                     'preserve'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  lines %lines.content;>
 <!ATTLIST  lines %lines.attributes;>
@@ -1166,10 +1091,7 @@
                        "(%div.cnt;)*"
 >
 <!ENTITY % div.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  div %div.content;>
 <!ATTLIST  div %div.attributes;>
@@ -1199,10 +1121,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  keyword %keyword.content;>
 <!ATTLIST  keyword %keyword.attributes;>
@@ -1220,10 +1139,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  term %term.content;>
 <!ATTLIST  term %term.attributes;>
@@ -1237,10 +1153,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  ph %ph.content;>
 <!ATTLIST  ph %ph.attributes;>
@@ -1284,10 +1197,7 @@
                value
                           CDATA
                                     #REQUIRED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  state %state.content;>
 <!ATTLIST  state %state.attributes;>
@@ -1336,10 +1246,7 @@
                format
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  image %image.content;>
 <!ATTLIST  image %image.attributes;>
@@ -1353,10 +1260,7 @@
                          %ph;)*"
 >
 <!ENTITY % alt.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  alt %alt.content;>
 <!ATTLIST  alt %alt.attributes;>
@@ -1385,10 +1289,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  longdescref %longdescref.content;>
 <!ATTLIST  longdescref %longdescref.attributes;>
@@ -1457,9 +1358,6 @@
                           CDATA
                                     #IMPLIED
                %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED
                longdescre CDATA     #IMPLIED"
 >
 <!ELEMENT  object %object.content;>
@@ -1511,10 +1409,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  simpletable %simpletable.content;>
 <!ATTLIST  simpletable %simpletable.attributes;>
@@ -1525,10 +1420,7 @@
                        "(%stentry;)+"
 >
 <!ENTITY % sthead.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  sthead %sthead.content;>
 <!ATTLIST  sthead %sthead.attributes;>
@@ -1539,10 +1431,7 @@
                        "(%stentry;)*"
 >
 <!ENTITY % strow.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  strow %strow.content;>
 <!ATTLIST  strow %strow.attributes;>
@@ -1556,10 +1445,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  stentry %stentry.content;>
 <!ATTLIST  stentry %stentry.attributes;>
@@ -1582,10 +1468,7 @@
                disposition
                           CDATA
                                     #IMPLIED
-               %univ-atts-translate-no;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-translate-no;"
 >
 <!ELEMENT  draft-comment %draft-comment.content;>
 <!ATTLIST  draft-comment %draft-comment.attributes;>
@@ -1599,10 +1482,7 @@
               "remap
                           CDATA
                                     #IMPLIED
-               %univ-atts-translate-no;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-translate-no;"
 >
 <!ELEMENT  required-cleanup %required-cleanup.content;>
 <!ATTLIST  required-cleanup %required-cleanup.attributes;>
@@ -1616,10 +1496,7 @@
               "callout
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  fn %fn.content;>
 <!ATTLIST  fn %fn.attributes;>
@@ -1670,10 +1547,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  cite %cite.content;>
 <!ATTLIST  cite %cite.attributes;>
@@ -1703,10 +1577,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  xref %xref.content;>
 <!ATTLIST  xref %xref.attributes;>

--- a/doctypes/dtd/base/dtd/delayResolutionDomain.mod
+++ b/doctypes/dtd/base/dtd/delayResolutionDomain.mod
@@ -77,10 +77,7 @@
               "keyref
                           CDATA
                                     #REQUIRED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  anchorkey %anchorkey.content;>
 <!ATTLIST  anchorkey %anchorkey.attributes;>

--- a/doctypes/dtd/base/dtd/ditavalrefDomain.mod
+++ b/doctypes/dtd/base/dtd/ditavalrefDomain.mod
@@ -39,7 +39,10 @@
                            -dita-use-conref-target)
                                     #IMPLIED
                %select-atts;
-               %localization-atts;"
+               %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!--                    LONG NAME: DITAVAL Reference               -->
 <!ENTITY % ditavalref.content
@@ -50,9 +53,6 @@
                           CDATA
                                     #IMPLIED
                href
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                scope

--- a/doctypes/dtd/base/dtd/hazardstatementDomain.mod
+++ b/doctypes/dtd/base/dtd/hazardstatementDomain.mod
@@ -96,10 +96,7 @@
                othertype
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  hazardstatement %hazardstatement.content;>
 <!ATTLIST  hazardstatement %hazardstatement.attributes;>
@@ -148,10 +145,7 @@
                            inline |
                            -dita-use-conref-target)
                                     'inline'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  hazardsymbol %hazardsymbol.content;>
 <!ATTLIST  hazardsymbol %hazardsymbol.attributes;>
@@ -169,10 +163,7 @@
               "spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  messagepanel %messagepanel.content;>
 <!ATTLIST  messagepanel %messagepanel.attributes;>
@@ -185,10 +176,7 @@
                          %tm;)*"
 >
 <!ENTITY % typeofhazard.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  typeofhazard %typeofhazard.content;>
 <!ATTLIST  typeofhazard %typeofhazard.attributes;>
@@ -201,10 +189,7 @@
                          %tm;)*"
 >
 <!ENTITY % consequence.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  consequence %consequence.content;>
 <!ATTLIST  consequence %consequence.attributes;>
@@ -215,10 +200,7 @@
                        "(%hazard.cnt;)*"
 >
 <!ENTITY % howtoavoid.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  howtoavoid %howtoavoid.content;>
 <!ATTLIST  howtoavoid %howtoavoid.attributes;>

--- a/doctypes/dtd/base/dtd/highlightDomain.mod
+++ b/doctypes/dtd/base/dtd/highlightDomain.mod
@@ -41,10 +41,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % b.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  b %b.content;>
 <!ATTLIST  b %b.attributes;>
@@ -60,10 +57,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % u.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  u %u.content;>
 <!ATTLIST  u %u.attributes;>
@@ -79,10 +73,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % i.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  i %i.content;>
 <!ATTLIST  i %i.attributes;>
@@ -98,10 +89,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % line-through.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  line-through %line-through.content;>
 <!ATTLIST  line-through %line-through.attributes;>
@@ -117,10 +105,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % overline.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  overline %overline.content;>
 <!ATTLIST  overline %overline.attributes;>
@@ -136,10 +121,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % tt.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  tt %tt.content;>
 <!ATTLIST  tt %tt.attributes;>
@@ -155,10 +137,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % sup.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  sup %sup.content;>
 <!ATTLIST  sup %sup.attributes;>
@@ -174,10 +153,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % sub.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  sub %sub.content;>
 <!ATTLIST  sub %sub.attributes;>

--- a/doctypes/dtd/base/dtd/map.mod
+++ b/doctypes/dtd/base/dtd/map.mod
@@ -459,9 +459,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
               "%univ-atts;
                mapref
                           CDATA
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!ELEMENT  navref %navref.content;>
@@ -487,9 +484,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
                           CDATA
                                     #IMPLIED
                copy-to
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                %topicref-atts;
@@ -527,9 +521,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
 >
 <!ENTITY % reltable.attributes
               "title
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                %topicref-atts-for-reltable;
@@ -638,10 +629,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
                          %xref;)*"
 >
 <!ENTITY % shortdesc.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  shortdesc %shortdesc.content;>
 <!ATTLIST  shortdesc %shortdesc.attributes;>

--- a/doctypes/dtd/base/dtd/mapGroup.mod
+++ b/doctypes/dtd/base/dtd/mapGroup.mod
@@ -129,9 +129,6 @@
               "navtitle
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                keys
                           CDATA
                                     #IMPLIED
@@ -187,9 +184,6 @@
                           CDATA
                                     #IMPLIED
                copy-to
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                collection-type
@@ -275,9 +269,6 @@
                           CDATA
                                     #IMPLIED
                copy-to
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                format
@@ -414,9 +405,6 @@
                copy-to
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                collection-type
                           (choice |
                            family |
@@ -506,9 +494,6 @@
                           CDATA
                                     #IMPLIED
                copy-to
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                collection-type

--- a/doctypes/dtd/base/dtd/tblDecl.mod
+++ b/doctypes/dtd/base/dtd/tblDecl.mod
@@ -170,34 +170,19 @@
                            200 |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ENTITY % dita.tgroup.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ENTITY % dita.thead.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ENTITY % dita.tbody.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ENTITY % dita.row.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ENTITY % dita.entry.attributes
               "%id-atts;

--- a/doctypes/dtd/base/dtd/topic.mod
+++ b/doctypes/dtd/base/dtd/topic.mod
@@ -346,10 +346,7 @@
                          %xref;)*"
 >
 <!ENTITY % shortdesc.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  shortdesc %shortdesc.content;>
 <!ATTLIST  shortdesc %shortdesc.attributes;>
@@ -360,10 +357,7 @@
                        "(%abstract.cnt;)*"
 >
 <!ENTITY % abstract.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  abstract %abstract.content;>
 <!ATTLIST  abstract %abstract.attributes;>
@@ -377,10 +371,7 @@
                          %section;)*"
 >
 <!ENTITY % body.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  body %body.content;>
 <!ATTLIST  body %body.attributes;>
@@ -393,10 +384,7 @@
                          %section;)*"
 >
 <!ENTITY % bodydiv.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  bodydiv %bodydiv.content;>
 <!ATTLIST  bodydiv %bodydiv.attributes;>
@@ -414,10 +402,7 @@
               "spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  section %section.content;>
 <!ATTLIST  section %section.attributes;>
@@ -429,10 +414,7 @@
                          %sectiondiv;)*"
 >
 <!ENTITY % sectiondiv.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  sectiondiv %sectiondiv.content;>
 <!ATTLIST  sectiondiv %sectiondiv.attributes;>
@@ -446,10 +428,7 @@
               "spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  example %example.content;>
 <!ATTLIST  example %example.attributes;>
@@ -483,10 +462,7 @@
 >
 <!ENTITY % related-links.attributes
               "%relational-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  related-links %related-links.content;>
 <!ATTLIST  related-links %related-links.attributes;>
@@ -508,10 +484,7 @@
                           CDATA
                                     #IMPLIED
                %relational-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  link %link.content;>
 <!ATTLIST  link %link.attributes;>
@@ -557,9 +530,6 @@
                %univ-atts;
                spectitle
                           CDATA
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!ELEMENT  linklist %linklist.content;>
@@ -599,10 +569,7 @@
                           CDATA
                                     #IMPLIED
                %relational-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  linkpool %linkpool.content;>
 <!ATTLIST  linkpool %linkpool.attributes;>

--- a/doctypes/dtd/base/dtd/utilitiesDomain.mod
+++ b/doctypes/dtd/base/dtd/utilitiesDomain.mod
@@ -64,10 +64,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  imagemap %imagemap.content;>
 <!ATTLIST  imagemap %imagemap.attributes;>
@@ -80,10 +77,7 @@
                          (%xref;))"
 >
 <!ENTITY % area.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  area %area.content;>
 <!ATTLIST  area %area.attributes;>
@@ -98,10 +92,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts-translate-no;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-translate-no;"
 >
 <!ELEMENT  shape %shape.content;>
 <!ATTLIST  shape %shape.attributes;>
@@ -115,10 +106,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts-translate-no;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-translate-no;"
 >
 <!ELEMENT  coords %coords.content;>
 <!ATTLIST  coords %coords.attributes;>

--- a/doctypes/dtd/subjectScheme/dtd/classifyDomain.mod
+++ b/doctypes/dtd/subjectScheme/dtd/classifyDomain.mod
@@ -104,9 +104,6 @@
                            yes |
                            -dita-use-conref-target)
                                     'no'
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  topicsubject %topicsubject.content;>
@@ -175,9 +172,6 @@
                            yes |
                            -dita-use-conref-target)
                                     'no'
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  topicapply %topicapply.content;>
@@ -244,9 +238,6 @@
                            yes |
                            -dita-use-conref-target)
                                     'no'
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  subjectref %subjectref.content;>
@@ -262,9 +253,6 @@
 >
 <!ENTITY % topicSubjectTable.attributes
               "%topicref-atts-no-toc;
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  topicSubjectTable %topicSubjectTable.content;>

--- a/doctypes/dtd/subjectScheme/dtd/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/dtd/subjectScheme.mod
@@ -215,9 +215,6 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  schemeref %schemeref.content;>
@@ -263,9 +260,6 @@
                           CDATA
                                     #IMPLIED
                cascade
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                %univ-atts;"
@@ -315,9 +309,6 @@
                cascade
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  hasKind %hasKind.content;>
@@ -365,9 +356,6 @@
                cascade
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  hasPart %hasPart.content;>
@@ -413,9 +401,6 @@
                           CDATA
                                     #IMPLIED
                cascade
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                %univ-atts;"
@@ -472,9 +457,6 @@
                cascade
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  hasRelated %hasRelated.content;>
@@ -511,9 +493,6 @@
                           CDATA
                                     #IMPLIED
                copy-to
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                collection-type
@@ -595,9 +574,6 @@
                           (no |
                            yes |
                            -dita-use-conref-target)
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED
                %univ-atts;"
 >
@@ -740,9 +716,6 @@
                copy-to
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                type
                           CDATA
                                     #IMPLIED
@@ -842,9 +815,6 @@
                            targetonly |
                            -dita-use-conref-target)
                                     'normal'
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  relatedSubjects %relatedSubjects.content;>
@@ -860,9 +830,6 @@
 >
 <!ENTITY % subjectRelTable.attributes
               "%topicref-atts-no-toc;
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  subjectRelTable %subjectRelTable.content;>

--- a/doctypes/rng/base/rng/commonElementsMod.rng
+++ b/doctypes/rng/base/rng/commonElementsMod.rng
@@ -1178,6 +1178,9 @@ ORIGINAL CREATION DATE:
           </optional>
           <ref name="base-attribute-extensions"/>
           <optional>
+            <attribute name="outputclass"/>
+          </optional>
+          <optional>
             <attribute name="rev" dita:since="1.3"/>
           </optional>
         </define>

--- a/doctypes/rng/base/rng/commonElementsMod.rng
+++ b/doctypes/rng/base/rng/commonElementsMod.rng
@@ -993,11 +993,17 @@ ORIGINAL CREATION DATE:
       <ref name="id-atts"/>
       <ref name="select-atts"/>
       <ref name="localization-atts"/>
+      <optional>
+        <attribute name="outputclass"/>
+      </optional>
     </define>
     <define name="univ-atts-translate-no">
       <ref name="id-atts"/>
       <ref name="select-atts"/>
       <ref name="localization-atts-translate-no"/>
+      <optional>
+        <attribute name="outputclass"/>
+      </optional>
     </define>
   </div>
   <div>
@@ -1039,9 +1045,6 @@ ORIGINAL CREATION DATE:
                 <value>-dita-use-conref-target</value>
               </choice>
             </attribute>
-          </optional>
-          <optional>
-            <attribute name="outputclass"/>
           </optional>
         </define>
         <define name="data-about.element">
@@ -1089,9 +1092,6 @@ ORIGINAL CREATION DATE:
               </choice>
             </attribute>
           </optional>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
 
       </div>
@@ -1126,9 +1126,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="unknown.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="unknown.element">
           <element name="unknown" dita:longName="Unknown">
@@ -1150,9 +1147,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="foreign.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="foreign.element">
           <element name="foreign" dita:longName="Foreign">
@@ -1183,9 +1177,6 @@ ORIGINAL CREATION DATE:
             <attribute name="base"/>
           </optional>
           <ref name="base-attribute-extensions"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
           <optional>
             <attribute name="rev" dita:since="1.3"/>
           </optional>
@@ -1247,9 +1238,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="desc.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="desc.element">
           <element name="desc" dita:longName="Description">
@@ -1278,9 +1266,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="p.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="p.element">
           <element name="p" dita:longName="Paragraph">
@@ -1329,9 +1314,6 @@ ORIGINAL CREATION DATE:
             <attribute name="othertype"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="note.element">
           <element name="note" dita:longName="Note">
@@ -1375,9 +1357,6 @@ ORIGINAL CREATION DATE:
             </attribute>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="longquoteref.element">
           <element name="longquoteref" dita:longName="Long Quote Reference">
@@ -1427,9 +1406,6 @@ ORIGINAL CREATION DATE:
             <attribute name="reftitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="lq.element">
           <element name="lq" dita:longName="Long Quote">
@@ -1454,9 +1430,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="q.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="q.element">
           <element name="q" dita:longName="Quote">
@@ -1498,9 +1471,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="sl.element">
           <element name="sl" dita:longName="Simple List">
@@ -1524,9 +1494,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="sli.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="sli.element">
           <element name="sli" dita:longName="Simple List Item">
@@ -1569,9 +1536,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="ul.element">
           <element name="ul" dita:longName="Unordered List">
@@ -1618,9 +1582,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="ol.element">
           <element name="ol" dita:longName="Ordered List">
@@ -1643,9 +1604,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="li.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="li.element">
           <element name="li" dita:longName="List Item">
@@ -1669,9 +1627,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="itemgroup.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="itemgroup.element">
           <element name="itemgroup" dita:longName="Item Group">
@@ -1716,9 +1671,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dl.element">
           <element name="dl" dita:longName="Definition List">
@@ -1745,9 +1697,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="dlhead.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dlhead.element">
           <element name="dlhead" dita:longName="Definition List Head">
@@ -1771,9 +1720,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="dthd.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dthd.element">
           <element name="dthd" dita:longName="Term Header">
@@ -1797,9 +1743,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="ddhd.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="ddhd.element">
           <element name="ddhd" dita:longName="Definition Header">
@@ -1826,9 +1769,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="dlentry.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dlentry.element">
           <element name="dlentry" dita:longName="Definition List Entry">
@@ -1855,9 +1795,6 @@ ORIGINAL CREATION DATE:
             <attribute name="keyref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dt.element">
           <element name="dt" dita:longName="Definition Term">
@@ -1880,9 +1817,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="dd.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="dd.element">
           <element name="dd" dita:longName="Definition Description">
@@ -1918,9 +1852,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="fig.element">
           <element name="fig" dita:longName="Figure">
@@ -1951,9 +1882,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="figgroup.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="figgroup.element">
           <element name="figgroup" dita:longName="Figure Group">
@@ -1986,9 +1914,6 @@ ORIGINAL CREATION DATE:
             </attribute>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="pre.element">
           <element name="pre" dita:longName="Preformatted Text">
@@ -2022,9 +1947,6 @@ ORIGINAL CREATION DATE:
             </attribute>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="lines.element">
           <element name="lines" dita:longName="Line Respecting Text">
@@ -2047,9 +1969,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="div.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="div.element">
           <element name="div" dita:longName="Division" dita:since="1.3">
@@ -2110,9 +2029,6 @@ ORIGINAL CREATION DATE:
             <attribute name="keyref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="keyword.element">
           <element name="keyword" dita:longName="Keyword">
@@ -2145,9 +2061,6 @@ ORIGINAL CREATION DATE:
             <attribute name="keyref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="term.element">
           <element name="term" dita:longName="Term">
@@ -2176,9 +2089,6 @@ ORIGINAL CREATION DATE:
             <attribute name="keyref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="ph.element">
           <element name="ph" dita:longName="Phrase">
@@ -2251,9 +2161,6 @@ ORIGINAL CREATION DATE:
           <attribute name="name"/>
           <attribute name="value"/>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="state.element">
           <element name="state" dita:longName="State">
@@ -2336,9 +2243,6 @@ ORIGINAL CREATION DATE:
             <attribute name="format" dita:since="1.3 errata 02"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="image.element">
           <element name="image" dita:longName="Image Data">
@@ -2370,9 +2274,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="alt.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="alt.element">
           <element name="alt" dita:longName="Alternate text">
@@ -2416,9 +2317,6 @@ ORIGINAL CREATION DATE:
             </attribute>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="longdescref.element">
           <element name="longdescref" dita:longName="Long description reference">
@@ -2520,9 +2418,6 @@ ORIGINAL CREATION DATE:
             <attribute name="longdescref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="object.element">
           <element name="object" dita:longName="Object (Streaming/Executable Data)">
@@ -2602,9 +2497,6 @@ ORIGINAL CREATION DATE:
             <attribute name="spectitle"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="simpletable.element">
           <element name="simpletable" dita:longName="Simple Table">
@@ -2630,9 +2522,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="sthead.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="sthead.element">
           <element name="sthead" dita:longName="Simple Table Head">
@@ -2655,9 +2544,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="strow.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="strow.element">
           <element name="strow" dita:longName="Simple Table Row">
@@ -2683,9 +2569,6 @@ ORIGINAL CREATION DATE:
             <attribute name="specentry"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="stentry.element">
           <element name="stentry" dita:longName="Simple Table Cell (entry)">
@@ -2723,9 +2606,6 @@ ORIGINAL CREATION DATE:
             <attribute name="disposition"/>
           </optional>
           <ref name="univ-atts-translate-no"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="draft-comment.element">
           <element name="draft-comment" dita:longName="Review Comments Block">
@@ -2751,9 +2631,6 @@ ORIGINAL CREATION DATE:
             <attribute name="remap"/>
           </optional>
           <ref name="univ-atts-translate-no"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="required-cleanup.element">
           <element name="required-cleanup" dita:longName="Required Cleanup Block">
@@ -2781,9 +2658,6 @@ ORIGINAL CREATION DATE:
             <attribute name="callout"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="fn.element">
           <element name="fn" dita:longName="Footnote">
@@ -2876,9 +2750,6 @@ ORIGINAL CREATION DATE:
             <attribute name="keyref"/>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="cite.element">
           <element name="cite" dita:longName="Citation (bibliographic source)">
@@ -2927,9 +2798,6 @@ ORIGINAL CREATION DATE:
             </attribute>
           </optional>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="xref.element">
           <element name="xref" dita:longName="Cross Reference/Link">

--- a/doctypes/rng/base/rng/delayResolutionDomain.rng
+++ b/doctypes/rng/base/rng/delayResolutionDomain.rng
@@ -118,9 +118,6 @@ ORIGINAL CREATION DATE:
         <ref name="conref-atts"/>
         <ref name="select-atts"/>
         <ref name="localization-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="anchorid.element">
         <a:documentation xml:space="preserve">The &lt;anchorid> element allows an author to 
@@ -148,9 +145,6 @@ ORIGINAL CREATION DATE:
       <define name="anchorkey.attributes">
         <attribute name="keyref"/>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="anchorkey.element">
         <a:documentation xml:space="preserve">The &lt;anchorkey> element allows an author to 

--- a/doctypes/rng/base/rng/delayResolutionDomain.rng
+++ b/doctypes/rng/base/rng/delayResolutionDomain.rng
@@ -118,6 +118,9 @@ ORIGINAL CREATION DATE:
         <ref name="conref-atts"/>
         <ref name="select-atts"/>
         <ref name="localization-atts"/>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
       </define>
       <define name="anchorid.element">
         <a:documentation xml:space="preserve">The &lt;anchorid> element allows an author to 

--- a/doctypes/rng/base/rng/ditavalrefDomain.rng
+++ b/doctypes/rng/base/rng/ditavalrefDomain.rng
@@ -111,9 +111,6 @@
           <attribute name="href"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>

--- a/doctypes/rng/base/rng/ditavalrefDomain.rng
+++ b/doctypes/rng/base/rng/ditavalrefDomain.rng
@@ -91,7 +91,10 @@
         </attribute>
       </optional>
       <ref name="select-atts"/>
-      <ref name="localization-atts"/>              
+      <ref name="localization-atts"/>
+      <optional>
+          <attribute name="outputclass"/>
+      </optional>
     </define>
   </div>
   <div>

--- a/doctypes/rng/base/rng/hazardstatementDomain.rng
+++ b/doctypes/rng/base/rng/hazardstatementDomain.rng
@@ -149,9 +149,6 @@ ORIGINAL CREATION DATE:
           <attribute name="othertype"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="hazardstatement.element">
         <element name="hazardstatement" dita:longName="Hazard Statement">
@@ -233,9 +230,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="hazardsymbol.element">
         <element name="hazardsymbol" dita:longName="Hazard Symbol">
@@ -272,9 +266,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="messagepanel.element">
         <element name="messagepanel" dita:longName="Hazard Message panel">
@@ -302,9 +293,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="typeofhazard.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="typeofhazard.element">
         <element name="typeofhazard" dita:longName="The Type of Hazard">
@@ -332,9 +320,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="consequence.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="consequence.element">
         <element name="consequence" dita:longName="Consequences of not Avoiding the Hazard">
@@ -358,9 +343,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="howtoavoid.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="howtoavoid.element">
         <element name="howtoavoid" dita:longName="How to Avoid the Hazard">

--- a/doctypes/rng/base/rng/highlightDomain.rng
+++ b/doctypes/rng/base/rng/highlightDomain.rng
@@ -103,9 +103,6 @@ UPDATES:
       </define>
       <define name="b.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="b.element">
         <element name="b" dita:longName="Bold">
@@ -135,9 +132,6 @@ UPDATES:
       </define>
       <define name="u.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="u.element">
         <element name="u" dita:longName="Underlined">
@@ -166,9 +160,6 @@ UPDATES:
       </define>
       <define name="i.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="i.element">
         <element name="i" dita:longName="Italic">
@@ -196,9 +187,6 @@ UPDATES:
       </define>
       <define name="line-through.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="line-through.element">
         <element name="line-through" dita:longName="Line through" 
@@ -228,9 +216,6 @@ UPDATES:
       </define>
       <define name="overline.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="overline.element">
         <element name="overline" dita:longName="Overline"
@@ -260,9 +245,6 @@ UPDATES:
       </define>
       <define name="tt.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="tt.element">
         <element name="tt" dita:longName="Teletype (monospaced)">
@@ -291,9 +273,6 @@ UPDATES:
       </define>
       <define name="sup.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="sup.element">
         <element name="sup" dita:longName="Superscript">
@@ -324,9 +303,6 @@ UPDATES:
       </define>
       <define name="sub.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="sub.element">
         <element name="sub" dita:longName="Subscript">

--- a/doctypes/rng/base/rng/mapGroupDomain.rng
+++ b/doctypes/rng/base/rng/mapGroupDomain.rng
@@ -481,6 +481,9 @@ ORIGINAL CREATION DATE:
           <attribute name="copy-to"/>
         </optional>
         <optional>
+          <attribute name="outputclass"/>
+        </optional>
+        <optional>
           <attribute name="collection-type">
             <choice>
               <value>choice</value>

--- a/doctypes/rng/base/rng/mapGroupDomain.rng
+++ b/doctypes/rng/base/rng/mapGroupDomain.rng
@@ -209,9 +209,6 @@ ORIGINAL CREATION DATE:
           <attribute name="navtitle"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="keys"/>
         </optional>
         <optional>
@@ -249,9 +246,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="topicgroup.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="topicref-atts-no-locktitle"/>
         <ref name="univ-atts"/>
       </define>
@@ -300,9 +294,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="copy-to"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -436,9 +427,6 @@ ORIGINAL CREATION DATE:
           <attribute name="copy-to"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="format" a:defaultValue="ditamap"/>
         </optional>
         <ref name="topicref-atts-without-format"/>
@@ -491,9 +479,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="copy-to"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -639,9 +624,6 @@ ORIGINAL CREATION DATE:
           <attribute name="copy-to"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="collection-type">
             <choice>
               <value>choice</value>
@@ -776,9 +758,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="copy-to"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <optional>
           <attribute name="collection-type">

--- a/doctypes/rng/base/rng/mapMod.rng
+++ b/doctypes/rng/base/rng/mapMod.rng
@@ -597,9 +597,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="anchorref"/>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="localization-atts"/>
         <ref name="topicref-atts"/>
         <ref name="select-atts"/>
@@ -631,9 +628,6 @@ ORIGINAL CREATION DATE:
         <ref name="univ-atts"/>
         <optional>
           <attribute name="mapref"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
       </define>
       <define name="navref.element">
@@ -677,9 +671,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="copy-to"/>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
       </define>
@@ -705,9 +696,6 @@ ORIGINAL CREATION DATE:
         <empty/>
       </define>
       <define name="anchor.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="localization-atts"/>
         <attribute name="id">
           <data type="ID"/>
@@ -751,9 +739,6 @@ ORIGINAL CREATION DATE:
       <define name="reltable.attributes">
         <optional>
           <attribute name="title"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <ref name="topicref-atts-for-reltable"/>
         <ref name="univ-atts"/>
@@ -810,9 +795,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="relcolspec.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="topicref-atts-for-reltable"/>
         <ref name="univ-atts"/>
       </define>
@@ -837,9 +819,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="relrow.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="relrow.element">
@@ -866,9 +845,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="relcell.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="topicref-atts-no-toc-no-keyscope"/>
         <ref name="univ-atts"/>
       </define>
@@ -988,9 +964,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="shortdesc.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="shortdesc.element">
           <element name="shortdesc" dita:longName="Short Description">
@@ -1017,9 +990,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="linktext.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="linktext.element">
@@ -1045,9 +1015,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="searchtitle.attributes">
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="searchtitle.element">

--- a/doctypes/rng/base/rng/mapMod.rng
+++ b/doctypes/rng/base/rng/mapMod.rng
@@ -597,6 +597,9 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="anchorref"/>
         </optional>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
         <ref name="localization-atts"/>
         <ref name="topicref-atts"/>
         <ref name="select-atts"/>
@@ -696,6 +699,9 @@ ORIGINAL CREATION DATE:
         <empty/>
       </define>
       <define name="anchor.attributes">
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
         <ref name="localization-atts"/>
         <attribute name="id">
           <data type="ID"/>

--- a/doctypes/rng/base/rng/tblDeclMod.rng
+++ b/doctypes/rng/base/rng/tblDeclMod.rng
@@ -237,33 +237,18 @@ For <entry>, add:
       </attribute>
     </optional>
     <ref name="univ-atts"/>
-    <optional>
-      <attribute name="outputclass"/>
-    </optional>
   </define>
   <define name="dita.tgroup.attributes">
     <ref name="univ-atts"/>
-    <optional>
-      <attribute name="outputclass"/>
-    </optional>
   </define>
   <define name="dita.thead.attributes">
     <ref name="univ-atts"/>
-    <optional>
-      <attribute name="outputclass"/>
-    </optional>
   </define>
   <define name="dita.tbody.attributes">
     <ref name="univ-atts"/>
-    <optional>
-      <attribute name="outputclass"/>
-    </optional>
   </define>
   <define name="dita.row.attributes">
     <ref name="univ-atts"/>
-    <optional>
-      <attribute name="outputclass"/>
-    </optional>
   </define>
   <define name="dita.entry.attributes">
     <ref name="id-atts"/>
@@ -276,9 +261,6 @@ For <entry>, add:
     </optional>
     <optional>
       <attribute name="rev"/>
-    </optional>
-    <optional>
-      <attribute name="outputclass"/>
     </optional>
     <optional>
       <attribute name="scope" dita:since="1.3">

--- a/doctypes/rng/base/rng/tblDeclMod.rng
+++ b/doctypes/rng/base/rng/tblDeclMod.rng
@@ -263,6 +263,9 @@ For <entry>, add:
       <attribute name="rev"/>
     </optional>
     <optional>
+      <attribute name="outputclass"/>
+    </optional>
+    <optional>
       <attribute name="scope" dita:since="1.3">
         <choice>
           <value>row</value>

--- a/doctypes/rng/base/rng/topicMod.rng
+++ b/doctypes/rng/base/rng/topicMod.rng
@@ -353,6 +353,9 @@ ORIGINAL CREATION DATE:
         <ref name="conref-atts"/>
         <ref name="select-atts"/>
         <ref name="localization-atts"/>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
       </define>
       <define name="topic.element">
         <element name="topic" dita:longName="Topic">

--- a/doctypes/rng/base/rng/topicMod.rng
+++ b/doctypes/rng/base/rng/topicMod.rng
@@ -353,9 +353,6 @@ ORIGINAL CREATION DATE:
         <ref name="conref-atts"/>
         <ref name="select-atts"/>
         <ref name="localization-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="topic.element">
         <element name="topic" dita:longName="Topic">
@@ -412,9 +409,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="searchtitle.attributes">
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="searchtitle.element">
@@ -443,9 +437,6 @@ ORIGINAL CREATION DATE:
         </define>
         <define name="shortdesc.attributes">
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="shortdesc.element">
           <element name="shortdesc" dita:longName="Short Description">
@@ -471,9 +462,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="abstract.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="abstract.element">
         <element name="abstract" dita:longName="Abstract">
@@ -504,9 +492,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="body.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="body.element">
         <element name="body" dita:longName="Body">
@@ -534,9 +519,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="bodydiv.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="bodydiv.element">
         <element name="bodydiv" dita:longName="Body division">
@@ -588,9 +570,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="section.element">
         <element name="section" dita:longName="Section">
@@ -620,9 +599,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="sectiondiv.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="sectiondiv.element">
         <element name="sectiondiv" dita:longName="Section division">
@@ -651,9 +627,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="example.element">
         <element name="example" dita:longName="Example">
@@ -740,9 +713,6 @@ ORIGINAL CREATION DATE:
         <define name="related-links.attributes">
           <ref name="relational-atts"/>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="related-links.element">
           <element name="related-links" dita:longName="related-links">
@@ -781,9 +751,6 @@ ORIGINAL CREATION DATE:
           </optional>
           <ref name="relational-atts"/>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="link.element">
           <element name="link" dita:longName="link">
@@ -882,9 +849,6 @@ ORIGINAL CREATION DATE:
           <optional>
             <attribute name="spectitle"/>
           </optional>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="linklist.element">
           <element name="linklist" dita:longName="linklist">
@@ -963,9 +927,6 @@ ORIGINAL CREATION DATE:
           </optional>
           <ref name="relational-atts"/>
           <ref name="univ-atts"/>
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
         </define>
         <define name="linkpool.element">
           <element name="linkpool" dita:longName="linkpool">

--- a/doctypes/rng/base/rng/utilitiesDomain.rng
+++ b/doctypes/rng/base/rng/utilitiesDomain.rng
@@ -111,9 +111,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="imagemap.element">
         <element dita:longName="Imagemap" name="imagemap">
@@ -140,9 +137,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="area.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="area.element">
         <element dita:longName="Hotspot Area Description" name="area">
@@ -173,9 +167,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts-translate-no"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="shape.element">
         <element dita:longName="Shape of the Hotspot" name="shape">
@@ -202,9 +193,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts-translate-no"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="coords.element">
         <element dita:longName="Coordinates of the Hotspot" name="coords">

--- a/doctypes/rng/subjectScheme/rng/classifyDomain.rng
+++ b/doctypes/rng/subjectScheme/rng/classifyDomain.rng
@@ -164,9 +164,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <a:documentation><![CDATA[The <topicsubject> element identifies the subjects for which the topic or collection of topics provides the authoritative treatment. The subjects can be identified by keys (if defined in the scheme) or, if the subject definition topic exists, by href (as with ordinary topic references). Additional secondary subjects can be specified by nested <subjectref> elements.]]></a:documentation>
@@ -270,9 +267,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <a:documentation><![CDATA[The <topicapply> element identifies subjects that qualify the content for filtering or flagging but not retrieval. The <topicapply> element can identify a single subject. Additional subjects can be specified by nested <subjectref> elements.]]></a:documentation>
@@ -369,9 +363,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <a:documentation><![CDATA[The <subjectref> element identifies a subject to classify content. The <subjectref> can identify the subject with a keyref attribute (if the scheme has a <subjectdef> with a keys attribute that assigns a key to the subject) or an href attribute (if a topic captures the consensus definition for the subject).]]></a:documentation>
@@ -404,9 +395,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="topicSubjectTable.attributes">
         <ref name="topicref-atts-no-toc"/>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <a:documentation><![CDATA[The <topicSubjectTable> element is a specialized relationship table which allows a map to use relationship tables to associate topics with subjects. In a <topicSubjectTable>, the first column is reserved for references to content. Subsequent columns are reserved for subjects that classify the content, each column supplying the subjects for a different category as identified in the header. The table resembles a traditional relationship table in which the first column identifies the source and the other columns identify the targets, but the relationship reflects the subjects covered by the content rather than linking between documents.]]></a:documentation>

--- a/doctypes/rng/subjectScheme/rng/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/rng/subjectSchemeMod.rng
@@ -252,9 +252,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="anchorref"/>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="localization-atts"/>
         <ref name="topicref-atts-for-subjectScheme"/>
         <ref name="select-atts"/>
@@ -327,9 +324,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="schemeref.element">
@@ -400,9 +394,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="cascade" dita:since="1.3"/>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="hasNarrower.element">
@@ -472,9 +463,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="cascade" dita:since="1.3"/>
-        </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
         </optional>
         <ref name="univ-atts"/>
       </define>
@@ -547,9 +535,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="cascade" dita:since="1.3"/>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="hasPart.element">
@@ -619,9 +604,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="cascade" dita:since="1.3"/>
-        </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
         </optional>
         <ref name="univ-atts"/>
       </define>
@@ -705,9 +687,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="cascade" dita:since="1.3"/>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="hasRelated.element">
@@ -760,9 +739,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="copy-to"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -899,9 +875,6 @@ ORIGINAL CREATION DATE:
               <value>-dita-use-conref-target</value>
             </choice>
           </attribute>
-        </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
         </optional>
         <ref name="univ-atts"/>
       </define>
@@ -1130,9 +1103,6 @@ ORIGINAL CREATION DATE:
           <attribute name="copy-to"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="type"/>
         </optional>
         <optional>
@@ -1280,9 +1250,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="relatedSubjects.element">
@@ -1317,9 +1284,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="subjectRelTable.attributes">
         <ref name="topicref-atts-no-toc"/>
-        <optional dita:since="DITA 1.3">
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="subjectRelTable.element">

--- a/doctypes/rng/subjectScheme/rng/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/rng/subjectSchemeMod.rng
@@ -252,6 +252,9 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="anchorref"/>
         </optional>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
         <ref name="localization-atts"/>
         <ref name="topicref-atts-for-subjectScheme"/>
         <ref name="select-atts"/>

--- a/specification/archSpec/base/dtd-coding-constraint-modules.dita
+++ b/specification/archSpec/base/dtd-coding-constraint-modules.dita
@@ -55,8 +55,7 @@
               removes <xmlatt>spectitle</xmlatt> and <xmlatt>othertype</xmlatt>:</p>
             <codeblock>&lt;!ENTITY % note.attributes  
        "type  (attention | caution | note ) #IMPLIED
-        %univ-atts;
-        outputclass  CDATA  #IMPLIED"&gt;</codeblock>
+        %univ-atts;"&gt;</codeblock>
           </dd>
         </dlentry>
         <dlentry>

--- a/specification/archSpec/base/dtd-coding-element-types.dita
+++ b/specification/archSpec/base/dtd-coding-element-types.dita
@@ -103,10 +103,8 @@
                 <codeph><varname>tagname</varname>.attributes</codeph> parameter entity enables the
               use of constraint modules to restrict attributes.</p>
             <p otherprops="examples">For
-              example:<codeblock>&lt;!ENTITY % topichead.attributes
- "navtitle CDATA #IMPLIED
-  outputclass CDATA #IMPLIED
-  keys CDATA #IMPLIED
+example:<codeblock>&lt;!ENTITY % topichead.attributes
+ "keys CDATA #IMPLIED
   copy-to CDATA #IMPLIED
   %topicref-atts-no-locktitle;
   %univ-atts;"

--- a/specification/archSpec/base/example-contraints-redefine-content-model-attributes.dita
+++ b/specification/archSpec/base/example-contraints-redefine-content-model-attributes.dita
@@ -59,7 +59,7 @@
               dir      (lro|ltr|rlo|rtl|-dita-use-conref-target) #IMPLIED' >
 
 &lt;!-- Declares the constrained content model. Original definition   -->
-&lt;!-- included %univ-atts;, spectitle, and outputclass; now includes-->
+&lt;!-- included %univ-atts; and spectitle; now includes-->
 &lt;!-- individual pieces of univ-atts, to make ID required.          -->
 
 &lt;!ENTITY % section.attributes 

--- a/specification/archSpec/base/relax-ng-coding-element-types.dita
+++ b/specification/archSpec/base/relax-ng-coding-element-types.dita
@@ -99,12 +99,6 @@
   &lt;/define>
   &lt;define name="topichead.attributes">
     &lt;optional>
-      &lt;attribute name="navtitle"/>
-    &lt;/optional>
-    &lt;optional>
-      &lt;attribute name="outputclass"/>
-    &lt;/optional>
-    &lt;optional>
       &lt;attribute name="keys"/>
     &lt;/optional>
     &lt;optional>

--- a/specification/archSpec/base/xsd-coding-element-types.dita
+++ b/specification/archSpec/base/xsd-coding-element-types.dita
@@ -69,7 +69,6 @@
 
 &lt;xs:attributeGroup name="codeph.attributes">
   &lt;xs:attributeGroup ref="univ-atts"/>
-  &lt;xs:attribute name="outputclass" type="xs:string"/>
 &lt;/xs:attributeGroup>
 
 &lt;xs:complexType name="codeph.class" mixed="true">

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN"
  "concept.dtd">
-
 <concept id="conref-attribute" xml:lang="en-us">
                 <title>Attribute description reuse file</title>
                 <shortdesc>This file contains attribute information used by multiple files in the
@@ -63,79 +62,33 @@
                                                 <xmlatt>locktitle</xmlatt> is available as part of
                                                 <xref
                                                 href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, it has no defined purpose for this element.</ph></p><p
-                                id="data-link-universal-keyref-outputclass">The following attributes
-                                are available on this element: <xref
-                                        href="../langRef/attributes/dataElementAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                />, <xref href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref href="../langRef/attributes/thekeyrefattribute.dita"
-                                                ><xmlatt>keyref</xmlatt></xref>, and <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />.</p><p id="data-link-universal-outputclass">The following
-                                attributes are available on this element: <xref
-                                        href="../langRef/attributes/dataElementAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                />, <xref href="../langRef/attributes/universalAttributes.dita"/>,
-                                and <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />.</p><p id="only-universal">The following attributes are available
+                                        />, it has no defined purpose for this element.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
+element: <xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/>, <xref
+href="../langRef/attributes/universalAttributes.dita"/>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
+<xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
+href="../langRef/attributes/universalAttributes.dita"/>.</p><p id="only-universal">The following attributes are available
                                 on this element: <xref
                                         href="../langRef/attributes/universalAttributes.dita"
-                                />.</p><p id="universal-outputclass">The following attributes are
-                                available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/> and
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />.</p><p id="universal-outputclass-name">The following attributes
-                                are available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/dataElementAttributes.dita#data-element-atts/name"
-                                />.</p><p id="universal-outputclass-keyref">The following attributes
-                                are available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref href="../langRef/attributes/thekeyrefattribute.dita"
-                                                ><xmlatt>keyref</xmlatt></xref>.</p><p
-                                id="universal-outputclass-specentry">The following attributes are
-                                available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/specentry"
-                                />.</p><p id="universal-outputclass-spectitle">The following
-                                attributes are available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                />.</p><p id="universal-outputclass-spectitle-compact">The following
-                                attributes are available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/compact"
-                                />, <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                />.</p><!--Used in <topic>, <concept>, etc.--><sectiondiv
+                                />.</p><p id="universal-outputclass-name">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/>, and <xref
+href="../langRef/attributes/dataElementAttributes.dita#data-element-atts/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/> and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry">The following attributes are available on this element:
+<xref href="../langRef/attributes/universalAttributes.dita"/> and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/specentry"/>.</p><p id="universal-spectitle">The following attributes are available on this element:
+<xref href="../langRef/attributes/universalAttributes.dita"/> and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="universal-spectitle-compact">The following attributes are available on this
+element: <xref href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><!--Used in <topic>, <concept>, etc.--><sectiondiv
                                 id="topic-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>id</xmlatt>, given
-                                        below), <xref
-                                                href="../langRef/attributes/architecturalAttributes.dita#arch-atts"
-                                        />, and <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>id</xmlatt>, given below) and <xref
+href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>.</p>
                                 <dl>
                                         <dlentry id="topic-id">
                                                 <dt><xmlatt>id</xmlatt>
@@ -151,21 +104,13 @@
                                                   conref="#conref-attribute/define-ID"/></dd>
                                         </dlentry>
                                 </dl>
-                        </sectiondiv><p id="topic-body">The following attributes are available on
-                                this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>
-                                (without the Metadata attribute group), <xmlatt>base</xmlatt> from
-                                the <xref href="../langRef/attributes/metadataAttributes.dita"/>,
-                                and <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />.</p><sectiondiv id="note-attributes">
+                        </sectiondiv><p id="topic-body">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/> (without the Metadata attribute group) and
+<xmlatt>base</xmlatt> from the <xref href="../langRef/attributes/metadataAttributes.dita"/>.</p><sectiondiv id="note-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref
-                                                href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                        />, and the attributes defined below.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and the
+attributes defined below.</p>
                                 <dl>
                                         <dlentry>
                                                 <dt><xmlatt>type</xmlatt></dt>
@@ -194,61 +139,38 @@
                                                   "other".</dd>
                                         </dlentry>
                                 </dl>
-                        </sectiondiv><p id="fig-attributes">The following attributes are available
-                                on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref href="../langRef/attributes/displayAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                />.</p><p id="pre-attributes">The following attributes are available
-                                on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref href="../langRef/attributes/displayAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/xmlspace"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                />.</p><p id="xref-attributes">The following attributes are
-                                available on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref
-                                        href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                />, <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref href="../langRef/attributes/thekeyrefattribute.dita"
-                                                ><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv
-                                id="fn-attributes">
-                                <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and the attribute defined below.</p>
-                                <dl>
-                                        <dlentry id="callout">
-                                                <dt><xmlatt>callout</xmlatt></dt>
-                                                <dd>Specifies what character is used for the
-                                                  footnote link, for example a number or an alpha
-                                                  character. The attribute <ph 
-                                                  >can</ph> also specify a short string of
-                                                  characters. When no <xmlatt>callout</xmlatt> value
-                                                  is specified, footnotes are typically
-                                                  numbered.<?datatype CDATA?><?default #IMPLIED?></dd>
-                                        </dlentry>
-                                </dl>
-                                <dl>
-                                        <dlentry id="lomdatatype">
-                                                <dt><xmlatt>datatype</xmlatt></dt>
-                                                <dd>Available for describing the type of data
-                                                  contained in the value attribute for this metadata
-                                                  element. The default value is the empty string
-                                                  "".</dd>
-                                        </dlentry>
-                                </dl>
-                        </sectiondiv><sectiondiv id="author-attributes">
+                        </sectiondiv><p id="fig-attributes">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/displayAttributes.dita"/>, and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="pre-attributes">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/displayAttributes.dita"/>, <xref
+href="../langRef/attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
+<p>The following attributes are available on this element: <xref
+href="../langRef/attributes/universalAttributes.dita"/> and the attribute defined below.</p>
+<dl>
+<dlentry id="callout">
+<dt><xmlatt>callout</xmlatt></dt>
+<dd>Specifies what character is used for the footnote link, for example a number or an alpha
+character. The attribute <ph>can</ph> also specify a short string of characters. When no
+<xmlatt>callout</xmlatt> value is specified, footnotes are typically
+numbered.<?datatype CDATA?><?default #IMPLIED?></dd>
+</dlentry>
+</dl>
+</sectiondiv>
+<sectiondiv>
+<dl>
+<dlentry id="lomdatatype">
+<dt><xmlatt>datatype</xmlatt></dt>
+<dd>Available for describing the type of data contained in the value attribute for this metadata
+element. The default value is the empty string "".</dd>
+</dlentry>
+</dl>
+</sectiondiv><sectiondiv id="author-attributes">
                                 <p>The following attributes are available on this element: <xref
                                                 href="../langRef/attributes/universalAttributes.dita"
                                         />, <xref
@@ -290,20 +212,12 @@
                                 </dl>
                         </sectiondiv><sectiondiv id="standard-topicref-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>href</xmlatt>,
-                                        given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+<xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-on-topicref">
                                                 <dt><xmlatt>href</xmlatt></dt>
@@ -322,20 +236,12 @@
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>href</xmlatt>,
-                                        given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt>
-                                        from <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+<xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
+href="../langRef/attributes/topicrefElementAttributes.dita"/>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-for-booklist">
                                                 <dt><xmlatt>href</xmlatt></dt>
@@ -357,20 +263,12 @@
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-topicrefs">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>href</xmlatt>,
-                                        given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt>
-                                        from <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+<xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
+href="../langRef/attributes/topicrefElementAttributes.dita"/>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
                                                 <dt/>
@@ -379,21 +277,12 @@
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-frontbackmatter">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>, and
-                                                <xmlatt>query</xmlatt> from <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />. This element also uses <xmlatt>scope</xmlatt>,
-                                                <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>
-                                        from <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and
+<xmlatt>query</xmlatt> from <xref href="../langRef/attributes/topicrefElementAttributes.dita"/>.
+This element also uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>
+from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"/>.</p>
                         </sectiondiv><sectiondiv>
                                 <p>Define the href value common to map references.</p>
                                 <dl>
@@ -487,20 +376,13 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="scheme-HAS-elements">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>href</xmlatt>,
-                                        given below), <xmlatt>processing-role</xmlatt> from <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xmlatt>navtitle</xmlatt> from <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xmlatt>processing-role</xmlatt> from <xref
+href="../langRef/attributes/commonMapAttributes.dita"/>, <xmlatt>navtitle</xmlatt> from <xref
+href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
                                                 <dt/>
@@ -509,128 +391,14 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="learningdomain-basic-topicref">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>href</xmlatt>,
-                                        given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+<xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
-                                                <dt/>
-                                                <dd/>
-                                        </dlentry>
-                                </dl>
-                        </sectiondiv><sectiondiv id="learningdomain-basic-topicref-no-collection">
-                                <!-- Used only for learningContentComponentRef, but stored here to keep in line with others from this map domain -->
-                                <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with narrowed definitions of <xmlatt>href</xmlatt> and
-                                                <xmlatt>format</xmlatt>, given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        /> (without the <xmlatt>collection-type</xmlatt> attribute),
-                                                <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <dl>
-                                        <dlentry conref="#conref-attribute/href-on-topicref">
-                                                <dt/>
-                                                <dd/>
-                                        </dlentry>
-                                        <dlentry>
-                                                <dt><xmlatt>format</xmlatt></dt>
-                                                <dd>On this element, the <xmlatt>format</xmlatt>
-                                                  attribute has a default value of "dita", because
-                                                  it usually links to DITA learning topics. If
-                                                  linking to something other than DITA, set the
-                                                  <xmlatt>format</xmlatt> attribute as described in
-                                                  <xref
-                                                  href="../langRef/attributes/theformatattribute.dita"
-                                                  />.</dd>
-                                        </dlentry>
-                                </dl>
-                        </sectiondiv><sectiondiv id="learningdomain-chunk-to-content">
-                                <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with narrowed definitions of <xmlatt>href</xmlatt> and
-                                                <xmlatt>format</xmlatt>, given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        /> (without the <xmlatt>collection-type</xmlatt> attribute,
-                                        and with a narrowed definition of <xmlatt>chunk</xmlatt>,
-                                        given below), <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <dl>
-                                        <dlentry conref="#conref-attribute/href-on-topicref">
-                                                <dt/>
-                                                <dd/>
-                                        </dlentry>
-                                        <dlentry>
-                                                <dt><xmlatt>format</xmlatt></dt>
-                                                <dd>On this element, the <xmlatt>format</xmlatt>
-                                                  attribute has a default value of "dita", because
-                                                  it usually links to DITA learning topics. If
-                                                  linking to something other than DITA, set the
-                                                  <xmlatt>format</xmlatt> attribute as described in
-                                                  <xref
-                                                  href="../langRef/attributes/theformatattribute.dita"
-                                                  />.</dd>
-                                        </dlentry>
-                                        <dlentry>
-                                                <dt><xmlatt>chunk</xmlatt></dt>
-                                                <dd>On this element, the <xmlatt>chunk</xmlatt>
-                                                  attribute has a default value of "to-content",
-                                                  which causes the current branch of content to be
-                                                  published as a single unit. See <xref
-                                                  href="../archSpec/base/chunking.dita"/> for more
-                                                  information and for details on other supported
-                                                  values.</dd>
-                                        </dlentry>
-                                </dl>
-                        </sectiondiv><sectiondiv id="learningdomain-mapref">
-                                <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        /> (with narrowed definitions of <xmlatt>href</xmlatt> and
-                                                <xmlatt>format</xmlatt>, given below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/topicrefElementAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, <xref href="../langRef/attributes/thekeysattribute.dita"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <dl>
-                                        <dlentry conref="#conref-attribute/href-on-topicref">
-                                                <dt/>
-                                                <dd/>
-                                        </dlentry>
-                                        <dlentry conref="#conref-attribute/format-mapref">
                                                 <dt/>
                                                 <dd/>
                                         </dlentry>
@@ -658,13 +426,9 @@ of map.-->
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>, also <coords> equivalents in L&T domain-->
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of
-                                        <xmlatt>translate</xmlatt>, given below), <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>translate</xmlatt>, given below), and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="translate-NO">
                                                 <dt><xmlatt>translate</xmlatt></dt>
@@ -697,11 +461,8 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="universal-outputclass-required-id">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>id</xmlatt>, given
-                                        below) and <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>id</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
                                                 <dt><xmlatt>id</xmlatt>
@@ -754,11 +515,8 @@ of map.-->
                                 inside is also used by fragref.</p><sectiondiv
                                 id="syntaxelement-optreq">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of
-                                                <xmlatt>importance</xmlatt>, given below) and  <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry id="importance-optreq">
                                                 <dt><xmlatt>importance</xmlatt></dt>
@@ -785,11 +543,8 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of
-                                                <xmlatt>importance</xmlatt>, given below) and  <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
                                                 <dt><xmlatt>importance</xmlatt></dt>
@@ -822,13 +577,9 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of
-                                                <xmlatt>importance</xmlatt>, given below),  <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>importance</xmlatt>, given below) and <xref
+href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry>
                                                 <dt><xmlatt>importance</xmlatt></dt>
@@ -996,20 +747,13 @@ of map.-->
                         <section id="section-4"><title>Attributes used on the <xmlelement>map</xmlelement> element</title><sectiondiv
                                         id="all-map-attributes">
                                         <p id="map-attributes-common">The following attributes are
-                                        available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of <xmlatt>id</xmlatt>, given
-                                        below), <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
-                                        />, <xref
-                                                href="../langRef/attributes/architecturalAttributes.dita#arch-atts"
-                                        />, <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />, and the attributes defined below. This element also uses
-                                                <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-                                                <xmlatt>format</xmlatt> from <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
-                                        />.</p>
+available on this element: <xref href="../langRef/attributes/universalAttributes.dita"/> (with a
+narrowed definition of <xmlatt>id</xmlatt>, given below), <xref
+href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
+href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes defined
+below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
+<xmlatt>format</xmlatt> from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"
+/>.</p>
                                         <dl>
                                                 <dlentry id="map-attribute-id">
                                                   <dt><xmlatt>id</xmlatt></dt>
@@ -1037,14 +781,11 @@ of map.-->
                                 </sectiondiv></section>
                 <section id="section-5">
                         <title>Common for simpletable and at least one specialization</title>
-                        <p id="simpletable-attributes">The following attributes are available on this
-                                element: <xref href="../langRef/attributes/universalAttributes.dita"/>,
-                                        <xref href="../langRef/attributes/displayAttributes.dita"/>, <xref
-                                        href="../langRef/attributes/simpletableAttributes.dita"/>, <xref
-                                        href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, and <xref
-                                        href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"
-                                />.</p>
+                        <p id="simpletable-attributes">The following attributes are available on
+this element: <xref href="../langRef/attributes/universalAttributes.dita"/>, <xref
+href="../langRef/attributes/displayAttributes.dita"/>, <xref
+href="../langRef/attributes/simpletableAttributes.dita"/>, and <xref
+href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
                 </section>
                 <section id="section-6"><title>Attributes for specialized reltables (drop <xmlatt>title</xmlatt> from base
                                 reltable)</title><sectiondiv id="reltable-minus-title">
@@ -1068,11 +809,8 @@ of map.-->
                 <section id="section-7"><title>Common to step and substep</title><p>Universal atts, with narrowed
                                 definition of <xmlatt>importance</xmlatt>.</p><sectiondiv id="step-and-substep">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
-                                        /> (with a narrowed definition of
-                                                <xmlatt>importance</xmlatt>, given below) and <xref
-                                                href="../langRef/attributes/commonAttributes.dita#common-atts/outputclass"
-                                        />.</p>
+href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+<xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
                                                 <dt>importance</dt>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -28,16 +28,6 @@
               information on using this attribute.
               <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></ph><?datatype CDATA?><?default #IMPLIED?></dd>
     </dlentry>
-    <dlentry id="outputclass">
-     <dt><xmlatt>outputclass</xmlatt></dt>
-     <dd><indexterm>outputclass
-                attribute</indexterm><indexterm>Attributes<indexterm>outputclass</indexterm></indexterm>Names
-            a role that the element is playing. The role must be consistent with the basic semantic
-            and expectations for the element. In particular, the <xmlatt>outputclass</xmlatt>
-            attribute can be used for styling during output processing; HTML output will typically
-            preserve <xmlatt>outputclass</xmlatt> for CSS processing.
-            <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
-    </dlentry>
     <dlentry id="compact">
      <dt><xmlatt>compact</xmlatt></dt>
      <dd><indexterm>compact

--- a/specification/langRef/attributes/universalAttributes.dita
+++ b/specification/langRef/attributes/universalAttributes.dita
@@ -13,15 +13,17 @@
 </metadata></prolog>
 <refbody>
   <section id="section-1">
-      <note >Earlier versions of the DITA specification grouped some attributes under
-        names taken directly from parameter entities in the standard DTD implementation of DITA.
-        These groups used names such as "univ-atts", which had no meaning outside the context of a
-        DTD module. In DITA 1.3, these groups are restructured and renamed in the specification
-        document for greater clarity, and no longer have a connection to the DTD. For example, this
-        grouping of "Universal attributes" was previously referred to as "univ-atts"; the updated
-        group includes several universal attributes that are not part of the univ-atts group in the
-        DTD.</note>
       <dl>
+<dlentry id="outputclass">
+<dt><xmlatt>outputclass</xmlatt></dt>
+<dd><indexterm>outputclass
+attribute</indexterm><indexterm>Attributes<indexterm>outputclass</indexterm></indexterm>Names a role
+that the element is playing. The role must be consistent with the basic semantic and expectations
+for the element. In particular, the <xmlatt>outputclass</xmlatt> attribute can be used for styling
+during output processing; HTML output will typically preserve <xmlatt>outputclass</xmlatt> for CSS
+processing.
+<!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+</dlentry>
         <dlentry id="class">
           <dt><xmlatt>class</xmlatt>
             <i>(Not for use by authors)</i></dt>

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -65,9 +65,7 @@
 		</section>
 		<section id="attributes">
 			<title>Attributes</title>
-			<p>The following attributes are available on this element: <xref
-					href="../attributes/universalAttributes.dita"/> and <xref
-					href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+<p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
 		</section>
 <example id="example" otherprops="examples"><title>Example: <xmlelement>abstract</xmlelement> with phrase-level short description</title><codeblock id="example-code">&lt;abstract&gt;The abstract is being used to provide more complex content. 
 	&lt;shortdesc&gt;The shortdesc must be directly contained by the abstract.&lt;/shortdesc&gt;

--- a/specification/langRef/base/alt.dita
+++ b/specification/langRef/base/alt.dita
@@ -15,9 +15,7 @@
 <refbody>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and <xref
-                    href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+<p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The markup for alternate text within an image looks like this:</p><codeblock>&lt;image href="tip-ing.jpg"&gt;
   &lt;alt&gt;Here's a Tip!&lt;/alt&gt;

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -26,8 +26,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below) and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+          <xmlatt>id</xmlatt>, given below).</p>
       <dl>
         <dlentry>
           <dt><xmlatt>id</xmlatt>

--- a/specification/langRef/base/anchorid.dita
+++ b/specification/langRef/base/anchorid.dita
@@ -172,9 +172,8 @@ that id, because processors will match on the topic's id first.</li>
 <section id="attributes"><title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below), <xref href="../attributes/thekeyrefattribute.dita"
-            ><xmlatt>keyref</xmlatt></xref>, and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+          <xmlatt>id</xmlatt>, given below) and <xref href="../attributes/thekeyrefattribute.dita"
+            ><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>id</xmlatt>

--- a/specification/langRef/base/anchorkey.dita
+++ b/specification/langRef/base/anchorkey.dita
@@ -32,8 +32,7 @@ topic/keyword delay-d/anchorkey </p></section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attribute
+          href="../attributes/universalAttributes.dita"/> and the attribute
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -62,7 +62,6 @@
                         <xmlatt>format</xmlatt>, all given below), <xref
                         href="../attributes/commonMapAttributes.dita"/>, <xref
                         href="../attributes/topicrefElementAttributes.dita"/>, <xref
-                        href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
                         href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and
                         <xref href="../attributes/thekeyrefattribute.dita"
                         ><xmlatt>keyref</xmlatt></xref>. </p>

--- a/specification/langRef/base/area.dita
+++ b/specification/langRef/base/area.dita
@@ -17,7 +17,7 @@ coordinates of that shape, and a link target for the area.</shortdesc>
 topic/figgroup ut-d/area </p></section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;area>
  &lt;shape>rect&lt;/shape>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -30,7 +30,7 @@
                     href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
                     <xmlatt>base</xmlatt> from <xref
                     href="../attributes/metadataAttributes.dita#select-atts"/>, <xref
-                    href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
+                    href="../attributes/universalAttributes.dita#univ-atts/outputclass"/>, <xref
                     href="../attributes/universalAttributes.dita#univ-atts/class"/>, and the
                 attributes defined below.</p>
             <dl>

--- a/specification/langRef/base/b.dita
+++ b/specification/langRef/base/b.dita
@@ -28,7 +28,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+   <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
   </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/base/body.dita
+++ b/specification/langRef/base/body.dita
@@ -7,9 +7,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;topic&gt;
 &lt;title&gt;Sample title&lt;/title&gt;

--- a/specification/langRef/base/bodydiv.dita
+++ b/specification/langRef/base/bodydiv.dita
@@ -34,9 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;topic id="sample" xml:lang="en">
  &lt;title>Sample for bodydiv&lt;/title>

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -20,8 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+          href="../attributes/universalAttributes.dita"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p&gt;The online article <b>&lt;cite&gt;</b>Specialization in the Darwin Information Typing

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -18,8 +18,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
-          <xmlatt>base</xmlatt> from the <xref href="../attributes/metadataAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          <xmlatt>base</xmlatt> from the <xref href="../attributes/metadataAttributes.dita"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
           <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
           <xmlatt>rowheader</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>

--- a/specification/langRef/base/consequence.dita
+++ b/specification/langRef/base/consequence.dita
@@ -17,7 +17,7 @@ may cause burn."</shortdesc>
 topic/li hazard-d/consequence</p></section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"> 			<title>Example</title><codeblock>&lt;hazardstatement type="warning"&gt;
   &lt;messagepanel&gt;

--- a/specification/langRef/base/data-about.dita
+++ b/specification/langRef/base/data-about.dita
@@ -26,9 +26,8 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita#univ-atts"/>, <xref
-                    href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>, and
-                    <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/></p>
+                    href="../attributes/universalAttributes.dita#univ-atts"/> and <xref
+                    href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>.</p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The full properties of a cited book can be maintained conveniently in the
                     <xmlelement>prolog</xmlelement>:</p><codeblock>&lt;topic id="questions"&gt;

--- a/specification/langRef/base/dd.dita
+++ b/specification/langRef/base/dd.dita
@@ -14,9 +14,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/simpleexample"></fig></example>

--- a/specification/langRef/base/ddhd.dita
+++ b/specification/langRef/base/ddhd.dita
@@ -20,9 +20,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/complexexample"></fig></example>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -26,7 +26,6 @@
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/topicrefElementAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>locktitle</xmlatt>, and

--- a/specification/langRef/base/desc.dita
+++ b/specification/langRef/base/desc.dita
@@ -40,9 +40,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples">       <title>Example</title>       <codeblock>&lt;fig&gt;&lt;title&gt;The Handshake&lt;/title&gt;
 <b>&lt;desc&gt;</b>This image shows two hands clasped in a formal, 

--- a/specification/langRef/base/div.dita
+++ b/specification/langRef/base/div.dita
@@ -27,9 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>
@@ -56,10 +54,7 @@
   "(%div.cnt;)*"
 >
 &lt;!ENTITY % pullquote.attributes
-             "%univ-atts;
-              outputclass 
-                        CDATA 
-                                  #IMPLIED"
+             "%univ-atts;"
 >
 &lt;!ELEMENT pullquote    %pullquote.content;>
 &lt;!ATTLIST pullquote    %pullquote.attributes;>

--- a/specification/langRef/base/dl.dita
+++ b/specification/langRef/base/dl.dita
@@ -92,7 +92,6 @@
 <section id="attributes">       <title>Attributes</title>
    <p >The following attributes are available on this element: <xref
      href="../attributes/universalAttributes.dita"/>, <xref
-     href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
      href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
      href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>     </section>
 </refbody>

--- a/specification/langRef/base/dlentry.dita
+++ b/specification/langRef/base/dlentry.dita
@@ -16,9 +16,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/simpleexample"></fig></example>

--- a/specification/langRef/base/dlhead.dita
+++ b/specification/langRef/base/dlhead.dita
@@ -20,9 +20,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/complexexample"></fig></example>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -49,8 +49,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (with a narrowed definition for
-          <xmlatt>translate</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          <xmlatt>translate</xmlatt>, given below) and the attributes
         defined below.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/translate-NO">

--- a/specification/langRef/base/dt.dita
+++ b/specification/langRef/base/dt.dita
@@ -18,8 +18,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+          href="../attributes/universalAttributes.dita"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig

--- a/specification/langRef/base/dthd.dita
+++ b/specification/langRef/base/dthd.dita
@@ -16,9 +16,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/complexexample"></fig></example>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -18,8 +18,7 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
           <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
-          href="../attributes/metadataAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          href="../attributes/metadataAttributes.dita"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
           <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
           <xmlatt>valign</xmlatt> from the <xref href="../attributes/calsTableAttributes.dita"

--- a/specification/langRef/base/example.dita
+++ b/specification/langRef/base/example.dita
@@ -23,9 +23,7 @@ Hence, in a DITA topic, to represent programming code and results within the dis
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p
-        conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-spectitle"
-      />
+      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;example id="example">
   &lt;title>Example&lt;/title>

--- a/specification/langRef/base/figgroup.dita
+++ b/specification/langRef/base/figgroup.dita
@@ -18,9 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;fig>
   &lt;title>Sample complex figure&lt;/title>

--- a/specification/langRef/base/foreign.dita
+++ b/specification/langRef/base/foreign.dita
@@ -86,7 +86,7 @@ stroke:rgb(0,0,100);stroke-width:2"/&gt;
 &lt;/p&gt; </codeblock>
     </example>
 <section id="attributes"><title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
 </section>
 </refbody>
 </reference>

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -23,7 +23,6 @@
             <xmlatt>href</xmlatt>, given below), processing-role from <xref
             href="../attributes/commonMapAttributes.dita"/>, navtitle from <xref
             href="../attributes/topicrefElementAttributes.dita"/>, <xref
-            href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -21,8 +21,7 @@ topic/note hazard-d/hazardstatement </p></section>
       <title>Attributes</title>
       <sectiondiv>
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/>, <xref
-            href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
+            href="../attributes/universalAttributes.dita"/> and <xref
             href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and
           the attributes defined below.</p>
         <dl>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -20,7 +20,6 @@ topic/image hazard-d/hazardsymbol</p></section>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/howtoavoid.dita
+++ b/specification/langRef/base/howtoavoid.dita
@@ -17,7 +17,7 @@ not use solvents to clean the drum surface."</shortdesc>
 topic/li hazard-d/howtoavoid</p></section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;hazardstatement type="notice">
   &lt;messagepanel>

--- a/specification/langRef/base/i.dita
+++ b/specification/langRef/base/i.dita
@@ -31,7 +31,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock
 xml:space="preserve">&lt;p&gt;Unplug the unit &lt;i&gt;before&lt;/i&gt; placing the metal screwdriver

--- a/specification/langRef/base/image.dita
+++ b/specification/langRef/base/image.dita
@@ -36,7 +36,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/itemgroup.dita
+++ b/specification/langRef/base/itemgroup.dita
@@ -19,7 +19,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+   <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
   </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;li&gt;Second point of a list.
  &lt;itemgroup&gt;related discourse&lt;/itemgroup&gt;

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -36,7 +36,6 @@
             <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"
           /> (with a narrowed definition of <xmlatt>processing-role</xmlatt>, given below), <xref
             href="../attributes/topicrefElementAttributes.dita"/>, <xref
-            href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
           attributes defined below.</p>
         <dl>

--- a/specification/langRef/base/keyword.dita
+++ b/specification/langRef/base/keyword.dita
@@ -45,9 +45,7 @@ for a message.</shortdesc>
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p
-            conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-keyref"
-         />
+<p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples"><codeblock xml:space="preserve">&lt;p&gt;The &lt;keyword&gt;assert&lt;/keyword&gt; pragma statement allows messages to be passed
 to the emulator, pre-compiler, etc..&lt;/p&gt;

--- a/specification/langRef/base/li.dita
+++ b/specification/langRef/base/li.dita
@@ -29,9 +29,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and <xref
-                    href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+        <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;ul&gt;
   &lt;li&gt;This is an item in an unordered list.&lt;/li&gt;

--- a/specification/langRef/base/line-through.dita
+++ b/specification/langRef/base/line-through.dita
@@ -31,7 +31,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -29,7 +29,6 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/displayAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -35,7 +35,6 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
     </section>

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -51,7 +51,6 @@ topic/linklist </p></section>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, <xref

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -19,7 +19,6 @@ in the DITA topic.</shortdesc>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
    <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>, and the attributes

--- a/specification/langRef/base/linktext.dita
+++ b/specification/langRef/base/linktext.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock
 xml:space="preserve">&lt;link href="tzover.htm#accsqlj"&gt;

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -18,8 +18,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+          href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -22,8 +22,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+          href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>A great person once said the following thing.

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -32,8 +32,7 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition for
-          <xmlatt>type</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+          <xmlatt>type</xmlatt>, given below), and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -35,7 +35,6 @@
             <xmlatt>href</xmlatt> and <xmlatt>format</xmlatt>, given below), <xref
             href="../attributes/commonMapAttributes.dita"/>, <xref
             href="../attributes/topicrefElementAttributes.dita"/>, <xref
-            href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/messagepanel.dita
+++ b/specification/langRef/base/messagepanel.dita
@@ -19,9 +19,7 @@ hazard.</shortdesc>
 topic/ul hazard-d/messagepanel</p></section>
     <section id="attributes">
       <title>Attributes</title>
-      <p
-        conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-spectitle-compact"
-      />
+      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle-compact"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;hazardstatement type="caution">
   <b>&lt;messagepanel></b>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -32,8 +32,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="universal-outputclass">The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attribute
+          href="../attributes/universalAttributes.dita"/> and the attribute
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -23,8 +23,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/>, <xref
-                    href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the
+                    href="../attributes/universalAttributes.dita"/> and the
                 attributes defined below.</p>
             <dl>
                 <dlentry>

--- a/specification/langRef/base/ol.dita
+++ b/specification/langRef/base/ol.dita
@@ -14,7 +14,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/overline.dita
+++ b/specification/langRef/base/overline.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/p.dita
+++ b/specification/langRef/base/p.dita
@@ -12,7 +12,7 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p&gt;This paragraph contains text that should be of
 interest. It might give details about my company, or an explanation

--- a/specification/langRef/base/ph.dita
+++ b/specification/langRef/base/ph.dita
@@ -15,9 +15,7 @@ which then allows (but does not require) specific processing or formatting.</sho
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p
-            conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-keyref"
-         />
+<p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>This was not changed. &lt;ph rev="v5r2"&gt;This was updated.&lt;/ph&gt; This was not.&lt;/p></codeblock></example>
 </refbody>

--- a/specification/langRef/base/q.dita
+++ b/specification/langRef/base/q.dita
@@ -39,7 +39,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>George said, &lt;q&gt;Disengage the power supply before servicing the unit.&lt;/q&gt;</codeblock></example>
 </refbody>

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -33,9 +33,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (apart from <xmlatt>href</xmlatt>),
-          <xref href="../attributes/theroleattribute.dita#theroleattribute"/>, and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+          href="../attributes/linkRelationshipAttributes.dita"/> (apart from <xmlatt>href</xmlatt>), and
+          <xref href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following
 indicates that the two external links are always applicable to this

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -39,7 +39,6 @@ restricted by the <xmlatt>linking</xmlatt> attribute of the subjects).</shortdes
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>collection-type</xmlatt>, and a narrowed

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -23,9 +23,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt>
-        attribute), and <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.
+          href="../attributes/universalAttributes.dita"/> and <xref
+          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt>).
         This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
         />.</p>

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -75,10 +75,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          href="../attributes/universalAttributes.dita"/> and <xref
           href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt> attribute), and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>. This element also
+          <xmlatt>collection-type</xmlatt>). This element also
         uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt> from <xref
           href="../attributes/linkRelationshipAttributes.dita"/>.</p>
     </section>

--- a/specification/langRef/base/relrow.dita
+++ b/specification/langRef/base/relrow.dita
@@ -20,7 +20,7 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
 href="reltable.dita"></xref>.</p></example>

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -51,10 +51,9 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonMapAttributes.dita"/> (without the <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt> attribute, and with a narrowed definition of
-          <xmlatt>toc</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
+          <xmlatt>collection-type</xmlatt>, and with a narrowed definition of
+          <xmlatt>toc</xmlatt>, given below), and the attributes
         defined below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
         />.</p>

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -30,8 +30,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (with a modified definition of
-          <xmlatt>translate</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          <xmlatt>translate</xmlatt>, given below), and the attributes
         defined below.<dl>
 <dlentry>
 <dt><xmlatt>remap</xmlatt></dt>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -4,8 +4,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>. This element also
-        uses <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
+          href="../attributes/universalAttributes.dita"/>, along with
+        <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
           href="../attributes/calsTableAttributes.dita"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -22,8 +22,7 @@
         <p>The following attributes are available on this element: <xref
             href="../attributes/universalAttributes.dita"/>, <xref
             href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
-            <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below),
-            <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
+            <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below), <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -30,9 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the
 following example, the general title "Programming Example" is likely

--- a/specification/langRef/base/section.dita
+++ b/specification/langRef/base/section.dita
@@ -31,9 +31,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p
-        conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-spectitle"
-      />
+<p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;reference id="reference"&gt;
  &lt;title&gt;Copy Command&lt;/title&gt;

--- a/specification/langRef/base/sectiondiv.dita
+++ b/specification/langRef/base/sectiondiv.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the example below, the <xmlelement>sectiondiv</xmlelement> element is used to group content
         that can be reused elsewhere.</p><codeblock>&lt;section>

--- a/specification/langRef/base/shortdesc.dita
+++ b/specification/langRef/base/shortdesc.dita
@@ -66,9 +66,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>

--- a/specification/langRef/base/sl.dita
+++ b/specification/langRef/base/sl.dita
@@ -24,8 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
+          href="../attributes/universalAttributes.dita"/>,, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/sli.dita
+++ b/specification/langRef/base/sli.dita
@@ -27,7 +27,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="sl.dita"></xref>.</p></example>
 </refbody>

--- a/specification/langRef/base/state.dita
+++ b/specification/langRef/base/state.dita
@@ -11,8 +11,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="universal-outputclass">The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+          href="../attributes/universalAttributes.dita"/> and the attributes
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/stentry.dita
+++ b/specification/langRef/base/stentry.dita
@@ -10,7 +10,5 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p
-        conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-specentry"
-      />
+      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-specentry"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="simpletable.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/sthead.dita
+++ b/specification/langRef/base/sthead.dita
@@ -4,5 +4,5 @@
         <indexterm>tables<indexterm>simple<indexterm>headers</indexterm></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="simpletable.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/strow.dita
+++ b/specification/langRef/base/strow.dita
@@ -4,5 +4,5 @@
         <indexterm>tables<indexterm>simple<indexterm>rows</indexterm></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="simpletable.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/sub.dita
+++ b/specification/langRef/base/sub.dita
@@ -30,7 +30,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p>The power produced by the electrohydraulic dam was 10&lt;sup&gt;10&lt;/sup&gt; more than 
 the older electric plant.  The difference was H<b>&lt;sub&gt;</b>2<b>&lt;/sub&gt;</b>O.&lt;/p></codeblock></example>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -23,9 +23,7 @@ controlled values.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xmlatt>navtitle</xmlatt> from <xref
-          href="../attributes/topicrefElementAttributes.dita"/>, and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>. This element also
+          href="../attributes/universalAttributes.dita"/>. This element also
         uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>, and narrowed definitions of
           <xmlatt>collection-type</xmlatt> and <xmlatt>linking</xmlatt> from <xref
           href="../attributes/commonMapAttributes.dita"/>. <dl>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -23,8 +23,7 @@
           href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"/>
         (with narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>,
-        given below), <xref href="../attributes/architecturalAttributes.dita#arch-atts"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attributes
+        given below), <xref href="../attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes
         defined below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
         />.</p>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -55,9 +55,7 @@
                                         href="../attributes/universalAttributes.dita"/>, <xref
                                         href="../attributes/topicrefElementAttributes.dita"/>, <xref
                                         href="../attributes/linkRelationshipAttributes.dita"/> (with
-                                a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-                                        href="../attributes/commonAttributes.dita#common-atts/outputclass"
-                                />, <xref href="../attributes/thekeysattribute.dita"
+                                a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref href="../attributes/thekeysattribute.dita"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                         href="../attributes/thekeyrefattribute.dita"
                                                 ><xmlatt>keyref</xmlatt></xref>. This element also

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -24,7 +24,6 @@
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>navtitle</xmlatt> and <xmlatt>query</xmlatt>
         from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of

--- a/specification/langRef/base/sup.dita
+++ b/specification/langRef/base/sup.dita
@@ -31,7 +31,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p>The power produced by the electrohydraulic dam was 10<b>&lt;sup&gt;</b>10<b>&lt;/sup&gt;</b> more than 
 the older electric plant.  The difference was H&lt;sub&gt;2&lt;/sub&gt;O.&lt;/p></codeblock></example>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -29,8 +29,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xmlatt
+          href="../attributes/universalAttributes.dita"/>, <xmlatt
           rev="errata-01">frame</xmlatt> and <xmlatt>scale</xmlatt> from <xref
           href="../attributes/displayAttributes.dita"/>, and the attributes defined below. This
         element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE reference
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
-<reference id="tbody" xml:lang="en-us"><title><xmlelement>tbody</xmlelement></title><shortdesc>The <xmlelement>tbody</xmlelement> element contains the rows in a table.</shortdesc><prolog><metadata><keywords><indexterm>tbody</indexterm><indexterm>table elements<indexterm>tbody</indexterm></indexterm></keywords></metadata></prolog><refbody>
+<reference id="tbody" xml:lang="en-us">
+<title><xmlelement>tbody</xmlelement></title>
+<shortdesc>The <xmlelement>tbody</xmlelement> element contains the rows in a table.</shortdesc>
+<prolog><metadata><keywords><indexterm>tbody</indexterm><indexterm>table elements<indexterm>tbody</indexterm></indexterm></keywords></metadata></prolog>
+<refbody>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and
+          href="../attributes/universalAttributes.dita"/> and
           <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>
+    </section>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/term.dita
+++ b/specification/langRef/base/term.dita
@@ -21,9 +21,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p
-            conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass-keyref"
-         />
+         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p&gt;A &lt;term&gt;reference implementation&lt;/term&gt; of DITA implements the standard, 
 fallback behaviors intended for DITA elements.&lt;/p&gt;</codeblock> </example>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -17,8 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and the attribute
+          href="../attributes/universalAttributes.dita"/> and the attribute
         defined below. This element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
           <xmlatt>align</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
       <dl>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE reference
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
-<reference id="thead" xml:lang="en-us"><title><xmlelement>thead</xmlelement></title><shortdesc>The <xmlelement>thead</xmlelement> element is a table header that precedes the table body
-            (<xmlelement>tbody</xmlelement>) element in a complex table.</shortdesc><prolog><metadata><keywords><indexterm>thead</indexterm><indexterm>table elements<indexterm>thead</indexterm></indexterm></keywords></metadata></prolog><refbody>
+<reference id="thead" xml:lang="en-us">
+<title><xmlelement>thead</xmlelement></title>
+<shortdesc>The <xmlelement>thead</xmlelement> element is a table header that precedes the table body
+            (<xmlelement>tbody</xmlelement>) element in a complex table.</shortdesc>
+<prolog><metadata><keywords><indexterm>thead</indexterm><indexterm>table elements<indexterm>thead</indexterm></indexterm></keywords></metadata></prolog>
+<refbody>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and
+          href="../attributes/universalAttributes.dita"/> and
           <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>
+    </section>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/title.dita
+++ b/specification/langRef/base/title.dita
@@ -25,9 +25,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
-          <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
-          href="../attributes/metadataAttributes.dita"/>, and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+          plus <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
+          href="../attributes/metadataAttributes.dita"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
    <codeblock >&lt;topic id="topicid">

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -22,7 +22,6 @@ can identify a single subject. Additional subjects can be specified by nested
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -44,9 +44,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonMapAttributes.dita"/> (except for <xmlatt>locktitle)</xmlatt>,
-        and <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
+          href="../attributes/universalAttributes.dita"/> and <xref
+          href="../attributes/commonMapAttributes.dita"/> (except for <xmlatt>locktitle</xmlatt>).</p>
       <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
         from <xref href="../attributes/linkRelationshipAttributes.dita"/> are also available.</p>
     </section>

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -40,13 +40,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonMapAttributes.dita"/>  (except for <xmlatt>locktitle)</xmlatt>,
-        and <xmlatt>copy-to</xmlatt> from <xref
-          href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>, and <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>.</p>
-      <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
-        from <xref href="../attributes/linkRelationshipAttributes.dita"/> are also available.</p>
+href="../attributes/universalAttributes.dita"/>, <xref href="../attributes/commonMapAttributes.dita"
+/> (except for <xmlatt>locktitle</xmlatt>), and <xmlatt>copy-to</xmlatt> from <xref
+href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>. This element also uses
+the <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes from <xref
+href="../attributes/linkRelationshipAttributes.dita"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>Note that in the following example, the first <xmlelement>topichead</xmlelement> element uses a
           <xmlelement>navtitle</xmlelement> element to provide the title, while the second

--- a/specification/langRef/base/topicset.dita
+++ b/specification/langRef/base/topicset.dita
@@ -33,7 +33,6 @@
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"
         />, <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/topicsetref.dita
+++ b/specification/langRef/base/topicsetref.dita
@@ -46,7 +46,6 @@
           <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below),
           <xref href="../attributes/commonMapAttributes.dita"/>, <xref
           href="../attributes/topicrefElementAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -29,9 +29,8 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-          <xmlatt>href</xmlatt>, given below), <xmlatt>navtitle</xmlatt> and <xmlatt>query</xmlatt>
+          <xmlatt>href</xmlatt>, given below), <xmlatt>query</xmlatt>
         from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>

--- a/specification/langRef/base/tt.dita
+++ b/specification/langRef/base/tt.dita
@@ -27,7 +27,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/base/typeofhazard.dita
+++ b/specification/langRef/base/typeofhazard.dita
@@ -16,7 +16,7 @@ a description of the type of hazard, for example, "Hot surfaces inside."</shortd
 topic/li hazard-d/typeofhazard</p></section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;hazardstatement type="caution">
   &lt;messagepanel>

--- a/specification/langRef/base/u.dita
+++ b/specification/langRef/base/u.dita
@@ -28,7 +28,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p>Beware: &lt;u&gt;overuse&lt;/u&gt; &lt;i&gt;of&lt;/i&gt; &lt;b&gt;highlighting&lt;/b&gt; is 
 sometimes known as font-itis!&lt;/p>

--- a/specification/langRef/base/ul.dita
+++ b/specification/langRef/base/ul.dita
@@ -27,7 +27,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           href="../attributes/universalAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/unknown.dita
+++ b/specification/langRef/base/unknown.dita
@@ -18,7 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-outputclass"/>
+      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>This example features a specialized <xmlelement>unknown</xmlelement> element that includes other
         non-DITA content. If this specialization is imported to a DTD or schema, the DTD or schema


### PR DESCRIPTION
- Updates spec to remove links to `@outputclass` for all elements that already use universal-atts
- Move definition of `@outputclass` to univ-atts topic
- Update code samples for grammar files that showed outputclass together with univ-atts
- Update grammar files to add `@outputclass` to univ-atts
- Update grammar files to remove `@outputclass` independent definition from any elements that use univ-atts