### PR TITLE
Add outputclass to 3 elements that didn't use univ-atts

### DIFF
--- a/doctypes/dtd/base/dtd/map.mod
+++ b/doctypes/dtd/base/dtd/map.mod
@@ -703,7 +703,10 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
                            -dita-use-conref-target)
                                     'no'
                %id-atts;
-               %select-atts;"
+               %select-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!ELEMENT  ux-window %ux-window.content;>
 <!ATTLIST  ux-window %ux-window.attributes;>

--- a/doctypes/dtd/base/dtd/metaDecl.mod
+++ b/doctypes/dtd/base/dtd/metaDecl.mod
@@ -479,12 +479,7 @@
                        "(%data.elements.incl;)*"
 >
 <!ENTITY % resourceid.attributes
-              "%select-atts;
-               %localization-atts;
-               id
-                          CDATA
-                                    #IMPLIED
-               %conref-atts;
+              "%univ-atts;
                appname
                           CDATA
                                     #IMPLIED

--- a/doctypes/dtd/base/dtd/tblDecl.mod
+++ b/doctypes/dtd/base/dtd/tblDecl.mod
@@ -209,7 +209,10 @@
 >
 <!ENTITY % dita.colspec.attributes
               "%id-atts;
-               %localization-atts;"
+               %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!--                    LONG NAME: Table                           -->
 <!ENTITY % table.content

--- a/doctypes/rng/base/rng/mapMod.rng
+++ b/doctypes/rng/base/rng/mapMod.rng
@@ -1087,6 +1087,9 @@ ORIGINAL CREATION DATE:
         </optional>
         <ref name="id-atts"/>
         <ref name="select-atts"/>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
       </define>
       <define name="ux-window.element">
         <a:documentation> Category: Map elements</a:documentation>

--- a/doctypes/rng/base/rng/metaDeclMod.rng
+++ b/doctypes/rng/base/rng/metaDeclMod.rng
@@ -834,12 +834,7 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="resourceid.attributes">
-        <ref name="select-atts"/>
-        <ref name="localization-atts"/>
-        <optional dita:since="1.3">
-          <attribute name="id"/>
-        </optional>
-        <ref name="conref-atts"/>
+        <ref name="univ-atts"/>
         <optional>
           <attribute name="appname"/>
         </optional>

--- a/doctypes/rng/base/rng/tblDeclMod.rng
+++ b/doctypes/rng/base/rng/tblDeclMod.rng
@@ -285,6 +285,9 @@ For <entry>, add:
   <define name="dita.colspec.attributes">
     <ref name="id-atts"/>
     <ref name="localization-atts"/>
+    <optional>
+      <attribute name="outputclass"/>
+    </optional>
   </define>
   
   <!--  -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

- `ux-window` did not have it and did not have universal atts, so adding there
- `resourceid` did not declare univ-atts because it used to have a required ID; as of DITA 1.3 it uses that attribute the same way as every other element, so I replaced the individual declarations with univ-atts
- `colspec` also didn't declare universal atts, so adding there