### PR TITLE
Switch attribute links to use keys

### DIFF
--- a/specification/archSpec/base/conref.ditamap
+++ b/specification/archSpec/base/conref.ditamap
@@ -25,10 +25,10 @@
     <topicref href="conref-overview.dita" />
    </relcell>
    <relcell>
-    <topicref href="../../langRef/attributes/theconactionattribute.dita"/>
-    <topicref href="../../langRef/attributes/theconkeyrefattribute.dita"/>
-    <topicref href="../../langRef/attributes/theconrefattribute.dita"/>
-    <topicref href="../../langRef/attributes/theconrefendattribute.dita"/>
+    <topicref keyref="attributes-conaction"/>
+    <topicref keyref="attributes-conkeyref"/>
+    <topicref keyref="attributes-conref"/>
+    <topicref keyref="attributes-conrefend"/>
    </relcell>
   </relrow>
   <relrow>
@@ -44,7 +44,7 @@
     <topicref href="conref-attributes-specified-on-elements.dita" />
    </relcell>
    <relcell>
-    <topicref href="../../langRef/attributes/ditauseconreftarget.dita"/>
+    <topicref keyref="attributes-useconreftarget"/>
    </relcell>
   </relrow>
   <relrow>

--- a/specification/base-relationship-tables.ditamap
+++ b/specification/base-relationship-tables.ditamap
@@ -89,7 +89,7 @@
      navtitle="How to use conditional processing attributes"/>
    </relcell>
    <relcell>
-    <topicref href="langRef/attributes/metadataAttributes.dita"
+    <topicref keyref="attributes-metadata"
      navtitle="select-atts attribute group"/>
     <topicref href="langRef/containers/ditaval-elements.dita"
      navtitle="DITAVAL elements"/>
@@ -100,7 +100,7 @@
     <topicref href="archSpec/base/filtering.dita"/>
    </relcell>
    <relcell>
-    <topicref href="langRef/attributes/metadataAttributes.dita"
+    <topicref keyref="attributes-metadata"
      navtitle="select-atts attribute group"/>
     <topicref href="langRef/ditaval/ditaval-val.dita" navtitle="val element in DITAVAL">
      <topicmeta>
@@ -195,7 +195,7 @@
   </relheader>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/ditauseconreftarget.dita"
+    <topicref keyref="attributes-useconreftarget"
      navtitle="Using the -dita-use-conref-target value"/>
    </relcell>
    <relcell>
@@ -212,7 +212,7 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/localizationAttributes.dita"
+    <topicref keyref="attributes-localization"
      navtitle="localization-atts attribute group"/>
    </relcell>
    <relcell>
@@ -221,7 +221,7 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/metadataAttributes.dita" navtitle="select-atts attribute group"/>
+    <topicref keyref="attributes-metadata" navtitle="select-atts attribute group"/>
    </relcell>
    <relcell>
     <topicref href="archSpec/base/specialization.dita" navtitle="Specialization"/>
@@ -231,7 +231,7 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/theconrefattribute.dita" navtitle="conref attribute"/>
+    <topicref keyref="attributes-conref" navtitle="conref attribute"/>
    </relcell>
    <relcell>
     <topicref href="archSpec/base/conref.dita" navtitle="Content inclusion (conref)"/>
@@ -239,8 +239,8 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/thekeyrefattribute.dita" navtitle="keyref attribute"/>
-    <topicref href="langRef/attributes/thekeysattribute.dita" navtitle="keys attribute"/>
+    <topicref keyref="attributes-keyref" navtitle="keyref attribute"/>
+    <topicref keyref="attributes-keys" navtitle="keys attribute"/>
    </relcell>
    <relcell>
     <topicref href="archSpec/base/key-based-addressing.dita" navtitle="Key-based addressing"/>
@@ -257,7 +257,7 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref href="langRef/attributes/commonMapAttributes.dita"/>
+   <topicref keyref="attributes-commonMap"/>
    </relcell>
    <relcell>
     <topicref href="archSpec/base/cascading-in-a-ditamap.dita"/>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -65,28 +65,28 @@
                                         />, it has no defined purpose for this element.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
 element: <xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/>, <xref
-href="../langRef/attributes/universalAttributes.dita"/>, and <xref
+keyref="attributes-universal"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
 <xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
-href="../langRef/attributes/universalAttributes.dita"/>.</p><p id="only-universal">The following attributes are available
+keyref="attributes-universal"/>.</p><p id="only-universal">The following attributes are available
                                 on this element: <xref
-                                        href="../langRef/attributes/universalAttributes.dita"
+                                        keyref="attributes-universal"
                                 />.</p><p id="universal-outputclass-name">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, and <xref
+keyref="attributes-universal"/>, and <xref
 href="../langRef/attributes/dataElementAttributes.dita#data-element-atts/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> and <xref
+keyref="attributes-universal"/> and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry">The following attributes are available on this element:
-<xref href="../langRef/attributes/universalAttributes.dita"/> and <xref
+<xref keyref="attributes-universal"/> and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/specentry"/>.</p><p id="universal-spectitle">The following attributes are available on this element:
-<xref href="../langRef/attributes/universalAttributes.dita"/> and <xref
+<xref keyref="attributes-universal"/> and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="universal-spectitle-compact">The following attributes are available on this
-element: <xref href="../langRef/attributes/universalAttributes.dita"/>, <xref
+element: <xref keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><!--Used in <topic>, <concept>, etc.--><sectiondiv
                                 id="topic-attributes">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>id</xmlatt>, given below) and <xref
 href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>.</p>
                                 <dl>
@@ -105,10 +105,10 @@ href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>.</p>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><p id="topic-body">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (without the Metadata attribute group) and
+keyref="attributes-universal"/> (without the Metadata attribute group) and
 <xmlatt>base</xmlatt> from the <xref href="../langRef/attributes/metadataAttributes.dita"/>.</p><sectiondiv id="note-attributes">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and the
 attributes defined below.</p>
                                 <dl>
@@ -140,18 +140,18 @@ attributes defined below.</p>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><p id="fig-attributes">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/displayAttributes.dita"/>, and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="pre-attributes">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/displayAttributes.dita"/>, <xref
 href="../langRef/attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> and the attribute defined below.</p>
+keyref="attributes-universal"/> and the attribute defined below.</p>
 <dl>
 <dlentry id="callout">
 <dt><xmlatt>callout</xmlatt></dt>
@@ -172,7 +172,7 @@ element. The default value is the empty string "".</dd>
 </dl>
 </sectiondiv><sectiondiv id="author-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
+                                                keyref="attributes-universal"
                                         />, <xref
                                                 href="../langRef/attributes/linkRelationshipAttributes.dita"
                                         /> (with a narrowed definition for <xmlatt>type</xmlatt>,
@@ -212,7 +212,7 @@ element. The default value is the empty string "".</dd>
                                 </dl>
                         </sectiondiv><sectiondiv id="standard-topicref-attributes">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
 <xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
@@ -236,7 +236,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
@@ -263,7 +263,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-topicrefs">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
@@ -277,7 +277,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-frontbackmatter">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and
 <xmlatt>query</xmlatt> from <xref href="../langRef/attributes/topicrefElementAttributes.dita"/>.
@@ -376,7 +376,7 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="scheme-HAS-elements">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xmlatt>processing-role</xmlatt> from <xref
 href="../langRef/attributes/commonMapAttributes.dita"/>, <xmlatt>navtitle</xmlatt> from <xref
@@ -391,7 +391,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="learningdomain-basic-topicref">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/>, <xref
+keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
 <xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
@@ -405,7 +405,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="standard-topicmeta-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
+                                                keyref="attributes-universal"
                                         /> and the attribute defined below.</p>
                                 <dl>
                                         <dlentry>
@@ -426,7 +426,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>, also <coords> equivalents in L&T domain-->
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>translate</xmlatt>, given below), and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -461,7 +461,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 </dl>
                         </sectiondiv><sectiondiv id="universal-outputclass-required-id">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>id</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
@@ -515,7 +515,7 @@ href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definit
                                 inside is also used by fragref.</p><sectiondiv
                                 id="syntaxelement-optreq">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry id="importance-optreq">
@@ -543,7 +543,7 @@ href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definit
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
@@ -577,7 +577,7 @@ href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definit
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below) and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -747,7 +747,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         <section id="section-4"><title>Attributes used on the <xmlelement>map</xmlelement> element</title><sectiondiv
                                         id="all-map-attributes">
                                         <p id="map-attributes-common">The following attributes are
-available on this element: <xref href="../langRef/attributes/universalAttributes.dita"/> (with a
+available on this element: <xref keyref="attributes-universal"/> (with a
 narrowed definition of <xmlatt>id</xmlatt>, given below), <xref
 href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
 href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes defined
@@ -782,7 +782,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                 <section id="section-5">
                         <title>Common for simpletable and at least one specialization</title>
                         <p id="simpletable-attributes">The following attributes are available on
-this element: <xref href="../langRef/attributes/universalAttributes.dita"/>, <xref
+this element: <xref keyref="attributes-universal"/>, <xref
 href="../langRef/attributes/displayAttributes.dita"/>, <xref
 href="../langRef/attributes/simpletableAttributes.dita"/>, and <xref
 href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
@@ -790,7 +790,7 @@ href="../langRef/attributes/specializationAttributes.dita#specialization-atts/sp
                 <section id="section-6"><title>Attributes for specialized reltables (drop <xmlatt>title</xmlatt> from base
                                 reltable)</title><sectiondiv id="reltable-minus-title">
                                 <p>The following attributes are available on this element: <xref
-                                                href="../langRef/attributes/universalAttributes.dita"
+                                                keyref="attributes-universal"
                                         /> and <xref
                                                 href="../langRef/attributes/commonMapAttributes.dita"
                                         /> (with a narrowed definition of <xmlatt>toc</xmlatt>,
@@ -809,7 +809,7 @@ href="../langRef/attributes/specializationAttributes.dita#specialization-atts/sp
                 <section id="section-7"><title>Common to step and substep</title><p>Universal atts, with narrowed
                                 definition of <xmlatt>importance</xmlatt>.</p><sectiondiv id="step-and-substep">
                                 <p>The following attributes are available on this element: <xref
-href="../langRef/attributes/universalAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -61,34 +61,34 @@
                                         id="locktitle-no-purpose">Although
                                                 <xmlatt>locktitle</xmlatt> is available as part of
                                                 <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
+                                                keyref="attributes-commonMap"
                                         />, it has no defined purpose for this element.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
-element: <xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/>, <xref
+                                        element: <xref keyref="attributes-dataElement"/>, <xref
+keyref="attributes-linkRelationship"/>, <xref
 keyref="attributes-universal"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
-<xref href="../langRef/attributes/dataElementAttributes.dita"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
+<xref keyref="attributes-dataElement"/>, <xref
+keyref="attributes-linkRelationship"/>, and <xref
 keyref="attributes-universal"/>.</p><p id="only-universal">The following attributes are available
                                 on this element: <xref
                                         keyref="attributes-universal"
                                 />.</p><p id="universal-outputclass-name">The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, and <xref
-href="../langRef/attributes/dataElementAttributes.dita#data-element-atts/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
+keyref="attributes-dataElement/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
 keyref="attributes-universal"/> and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry">The following attributes are available on this element:
 <xref keyref="attributes-universal"/> and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/specentry"/>.</p><p id="universal-spectitle">The following attributes are available on this element:
+keyref="attributes-specialization/specentry"/>.</p><p id="universal-spectitle">The following attributes are available on this element:
 <xref keyref="attributes-universal"/> and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="universal-spectitle-compact">The following attributes are available on this
+keyref="attributes-specialization/spectitle"/>.</p><p id="universal-spectitle-compact">The following attributes are available on this
 element: <xref keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><!--Used in <topic>, <concept>, etc.--><sectiondiv
+keyref="attributes-common/compact"/>, and <xref
+keyref="attributes-specialization/spectitle"/>.</p><!--Used in <topic>, <concept>, etc.--><sectiondiv
                                 id="topic-attributes">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>id</xmlatt>, given below) and <xref
-href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>.</p>
+keyref="attributes-architectural"/>.</p>
                                 <dl>
                                         <dlentry id="topic-id">
                                                 <dt><xmlatt>id</xmlatt>
@@ -106,10 +106,10 @@ href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>.</p>
                                 </dl>
                         </sectiondiv><p id="topic-body">The following attributes are available on this element: <xref
 keyref="attributes-universal"/> (without the Metadata attribute group) and
-<xmlatt>base</xmlatt> from the <xref href="../langRef/attributes/metadataAttributes.dita"/>.</p><sectiondiv id="note-attributes">
+<xmlatt>base</xmlatt> from the <xref keyref="attributes-metadata"/>.</p><sectiondiv id="note-attributes">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and the
+keyref="attributes-specialization/spectitle"/>, and the
 attributes defined below.</p>
                                 <dl>
                                         <dlentry>
@@ -141,14 +141,14 @@ attributes defined below.</p>
                                 </dl>
                         </sectiondiv><p id="fig-attributes">The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/displayAttributes.dita"/>, and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="pre-attributes">The following attributes are available on this element: <xref
+keyref="attributes-display"/>, and <xref
+keyref="attributes-specialization/spectitle"/>.</p><p id="pre-attributes">The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/displayAttributes.dita"/>, <xref
-href="../langRef/attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
+keyref="attributes-display"/>, <xref
+keyref="attributes-common/xmlspace"/>, and <xref
+keyref="attributes-specialization/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/>, and <xref
+keyref="attributes-linkRelationship"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/> and the attribute defined below.</p>
@@ -174,7 +174,7 @@ element. The default value is the empty string "".</dd>
                                 <p>The following attributes are available on this element: <xref
                                                 keyref="attributes-universal"
                                         />, <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
+                                                keyref="attributes-linkRelationship"
                                         /> (with a narrowed definition for <xmlatt>type</xmlatt>,
                                         given below), and <xref
                                                 href="../langRef/attributes/thekeyrefattribute.dita"
@@ -213,9 +213,9 @@ element. The default value is the empty string "".</dd>
                         </sectiondiv><sectiondiv id="standard-topicref-attributes">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
-<xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+keyref="attributes-linkRelationship"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
+<xref keyref="attributes-topicrefElement"/>, <xref
 href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -237,10 +237,10 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+keyref="attributes-linkRelationship"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
-href="../langRef/attributes/topicrefElementAttributes.dita"/>, and <xref
+keyref="attributes-topicrefElement"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-for-booklist">
@@ -264,10 +264,10 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         </sectiondiv><sectiondiv id="bookmap-topicrefs">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
+keyref="attributes-linkRelationship"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
-href="../langRef/attributes/topicrefElementAttributes.dita"/>, and <xref
+keyref="attributes-topicrefElement"/>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
@@ -278,11 +278,11 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         </sectiondiv><sectiondiv id="bookmap-frontbackmatter">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
+keyref="attributes-commonMap"/>, <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and
-<xmlatt>query</xmlatt> from <xref href="../langRef/attributes/topicrefElementAttributes.dita"/>.
+<xmlatt>query</xmlatt> from <xref keyref="attributes-topicrefElement"/>.
 This element also uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>
-from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"/>.</p>
+from <xref keyref="attributes-linkRelationship"/>.</p>
                         </sectiondiv><sectiondiv>
                                 <p>Define the href value common to map references.</p>
                                 <dl>
@@ -293,7 +293,7 @@ from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"/>.</p>
                                                   because the purpose of the element is to reference
                                                   a ditamap document. Otherwise, the attribute is
                                                   the same as described in <xref
-                                                  href="../langRef/attributes/linkRelationshipAttributes.dita"
+                                                  keyref="attributes-linkRelationship"
                                                   />.</dd>
                                         </dlentry>
                                 </dl>
@@ -309,7 +309,7 @@ from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"/>.</p>
                                                   value will cascade from the closest ancestor. On
                                                   this element the default value for
                                                   <xmlatt>toc</xmlatt> is "no". See <xref
-                                                  href="../langRef/attributes/commonMapAttributes.dita"
+                                                  keyref="attributes-commonMap"
                                                   /> for a complete definition of
                                                   <xmlatt>toc</xmlatt>.</dd>
                                         </dlentry>
@@ -370,17 +370,17 @@ of map.-->
                                                   <xmlatt>processing-role</xmlatt> is
                                                   "resource-only". Otherwise, the definition matches
                                                   the one found in <xref
-                                                  href="../langRef/attributes/commonMapAttributes.dita"
+                                                  keyref="attributes-commonMap"
                                                   />.</dd>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="scheme-HAS-elements">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xmlatt>processing-role</xmlatt> from <xref
-href="../langRef/attributes/commonMapAttributes.dita"/>, <xmlatt>navtitle</xmlatt> from <xref
-href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+keyref="attributes-commonMap"/>, <xmlatt>navtitle</xmlatt> from <xref
+keyref="attributes-topicrefElement"/>, <xref
 href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -392,9 +392,9 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                         </sectiondiv><sectiondiv id="learningdomain-basic-topicref">
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-<xmlatt>href</xmlatt>, given below), <xref href="../langRef/attributes/commonMapAttributes.dita"/>,
-<xref href="../langRef/attributes/topicrefElementAttributes.dita"/>, <xref
+keyref="attributes-linkRelationship"/> (with a narrowed definition of
+<xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
+<xref keyref="attributes-topicrefElement"/>, <xref
 href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
 href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -502,7 +502,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                 <dlentry>
                                         <dt><xmlatt>collection-type</xmlatt></dt>
                                         <dd>See <xref
-                                                  href="../langRef/attributes/commonMapAttributes.dita#topicref-atts/collection-type"
+                                        keyref="attributes-commonMap/collection-type"
                                                 /> for a full definition and list of supported
                                                 values. </dd>
                                 </dlentry>
@@ -749,10 +749,10 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                         <p id="map-attributes-common">The following attributes are
 available on this element: <xref keyref="attributes-universal"/> (with a
 narrowed definition of <xmlatt>id</xmlatt>, given below), <xref
-href="../langRef/attributes/commonMapAttributes.dita"/>, <xref
-href="../langRef/attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes defined
+keyref="attributes-commonMap"/>, <xref
+keyref="attributes-architectural"/>, and the attributes defined
 below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-<xmlatt>format</xmlatt> from <xref href="../langRef/attributes/linkRelationshipAttributes.dita"
+<xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
 />.</p>
                                         <dl>
                                                 <dlentry id="map-attribute-id">
@@ -783,21 +783,21 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                         <title>Common for simpletable and at least one specialization</title>
                         <p id="simpletable-attributes">The following attributes are available on
 this element: <xref keyref="attributes-universal"/>, <xref
-href="../langRef/attributes/displayAttributes.dita"/>, <xref
-href="../langRef/attributes/simpletableAttributes.dita"/>, and <xref
-href="../langRef/attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
+keyref="attributes-display"/>, <xref
+keyref="attributes-simpletableElement"/>, and <xref
+keyref="attributes-specialization/spectitle"/>.</p>
                 </section>
                 <section id="section-6"><title>Attributes for specialized reltables (drop <xmlatt>title</xmlatt> from base
                                 reltable)</title><sectiondiv id="reltable-minus-title">
                                 <p>The following attributes are available on this element: <xref
                                                 keyref="attributes-universal"
                                         /> and <xref
-                                                href="../langRef/attributes/commonMapAttributes.dita"
+                                                keyref="attributes-commonMap"
                                         /> (with a narrowed definition of <xmlatt>toc</xmlatt>,
                                         given below). This element also uses <xmlatt>type</xmlatt>,
                                                 <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt>
                                         from <xref
-                                                href="../langRef/attributes/linkRelationshipAttributes.dita"
+                                                keyref="attributes-linkRelationship"
                                         />.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/toc-default-no">

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -14,7 +14,7 @@
                                 <dlentry id="ditauseconref">
                                         <dt>-dita-use-conref-target </dt>
                                         <dd>See <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                 /> for more information. </dd>
                                 </dlentry>
                         </dl><p>Common phrase for filter/flatting attributes: <ph
@@ -66,7 +66,7 @@
                                         element: <xref keyref="attributes-dataElement"/>, <xref
 keyref="attributes-linkRelationship"/>, <xref
 keyref="attributes-universal"/>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
 <xref keyref="attributes-dataElement"/>, <xref
 keyref="attributes-linkRelationship"/>, and <xref
 keyref="attributes-universal"/>.</p><p id="only-universal">The following attributes are available
@@ -76,7 +76,7 @@ keyref="attributes-universal"/>.</p><p id="only-universal">The following attribu
 keyref="attributes-universal"/>, and <xref
 keyref="attributes-dataElement/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
 keyref="attributes-universal"/> and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry">The following attributes are available on this element:
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry">The following attributes are available on this element:
 <xref keyref="attributes-universal"/> and <xref
 keyref="attributes-specialization/specentry"/>.</p><p id="universal-spectitle">The following attributes are available on this element:
 <xref keyref="attributes-universal"/> and <xref
@@ -120,13 +120,13 @@ attributes defined below.</p>
                                                   draw the reader&apos;s attention to it. <ph
                                                   conref="#conref-attribute/nonstandard-type"/> See
                                                   <xref
-                                                  href="../langRef/attributes/thetypeattribute.dita"
+                                                  keyref="attributes-type"
                                                   /> for detailed information on supported values
                                                   and processing implications. Available values are
                                                   note, tip, fastpath, restriction, important,
                                                   remember, attention, caution, notice, danger,
                                                   warning, <ph>trouble</ph>, other, and <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita#usingthe-dita-use-conref-targetvalue"
+                                                  keyref="attributes-useconreftarget"
                                                   >-dita-use-​conref-​target</xref>. </dd>
                                         </dlentry>
                                         <dlentry>
@@ -149,7 +149,7 @@ keyref="attributes-common/xmlspace"/>, and <xref
 keyref="attributes-specialization/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
 keyref="attributes-linkRelationship"/>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/> and the attribute defined below.</p>
 <dl>
@@ -177,13 +177,13 @@ element. The default value is the empty string "".</dd>
                                                 keyref="attributes-linkRelationship"
                                         /> (with a narrowed definition for <xmlatt>type</xmlatt>,
                                         given below), and <xref
-                                                href="../langRef/attributes/thekeyrefattribute.dita"
+                                                keyref="attributes-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="type">
                                                 <dt><xmlatt>type</xmlatt></dt>
                                                 <dd>Describes the target of a reference. See <xref
-                                                  href="../langRef/attributes/thetypeattribute.dita"
+                                                keyref="attributes-type"
                                                   /> for detailed information on supported values
                                                   and processing implications. <ph
                                                   conref="#conref-attribute/nonstandard-type"/>
@@ -216,14 +216,14 @@ keyref="attributes-universal"/>, <xref
 keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xref keyref="attributes-topicrefElement"/>, <xref
-href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-on-topicref">
                                                 <dt><xmlatt>href</xmlatt></dt>
                                                 <dd>A pointer to the resource represented by the
                                                   <xmlelement>topicref</xmlelement>. See <xref
-                                                  href="../langRef/attributes/thehrefattribute.dita"
+                                                  keyref="attributes-href"
                                                   /> for detailed information on supported values
                                                   and processing implications. References to DITA
                                                   content cannot be below the topic level: that is,
@@ -241,13 +241,13 @@ keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
 keyref="attributes-topicrefElement"/>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-for-booklist">
                                                 <dt><xmlatt>href</xmlatt></dt>
                                                 <dd>References a manual listing for the current
                                                   element. See <xref
-                                                  href="../langRef/attributes/thehrefattribute.dita"
+                                                  keyref="attributes-href"
                                                   /> for detailed information on supported values
                                                   and processing implications. If no
                                                   <xmlatt>href</xmlatt> is specified, processors <ph
@@ -268,7 +268,7 @@ keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xmlatt>navtitle</xmlatt> and <xmlatt>copy-to</xmlatt> from <xref
 keyref="attributes-topicrefElement"/>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
                                                 <dt/>
@@ -279,7 +279,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref
 keyref="attributes-commonMap"/>, <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and
 <xmlatt>query</xmlatt> from <xref keyref="attributes-topicrefElement"/>.
 This element also uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>
 from <xref keyref="attributes-linkRelationship"/>.</p>
@@ -381,8 +381,8 @@ keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xmlatt>processing-role</xmlatt> from <xref
 keyref="attributes-commonMap"/>, <xmlatt>navtitle</xmlatt> from <xref
 keyref="attributes-topicrefElement"/>, <xref
-href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
                                                 <dt/>
@@ -395,8 +395,8 @@ keyref="attributes-universal"/>, <xref
 keyref="attributes-linkRelationship"/> (with a narrowed definition of
 <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"/>,
 <xref keyref="attributes-topicrefElement"/>, <xref
-href="../langRef/attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry conref="#conref-attribute/href-on-topicref">
                                                 <dt/>
@@ -418,7 +418,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                                   <xmlelement>topicmeta</xmlelement> element is set
                                                   to "no". Allowable values are "yes", "no", and
                                                   <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                   />.</p>
                                                 </dd>
                                         </dlentry>
@@ -428,7 +428,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>translate</xmlatt>, given below), and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="translate-NO">
                                                 <dt><xmlatt>translate</xmlatt></dt>
@@ -509,7 +509,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                         </dl></section>
                 <section id="section-2"><title>Reusable groups for syntax diagram elements</title><p>These tend to
                                 be similar, with tweaks in <xmlatt>importance</xmlatt>, or adding/removing <xref
-                                        href="../langRef/attributes/thekeyrefattribute.dita"
+                                        keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p><p>"optreq"
                                 sectiondiv is used by delim, repsep. The <xmlatt>importance</xmlatt> definition
                                 inside is also used by fragref.</p><sectiondiv
@@ -579,7 +579,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                 <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below) and <xref
-href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry>
                                                 <dt><xmlatt>importance</xmlatt></dt>
@@ -622,7 +622,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                 <dlentry id="image-href">
                                         <dt><xmlatt>href</xmlatt></dt>
                                         <dd>Provides a reference to the image. See <xref
-                                                  href="../langRef/attributes/thehrefattribute.dita"
+                                                  keyref="attributes-href"
                                                 /> for detailed information on supported values and
                                                 processing implications.</dd>
                                 </dlentry>
@@ -632,9 +632,9 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                                 closeness of the relationship between the current
                                                 document and the target resource. Allowable values
                                                 are local, peer, external, and <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                   >-dita-use-conref-target</xref>. See <xref
-                                                  href="../langRef/attributes/thescopeattribute.dita"/> for more
+                                                  keyref="attributes-scope"/> for more
                                                 information on values.</dd>
                                 </dlentry>
                                 <dlentry id="image-height">
@@ -695,7 +695,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                         <dd>Allow an image to be scaled up or down to fit within
                                                 available space. Allowable values are yes, no, and
                                                   <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                   >-dita-use-conref-target</xref>. If, for a given
                                                 image, any one of <xmlatt>height</xmlatt>,
                                                   <xmlatt>width</xmlatt>, or <xmlatt>scale</xmlatt>
@@ -721,7 +721,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                                 separated from the surrounding text. The default is
                                                 inline. Allowable values are: inline, break, or and
                                                   <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                   >-dita-use-conref-target</xref>.</dd>
                                 </dlentry>
                                 <dlentry id="image-longdescref">
@@ -731,7 +731,7 @@ href="../langRef/attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xr
                                         <dd>A reference to a textual description of the graphic or
                                                 object. This attribute supports creating accessible
                                                 content. See <xref
-                                                  href="../langRef/attributes/thehrefattribute.dita"
+                                                  keyref="attributes-href"
                                                 /> for detailed information on supported values and
                                                 processing implications. <ph>For examples of how
                                                   this attribute is used in output, see this topic
@@ -821,7 +821,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                                   >might</ph> highlight steps
                                                   that are optional or required. Allowed values are
                                                   "optional", "required", or <xref
-                                                  href="../langRef/attributes/ditauseconreftarget.dita"
+                                                  keyref="attributes-useconreftarget"
                                                   >-dita-use-conref-target</xref>.</dd>
                                         </dlentry>
                                 </dl>
@@ -893,7 +893,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                                 <dd>Provides a URI reference to the image file,
                                                 using the same syntax as the <xmlatt>href</xmlatt>
                                                 attribute. See <xref
-                                                  href="../langRef/attributes/thehrefattribute.dita"
+                                                  keyref="attributes-href"
                                                 /> for information on supported values and
                                                 processing implications.</dd>
                                         </dlentry>

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -172,7 +172,7 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
                                 >Beginning with DITA 1.3, the <xmlatt>print</xmlatt> attribute is
                                 deprecated. It is replaced with a conditional processing attribute:
                                         <xmlatt>deliveryTarget</xmlatt>. See <xref
-                                        href="../langRef/attributes/metadataAttributes.dita#select-atts/deliveryTarget"
+                                        keyref="attributes-metadata/deliveryTarget"
                                                 ><xmlatt>deliveryTarget</xmlatt></xref> for more
                                 details.</note>
                         <note id="mapref-with-child-elements">If a <xmlelement>topicref</xmlelement>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -24,7 +24,7 @@
      <dd><indexterm>keyref
               attribute</indexterm><indexterm>Attributes<indexterm>keyref</indexterm></indexterm><ph
               id="keyrefDescription"><xmlatt>keyref</xmlatt> provides a redirectable reference based
-              on a key defined within a map. See <xref href="thekeyrefattribute.dita"/> for
+              on a key defined within a map. See <xref keyref="attributes-keyref"/> for
               information on using this attribute.
               <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></ph><?datatype CDATA?><?default #IMPLIED?></dd>
     </dlentry>

--- a/specification/langRef/attributes/commonMapAttributes.dita
+++ b/specification/langRef/attributes/commonMapAttributes.dita
@@ -157,7 +157,7 @@
        </dlentry>
        <dlentry>
         <dt>-dita-use-conref-target </dt>
-        <dd>See <xref href="ditauseconreftarget.dita"/> for more information. </dd>
+        <dd>See <xref keyref="attributes-useconreftarget"/> for more information. </dd>
        </dlentry>
       </dl></dd>
     </dlentry>
@@ -177,7 +177,7 @@
         <dd> </dd>
        </dlentry>
        <dlentry>
-        <dt><xref href="ditauseconreftarget.dita">-dita-use-conref-target</xref>
+        <dt><xref keyref="attributes-useconreftarget">-dita-use-conref-target</xref>
         </dt>
         <dd> </dd>
        </dlentry>
@@ -195,7 +195,7 @@
     <dlentry id="keyscope" >
      <dt><xmlatt>keyscope</xmlatt></dt>
      <dd>Specifies that the element marks the boundaries of a key scope. See <xref
-       href="the-key-scope-attribute.dita"/> for details on how to use the <xmlatt>keyscope</xmlatt>
+       keyref="attributes-keyscope"/> for details on how to use the <xmlatt>keyscope</xmlatt>
       attribute.</dd>
     </dlentry>
    </dl>

--- a/specification/langRef/attributes/displayAttributes.dita
+++ b/specification/langRef/attributes/displayAttributes.dita
@@ -101,7 +101,7 @@
        scale property. If not specifically scaled, such an <xmlelement>image</xmlelement> is
        unchanged by the scale property of its parent <xmlelement>table</xmlelement> or
         <xmlelement>fig</xmlelement>. </p><p>Allowable values are 50, 60, 70, 80, 90, 100, 110, 120,
-       140, 160, 180, 200, and <xref href="ditauseconreftarget.dita">-dita-use-conref-target</xref>.
+       140, 160, 180, 200, and <xref keyref="attributes-useconreftarget">-dita-use-conref-target</xref>.
        Some DITA processors or output formats <ph >might</ph> not be able to
        support all values. </p></dd>
     </dlentry>

--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -4,38 +4,38 @@
 <map id="ditaref-commonatts" xml:lang="en-us" collection-type="sequence">
  <title>Common attribute definitions used by each version of the guide</title>
  <topicref href="attributes.dita" collection-type="sequence">
-  <topicref href="universalAttributes.dita">
-   <topicref href="idAttributes.dita"/>
-   <topicref href="metadataAttributes.dita"/>
-   <topicref href="localizationAttributes.dita"/>
-  </topicref>
-  <topicref href="architecturalAttributes.dita"/>
-  <topicref href="commonMapAttributes.dita"/>
-  <topicref href="calsTableAttributes.dita"/>
-  <topicref href="dataElementAttributes.dita"/>
-  <topicref href="dateAttributes.dita"/>
-  <topicref href="displayAttributes.dita"/>
-  <topicref href="linkRelationshipAttributes.dita"/>
-  <topicref href="commonAttributes.dita"/>
-  <topicref href="simpletableAttributes.dita"/>
-  <topicref href="specializationAttributes.dita"/>
-  <topicref href="topicrefElementAttributes.dita"/>
+  <topicref href="universalAttributes.dita" keys="attributes-universal">
+<topicref href="idAttributes.dita" keys="attributes-id"/>
+<topicref href="metadataAttributes.dita" keys="attributes-metadata"/>
+<topicref href="localizationAttributes.dita" keys="attributes-localization"/>
+</topicref>
+ <topicref href="architecturalAttributes.dita" keys="attributes-architectural"/>
+ <topicref href="commonMapAttributes.dita" keys="attributes-commonMap"/>
+ <topicref href="calsTableAttributes.dita" keys="attributes-calsTable"/>
+ <topicref href="dataElementAttributes.dita" keys="attributes-dataElement"/>
+ <topicref href="dateAttributes.dita" keys="attributes-date"/>
+ <topicref href="displayAttributes.dita" keys="attributes-display"/>
+ <topicref href="linkRelationshipAttributes.dita" keys="attributes-linkRelationship"/>
+ <topicref href="commonAttributes.dita" keys="attributes-common"/>
+ <topicref href="simpletableAttributes.dita" keys="attributes-simpletableElement"/>
+ <topicref href="specializationAttributes.dita" keys="attributes-specialization"/>
+ <topicref href="topicrefElementAttributes.dita" keys="attributes-topicrefElement"/>
   <topicref href="complexattributedefinitions.dita" navtitle="Complex attribute definitions">
-   <topicref href="thehrefattribute.dita" navtitle="The href attribute"/>
-   <topicref href="thekeysattribute.dita"/>
-   <topicref href="thekeyrefattribute.dita"/>
-   <topicref href="the-key-scope-attribute.dita"/>
+  <topicref href="thehrefattribute.dita" navtitle="The href attribute" keys="attributes-href"/>
+  <topicref href="thekeysattribute.dita" keys="attributes-keys"/>
+  <topicref href="thekeyrefattribute.dita" keys="attributes-keyref"/>
+  <topicref href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
    <topicref href="theconrefattribute.dita" navtitle="The conref attribute"
-    collection-type="sequence">
-    <topicref href="ditauseconreftarget.dita" navtitle="Using the -dita-use-conref-target value"/>
+   collection-type="sequence" keys="attributes-conref">
+   <topicref href="ditauseconreftarget.dita" navtitle="Using the -dita-use-conref-target value" keys="attributes-useconreftarget"/>
    </topicref>
-   <topicref href="theconactionattribute.dita" navtitle="The conaction attribute"/>
-   <topicref href="theconrefendattribute.dita" navtitle="The conrefend attribute"/>
-   <topicref href="theconkeyrefattribute.dita" navtitle="The conkeyref attribute"/>
-   <topicref href="thetypeattribute.dita" navtitle="The type attribute"/>
-   <topicref href="theformatattribute.dita" navtitle="The format attribute"/>
-   <topicref href="thescopeattribute.dita" navtitle="The scope attribute"/>
-   <topicref href="theroleattribute.dita" navtitle="The role attribute"/>
+  <topicref href="theconactionattribute.dita" navtitle="The conaction attribute" keys="attributes-conaction"/>
+  <topicref href="theconrefendattribute.dita" navtitle="The conrefend attribute" keys="attributes-conrefend"/>
+  <topicref href="theconkeyrefattribute.dita" navtitle="The conkeyref attribute" keys="attributes-conkeyref"/>
+  <topicref href="thetypeattribute.dita" navtitle="The type attribute" keys="attributes-type"/>
+  <topicref href="theformatattribute.dita" navtitle="The format attribute" keys="attributes-format"/>
+  <topicref href="thescopeattribute.dita" navtitle="The scope attribute" keys="attributes-scope"/>
+  <topicref href="theroleattribute.dita" navtitle="The role attribute" keys="attributes-role"/>
   </topicref>
  </topicref>
  <?Pub Caret -1?>

--- a/specification/langRef/attributes/idAttributes.dita
+++ b/specification/langRef/attributes/idAttributes.dita
@@ -33,7 +33,7 @@
      <dd><indexterm>conref
               attribute</indexterm><indexterm>Attributes<indexterm>conref</indexterm></indexterm>This
             attribute is used to reference an ID on content that can be reused. See <xref
-              href="theconrefattribute.dita"/> for examples and details about the syntax.
+              keyref="attributes-conref"/> for examples and details about the syntax.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
     </dlentry>
     <dlentry id="conrefend">
@@ -42,7 +42,7 @@
                 attribute</indexterm><indexterm>Attributes<indexterm>conrefend</indexterm></indexterm>The
               <xmlatt>conrefend</xmlatt> attribute is used when reusing a range of elements through
               <xmlatt>conref</xmlatt>. The syntax is the same as for the <xmlatt>conref</xmlatt>
-            attribute; see <xref href="theconrefendattribute.dita"/> for examples.
+              attribute; see <xref keyref="attributes-conrefend"/> for examples.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
     </dlentry>
     <dlentry id="conaction">
@@ -51,7 +51,7 @@
         attribute</indexterm><indexterm>Attributes<indexterm>conaction</indexterm></indexterm>This
       attribute enables users to push content into a new location. Allowable values are mark,
       pushafter, pushbefore, pushreplace, and -dita-use-conref-target. See <xref
-       href="theconactionattribute.dita"/> for examples and details about the syntax.</dd>
+       keyref="attributes-conaction"/> for examples and details about the syntax.</dd>
     </dlentry>
     <dlentry id="conkeyref">
      <dt><xmlatt>conkeyref</xmlatt></dt>
@@ -59,7 +59,7 @@
                 attribute</indexterm><indexterm>Attributes<indexterm>conkeyref</indexterm></indexterm>Allows
             the conref feature to operate using a key instead of a URI.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
-            See <xref href="theconkeyrefattribute.dita"/> for more details about the syntax and
+            See <xref keyref="attributes-conkeyref"/> for more details about the syntax and
             behaviors.</dd>
     </dlentry>
    </dl>

--- a/specification/langRef/attributes/linkRelationshipAttributes.dita
+++ b/specification/langRef/attributes/linkRelationshipAttributes.dita
@@ -19,7 +19,7 @@
           <dt><xmlatt>href</xmlatt></dt>
           <dd><indexterm>href
               attribute</indexterm><indexterm>Attributes<indexterm>href</indexterm></indexterm>Provides
-            a reference to a resource. See <xref href="thehrefattribute.dita"/> for detailed
+            a reference to a resource. See <xref keyref="attributes-href"/> for detailed
             information on supported values and processing implications..
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
         </dlentry>
@@ -28,7 +28,7 @@
      <dd><indexterm>format
               attribute</indexterm><indexterm>Attributes<indexterm>format</indexterm></indexterm>The
               <xmlatt>format</xmlatt> attribute identifies the format of the resource being
-            referenced. See <xref href="theformatattribute.dita"/> for details on supported values.
+     referenced. See <xref keyref="attributes-format"/> for details on supported values.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
     </dlentry>
     <dlentry id="scope">
@@ -37,14 +37,14 @@
               attribute</indexterm><indexterm>Attributes<indexterm>scope</indexterm></indexterm>The
               <xmlatt>scope</xmlatt> attribute identifies the closeness of the relationship between
             the current document and the target resource. Allowable values are local, peer,
-            external, and -dita-use-conref-target; see <xref href="thescopeattribute.dita"/> for
+            external, and -dita-use-conref-target; see <xref keyref="attributes-scope"/> for
             more information on these values.</dd>
     </dlentry>
     <dlentry id="type">
      <dt><xmlatt>type</xmlatt></dt>
      <dd><indexterm>type
               attribute</indexterm><indexterm>Attributes<indexterm>type</indexterm></indexterm>Describes
-            the target of a reference. See <xref href="thetypeattribute.dita"/> for detailed
+     the target of a reference. See <xref keyref="attributes-type"/> for detailed
             information on supported values and processing implications.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
     </dlentry>

--- a/specification/langRef/attributes/theconkeyrefattribute.dita
+++ b/specification/langRef/attributes/theconkeyrefattribute.dita
@@ -28,7 +28,7 @@
           >cannot</ph> include a key. Instead the map or topic element
         addressed by the key name component of the <xmlatt>conkeyref</xmlatt> is used in place of
         whatever map or topic element is addressed by the <xmlatt>conrefend</xmlatt> attribute. See
-          <xref href="theconrefendattribute.dita#theconrefendattribute/conkeyref"/> for more
+        <xref keyref="attributes-conrefend/conkeyref"/> for more
         information and for examples of this behavior.</p>
     </section>
 </refbody>

--- a/specification/langRef/attributes/thescopeattribute.dita
+++ b/specification/langRef/attributes/thescopeattribute.dita
@@ -16,7 +16,7 @@
                     those with <xmlatt>scope</xmlatt> set to "external".</li>
 <li>Set <xmlatt>scope</xmlatt> to "external" when the resource is not part of the current
                     information set and should open in a new browser window.</li>
-<li>See <xref href="ditauseconreftarget.dita"></xref> for more information
+<li>See <xref keyref="attributes-useconreftarget"></xref> for more information
 on -dita-use-conref-target.</li>
 </ul><p ><ph
                     conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/> The

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -25,7 +25,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below).</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/anchorid.dita
+++ b/specification/langRef/base/anchorid.dita
@@ -171,7 +171,7 @@ that id, because processors will match on the topic's id first.</li>
 <example conref="anchorkey.dita#anchorkey/example" id="example2" otherprops="examples"/>
 <section id="attributes"><title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below) and <xref href="../attributes/thekeyrefattribute.dita"
             ><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/anchorid.dita
+++ b/specification/langRef/base/anchorid.dita
@@ -172,7 +172,7 @@ that id, because processors will match on the topic's id first.</li>
 <section id="attributes"><title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below) and <xref href="../attributes/thekeyrefattribute.dita"
+          <xmlatt>id</xmlatt>, given below) and <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/anchorkey.dita
+++ b/specification/langRef/base/anchorkey.dita
@@ -32,7 +32,7 @@ topic/keyword delay-d/anchorkey </p></section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attribute
+          keyref="attributes-universal"/> and the attribute
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -57,11 +57,11 @@
             <sectiondiv id="standard-topicref-attributes">
                 <p>The following attributes are available on this element: <xref
                         keyref="attributes-universal"/>, <xref
-                        href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed
+                        keyref="attributes-linkRelationship"/> (with narrowed
                     definitions of <xmlatt>href</xmlatt>, <xmlatt>type</xmlatt>, and
                         <xmlatt>format</xmlatt>, all given below), <xref
-                        href="../attributes/commonMapAttributes.dita"/>, <xref
-                        href="../attributes/topicrefElementAttributes.dita"/>, <xref
+                        keyref="attributes-commonMap"/>, <xref
+                        keyref="attributes-topicrefElement"/>, <xref
                         href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and
                         <xref href="../attributes/thekeyrefattribute.dita"
                         ><xmlatt>keyref</xmlatt></xref>. </p>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -62,8 +62,8 @@
                         <xmlatt>format</xmlatt>, all given below), <xref
                         keyref="attributes-commonMap"/>, <xref
                         keyref="attributes-topicrefElement"/>, <xref
-                        href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and
-                        <xref href="../attributes/thekeyrefattribute.dita"
+                        keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and
+                        <xref keyref="attributes-keyref"
                         ><xmlatt>keyref</xmlatt></xref>. </p>
                 <dl>
                     <dlentry>
@@ -71,7 +71,7 @@
                         <dd>A pointer to an <xmlelement>anchor</xmlelement> element in this or
                             another DITA map. When rendered, the contents of the current element
                             will be copied to the location of the <xmlelement>anchor</xmlelement>.
-                                <ph>See <xref href="../attributes/thehrefattribute.dita"/> for
+                                <ph>See <xref keyref="attributes-href"/> for
                                 supported syntax when referencing a map element.</ph>
                             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
                     </dlentry>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -56,7 +56,7 @@
             <title>Attributes</title>
             <sectiondiv id="standard-topicref-attributes">
                 <p>The following attributes are available on this element: <xref
-                        href="../attributes/universalAttributes.dita"/>, <xref
+                        keyref="attributes-universal"/>, <xref
                         href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed
                     definitions of <xmlatt>href</xmlatt>, <xmlatt>type</xmlatt>, and
                         <xmlatt>format</xmlatt>, all given below), <xref

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -30,8 +30,8 @@
                     href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
                     <xmlatt>base</xmlatt> from <xref
                     href="../attributes/metadataAttributes.dita#select-atts"/>, <xref
-                    href="../attributes/universalAttributes.dita#univ-atts/outputclass"/>, <xref
-                    href="../attributes/universalAttributes.dita#univ-atts/class"/>, and the
+                    keyref="attributes-universal/outputclass"/>, <xref
+                    keyref="attributes-universal/class"/>, and the
                 attributes defined below.</p>
             <dl>
                 <dlentry>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -27,9 +27,9 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
+                    keyref="attributes-id"/>, <xmlatt>status</xmlatt> and
                     <xmlatt>base</xmlatt> from <xref
-                    href="../attributes/metadataAttributes.dita#select-atts"/>, <xref
+                    keyref="attributes-metadata"/>, <xref
                     keyref="attributes-universal/outputclass"/>, <xref
                     keyref="attributes-universal/class"/>, and the
                 attributes defined below.</p>

--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -28,7 +28,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attributes defined below.</p>
+          keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry id="type">
           <dt><xmlatt>type</xmlatt></dt>

--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -40,7 +40,7 @@
               <keyword>purchaser</keyword>, <keyword>administrator</keyword>,
               <keyword>programmer</keyword>, <keyword>executive</keyword>,
               <keyword>services</keyword>, <keyword>other</keyword>, and <xref
-              href="../attributes/ditauseconreftarget.dita">-dita-use-conref-target</xref>.</dd>
+              keyref="attributes-useconreftarget">-dita-use-conref-target</xref>.</dd>
         </dlentry>
         <dlentry id="othertype">
           <dt><xmlatt>othertype</xmlatt></dt>
@@ -62,7 +62,7 @@
               using</keyword>, <keyword>maintaining</keyword>, <keyword>troubleshooting</keyword>,
               <keyword>evaluating</keyword>, <keyword>planning</keyword>,
               <keyword>migrating</keyword>, <keyword>other</keyword>, and <xref
-              href="../attributes/ditauseconreftarget.dita">-dita-use-conref-target</xref>.</dd>
+              keyref="attributes-useconreftarget">-dita-use-conref-target</xref>.</dd>
         </dlentry>
         <dlentry id="otherjob">
           <dt><xmlatt>otherjob</xmlatt></dt>
@@ -79,7 +79,7 @@
             not limited to a small number of choices; the following values were used in DITA 1.0 and
             DITA 1.1, and are still provided as sample values: <keyword>novice</keyword>,
               <keyword>general</keyword>, <keyword>expert</keyword>, and <xref
-              href="../attributes/ditauseconreftarget.dita">-dita-use-conref-target</xref>.</dd>
+              keyref="attributes-useconreftarget">-dita-use-conref-target</xref>.</dd>
         </dlentry>
         <dlentry id="name">
           <dt><xmlatt>name</xmlatt></dt>

--- a/specification/langRef/base/brand.dita
+++ b/specification/langRef/base/brand.dita
@@ -15,7 +15,7 @@ the parent  <xmlelement>prodinfo</xmlelement> element.</shortdesc>
   <section id="attributes">
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/>.</p>
+     keyref="attributes-universal"/>.</p>
   </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;prodinfo&gt;
  &lt;prodname&gt;Some Product&lt;/prodname&gt;

--- a/specification/langRef/base/category.dita
+++ b/specification/langRef/base/category.dita
@@ -23,7 +23,7 @@ categories.</shortdesc>
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/>.</p>
+                    keyref="attributes-universal"/>.</p>
         </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -20,7 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p&gt;The online article <b>&lt;cite&gt;</b>Specialization in the Darwin Information Typing

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -21,7 +21,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p&gt;The online article <b>&lt;cite&gt;</b>Specialization in the Darwin Information Typing
 Architecture<b>&lt;/cite&gt;</b> provides a detailed explanation of how to define new

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -18,10 +18,10 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (without the Metadata attribute group),
-          <xmlatt>base</xmlatt> from the <xref href="../attributes/metadataAttributes.dita"/>, and the attributes
+          <xmlatt>base</xmlatt> from the <xref keyref="attributes-metadata"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
           <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>rowheader</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
+          <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>colnum</xmlatt></dt>

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -17,7 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
+          keyref="attributes-universal"/> (without the Metadata attribute group),
           <xmlatt>base</xmlatt> from the <xref href="../attributes/metadataAttributes.dita"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
           <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and

--- a/specification/langRef/base/component.dita
+++ b/specification/langRef/base/component.dita
@@ -24,7 +24,7 @@ logic is not currently supported in DITA processing.--></p>
   <section id="attributes">
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/>.</p>
+     keyref="attributes-universal"/>.</p>
   </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;prodinfo&gt;
  &lt;prodname&gt;BatCom&lt;/prodname&gt;

--- a/specification/langRef/base/copyrholder.dita
+++ b/specification/langRef/base/copyrholder.dita
@@ -14,7 +14,7 @@ legal rights to the material contained in the topic.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;copyright&gt;
   &lt;copyryear year="2001"&gt;&lt;/copyryear&gt;

--- a/specification/langRef/base/copyright.dita
+++ b/specification/langRef/base/copyright.dita
@@ -21,7 +21,7 @@ legal ownership of the content.</shortdesc>
   <section id="attributes">
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/> and the attribute defined below.</p>
+     keyref="attributes-universal"/> and the attribute defined below.</p>
    <dl>
     <!--<dlhead conref="../../common/conref-file.dita#reuse_file/attributeDlhead"><dthd/><ddhd/></dlhead>-->
     <dlentry id="type">

--- a/specification/langRef/base/copyryear.dita
+++ b/specification/langRef/base/copyryear.dita
@@ -14,7 +14,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attribute defined below.</p>
+          keyref="attributes-universal"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="year">
           <dt><xmlatt>year</xmlatt></dt>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -14,7 +14,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/dateAttributes.dita"/>, and the attribute defined below.</p>
+          keyref="attributes-date"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="date">
           <dt><xmlatt>date</xmlatt>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -13,7 +13,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/dateAttributes.dita"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="date">

--- a/specification/langRef/base/critdates.dita
+++ b/specification/langRef/base/critdates.dita
@@ -21,7 +21,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/data-about.dita
+++ b/specification/langRef/base/data-about.dita
@@ -27,7 +27,7 @@
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/> and <xref
-                    href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>.</p>
+                    keyref="attributes-linkRelationship"/>.</p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The full properties of a cited book can be maintained conveniently in the
                     <xmlelement>prolog</xmlelement>:</p><codeblock>&lt;topic id="questions"&gt;

--- a/specification/langRef/base/data-about.dita
+++ b/specification/langRef/base/data-about.dita
@@ -26,7 +26,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita#univ-atts"/> and <xref
+                    keyref="attributes-universal"/> and <xref
                     href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>.</p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The full properties of a cited book can be maintained conveniently in the

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -26,8 +26,8 @@
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           keyref="attributes-topicrefElement"/>, <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>locktitle</xmlatt>, and
           <xmlatt>toc</xmlatt> from <xref keyref="attributes-commonMap"/>.</p>
       <dl>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -23,13 +23,13 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          href="../attributes/topicrefElementAttributes.dita"/>, <xref
+          keyref="attributes-topicrefElement"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>locktitle</xmlatt>, and
-          <xmlatt>toc</xmlatt> from <xref href="../attributes/commonMapAttributes.dita"/>.</p>
+          <xmlatt>toc</xmlatt> from <xref keyref="attributes-commonMap"/>.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
           <dt/>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -22,7 +22,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/topicrefElementAttributes.dita"/>, <xref

--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -18,8 +18,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xmlatt>xmlns:ditaarch</xmlatt> and
           <xmlatt>DITAArchVersion</xmlatt> from <xref
-          href="../attributes/architecturalAttributes.dita"/>, and <xref
-          href="../attributes/localizationAttributes.dita"/>.</p>
+          keyref="attributes-architectural"/>, and <xref
+          keyref="attributes-localization"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;dita&gt;
   &lt;concept id="batintro"&gt;&lt;title>Intro to bats&lt;/title>&lt;conbody>&lt;!-- ... -->&lt;/conbody>&lt;/concept&gt;

--- a/specification/langRef/base/ditavalmeta.dita
+++ b/specification/langRef/base/ditavalmeta.dita
@@ -31,7 +31,7 @@ conref="../../common/conref-examples.dita#conref-examples/ditavalref"/>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain).</p>
     </section>
   </refbody>

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -122,14 +122,14 @@ conref="../../common/conref-examples.dita#conref-examples/ditavalref"/>
           <dd>Provides a reference to a DITAVAL document. If the <xmlatt>href</xmlatt> attribute is
             unspecified, this <xmlelement>ditavalref</xmlelement> will not result in any new
             filtering behavior, but other aspects of the element are still evaluated. See <xref
-              href="../attributes/thehrefattribute.dita"/> for general information on the format and
+              keyref="attributes-href"/> for general information on the format and
             processing implications of the <xmlatt>href</xmlatt> attribute.</dd>
         </dlentry>
         <dlentry>
           <dt id="ditavalref-format"><xmlatt>format</xmlatt></dt>
           <dd>Format of the target document, which <term  outputclass="RFC-2119"
               >MUST</term> be a DITAVAL document. The default value for this element is "ditaval".
-            See <xref href="../attributes/theformatattribute.dita"/> for more information.</dd>
+          See <xref keyref="attributes-format"/> for more information.</dd>
         </dlentry>
         <dlentry>
           <dt id="ditavalref-processing-role"><xmlatt>processing-role</xmlatt></dt>

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -114,7 +114,7 @@ conref="../../common/conref-examples.dita#conref-examples/ditavalref"/>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain) and the attributes defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/dl.dita
+++ b/specification/langRef/base/dl.dita
@@ -91,7 +91,7 @@
 </dlentry></dl></example>
 <section id="attributes">       <title>Attributes</title>
    <p >The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/>, <xref
+     keyref="attributes-universal"/>, <xref
      href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
      href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>     </section>
 </refbody>

--- a/specification/langRef/base/dl.dita
+++ b/specification/langRef/base/dl.dita
@@ -92,7 +92,7 @@
 <section id="attributes">       <title>Attributes</title>
    <p >The following attributes are available on this element: <xref
      keyref="attributes-universal"/>, <xref
-     href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
-     href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>     </section>
+     keyref="attributes-common/compact"/>, and <xref
+     keyref="attributes-specialization/spectitle"/>.</p>     </section>
 </refbody>
 </reference>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -48,7 +48,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition for
+          keyref="attributes-universal"/> (with a narrowed definition for
           <xmlatt>translate</xmlatt>, given below) and the attributes
         defined below.</p>
       <dl>

--- a/specification/langRef/base/dt.dita
+++ b/specification/langRef/base/dt.dita
@@ -19,7 +19,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig
 conref="dl.dita#dl/simpleexample"></fig></example>

--- a/specification/langRef/base/dt.dita
+++ b/specification/langRef/base/dt.dita
@@ -18,7 +18,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -53,7 +53,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain) and the attribute defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -53,7 +53,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain) and the attribute defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -55,7 +55,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain) and the attribute defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -27,7 +27,7 @@
           <codeph>scope="external"</codeph>. Rules for which resources are eligible for renaming,
         and what names are allowed as valid resource names, are the same as those for the
           <xmlatt>copy-to</xmlatt> attribute defined in <xref
-          href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>.</p>
+          keyref="attributes-topicrefElement"/>.</p>
     </section>
     <section id="contains" conref="../../common/commonNavLibraryTable.dita#contentmodel-dvrResourcePrefix/contains" otherprops="contains"></section>
     <section id="inheritance" otherprops="inheritance">

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -29,7 +29,7 @@
           <codeph>scope="external"</codeph>. Rules for which resources are eligible for renaming,
         and what names are allowed as valid resource names, are the same as those for the
           <xmlatt>copy-to</xmlatt> attribute defined in <xref
-          href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>, with one
+          keyref="attributes-topicrefElement"/>, with one
         exception. Where <xmlatt>copy-to</xmlatt> and <xmlelement>dvrResourcePrefix</xmlelement>
         <ph >might</ph> include path information, path information is not valid
         in <xmlelement>dvrResourceSuffix</xmlelement>.</p>

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -60,7 +60,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (except for <xmlatt>conkeyref</xmlatt>,
+          keyref="attributes-universal"/> (except for <xmlatt>conkeyref</xmlatt>,
         which is removed for all elements in this domain) and the attribute defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -21,9 +21,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
-          <xmlatt>base</xmlatt> from <xref href="../attributes/metadataAttributes.dita#select-atts"
-        />, <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
+          keyref="attributes-id"/>, <xmlatt>status</xmlatt> and
+          <xmlatt>base</xmlatt> from <xref keyref="attributes-metadata"
+          />, <xref keyref="attributes-common/outputclass"/>, <xref
           keyref="attributes-universal/class"/>, and the attributes
         defined below.</p>
       <dl>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -24,7 +24,7 @@
           href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
           <xmlatt>base</xmlatt> from <xref href="../attributes/metadataAttributes.dita#select-atts"
         />, <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, <xref
-          href="../attributes/universalAttributes.dita#univ-atts/class"/>, and the attributes
+          keyref="attributes-universal/class"/>, and the attributes
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -18,10 +18,10 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (without the Metadata attribute group),
           <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
-          href="../attributes/metadataAttributes.dita"/>, and the attributes
+          keyref="attributes-metadata"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
           <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>valign</xmlatt> from the <xref href="../attributes/calsTableAttributes.dita"
+          <xmlatt>valign</xmlatt> from the <xref keyref="attributes-calsTable"
         />.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -16,7 +16,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
+          keyref="attributes-universal"/> (without the Metadata attribute group),
           <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
           href="../attributes/metadataAttributes.dita"/>, and the attributes
         defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -48,7 +48,7 @@
                     href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
                     <xmlatt>base</xmlatt> from <xref href="../attributes/metadataAttributes.dita"/>,
                     <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
-                    href="../attributes/universalAttributes.dita#univ-atts/class"/>.</p>
+                    keyref="attributes-universal/class"/>.</p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p id="enumeration-xpl">In this example, enumerations are specified for the
                     <xmlatt>platform</xmlatt> and <xmlatt>otherprops</xmlatt> attributes. Note that

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -45,9 +45,9 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/idAttributes.dita"/>, <xmlatt>status</xmlatt> and
-                    <xmlatt>base</xmlatt> from <xref href="../attributes/metadataAttributes.dita"/>,
-                    <xref href="../attributes/commonAttributes.dita#common-atts/outputclass"/>, and <xref
+                    keyref="attributes-id"/>, <xmlatt>status</xmlatt> and
+                    <xmlatt>base</xmlatt> from <xref keyref="attributes-metadata"/>,
+                    <xref keyref="attributes-common/outputclass"/>, and <xref
                     keyref="attributes-universal/class"/>.</p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><p id="enumeration-xpl">In this example, enumerations are specified for the

--- a/specification/langRef/base/exportanchors.dita
+++ b/specification/langRef/base/exportanchors.dita
@@ -55,7 +55,7 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <xref
-               href="../attributes/universalAttributes.dita"/>.</p>
+               keyref="attributes-universal"/>.</p>
       </section>
       <!--Pull in examples for both anchorid and anchorkey-->
       <example conref="anchorid.dita#anchorid/example" id="example" otherprops="examples"/>

--- a/specification/langRef/base/featnum.dita
+++ b/specification/langRef/base/featnum.dita
@@ -6,7 +6,7 @@ number (featnum)</indexterm><indexterm>prolog elements<indexterm>featnum</indext
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;prodinfo&gt;
  &lt;prodname&gt;BatCom&lt;/prodname&gt;
  &lt;vrmlist&gt;

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -18,7 +18,7 @@
       <title>Attributes</title>
       <sectiondiv id="scheme-HAS-elements">
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/>, <xref
+            keyref="attributes-universal"/>, <xref
             href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
             <xmlatt>href</xmlatt>, given below), processing-role from <xref
             href="../attributes/commonMapAttributes.dita"/>, navtitle from <xref

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -23,8 +23,8 @@
             <xmlatt>href</xmlatt>, given below), processing-role from <xref
             keyref="attributes-commonMap"/>, navtitle from <xref
             keyref="attributes-topicrefElement"/>, <xref
-            href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-            href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+            keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>
           <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
             <dt/>

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -19,10 +19,10 @@
       <sectiondiv id="scheme-HAS-elements">
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/>, <xref
-            href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+            keyref="attributes-linkRelationship"/> (with a narrowed definition of
             <xmlatt>href</xmlatt>, given below), processing-role from <xref
-            href="../attributes/commonMapAttributes.dita"/>, navtitle from <xref
-            href="../attributes/topicrefElementAttributes.dita"/>, <xref
+            keyref="attributes-commonMap"/>, navtitle from <xref
+            keyref="attributes-topicrefElement"/>, <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -21,7 +21,7 @@ topic/note hazard-d/hazardstatement </p></section>
       <title>Attributes</title>
       <sectiondiv>
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/> and <xref
+            keyref="attributes-universal"/> and <xref
             href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and
           the attributes defined below.</p>
         <dl>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -22,7 +22,7 @@ topic/note hazard-d/hazardstatement </p></section>
       <sectiondiv>
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/> and <xref
-            href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, and
+            keyref="attributes-specialization/spectitle"/>, and
           the attributes defined below.</p>
         <dl>
           <dlentry>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -30,11 +30,11 @@ topic/note hazard-d/hazardstatement </p></section>
             <dd>Describes the level of hazard. Safety hazard level definitions correspond to the
               same values in the ANSI Z535 and the ISO 3864 standards. <ph
                 conref="../../common/conref-attribute.dita#conref-attribute/nonstandard-type"/> See
-                <xref href="../attributes/thetypeattribute.dita"/> for detailed information on
+            <xref keyref="attributes-type"/> for detailed information on
               supported values and processing implications. Available values are note, tip,
               fastpath, restriction, important, remember, attention, caution, notice, danger,
               warning, other, and <xref
-                href="../attributes/ditauseconreftarget.dita#usingthe-dita-use-conref-targetvalue"
+                keyref="attributes-useconreftarget"
                 >-dita-use-​conref-​target</xref>.
               <!--Asked TC for input: should @type=trouble be added here as it was on <note>. Local definition with the reference to ANSI still differs from the base <xmlelement>note</xmlelement> element. UPDATE 12 February 2014: TC agreed not ot add trouble, most of these values should not hvae been added but are left now for backwards compatibility--></dd>
           </dlentry>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -19,7 +19,7 @@ topic/image hazard-d/hazardsymbol</p></section>
       <title>Attributes</title>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -20,7 +20,7 @@ topic/image hazard-d/hazardsymbol</p></section>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-href">

--- a/specification/langRef/base/image.dita
+++ b/specification/langRef/base/image.dita
@@ -36,7 +36,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-href">
@@ -51,7 +51,7 @@
 <dt><xmlatt>format</xmlatt></dt>
 <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->The
 <xmlatt>format</xmlatt> attribute identifies the format of the resource being referenced. See <xref
-href="../attributes/theformatattribute.dita"/> for details on supported values.</dd>
+keyref="attributes-format"/> for details on supported values.</dd>
 </dlentry>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-height">
           <dt/>

--- a/specification/langRef/base/image.dita
+++ b/specification/langRef/base/image.dita
@@ -35,7 +35,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/index-base.dita
+++ b/specification/langRef/base/index-base.dita
@@ -29,7 +29,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/index-base.dita
+++ b/specification/langRef/base/index-base.dita
@@ -30,7 +30,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
 <p rev="errata-02"><i>This element is not intended to be used in source files.</i></p><p>The <xmlelement>index-see-also</xmlelement> element is specialized from

--- a/specification/langRef/base/index-see-also.dita
+++ b/specification/langRef/base/index-see-also.dita
@@ -27,7 +27,7 @@ topic/index-base indexing-d/index-see-also </p></section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/index-see-also.dita
+++ b/specification/langRef/base/index-see-also.dita
@@ -28,7 +28,7 @@ topic/index-base indexing-d/index-see-also </p></section>
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">
 <title>Example</title><p>The following example illustrates the use of an <xmlelement>index-see-also</xmlelement>

--- a/specification/langRef/base/index-see.dita
+++ b/specification/langRef/base/index-see.dita
@@ -52,7 +52,7 @@ topic/index-base indexing-d/index-see </p></section>
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">
 <title>Example</title><p>The following example illustrates the use of an <xmlelement>index-see</xmlelement> redirection

--- a/specification/langRef/base/index-see.dita
+++ b/specification/langRef/base/index-see.dita
@@ -51,7 +51,7 @@ topic/index-base indexing-d/index-see </p></section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -74,7 +74,7 @@ topic/index-base indexing-d/index-sort-as </p></section>
                         <title>Attributes</title>
                         <p>The following attributes are available on this element: <xref
                                         keyref="attributes-universal"/> and <xref
-                                        href="../attributes/thekeyrefattribute.dita"
+                                        keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                 </section>
 <example id="example" otherprops="examples"><p>This is an example of an index entry for <codeph>&lt;data&gt;</codeph> that will be sorted as

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -73,7 +73,7 @@ topic/index-base indexing-d/index-sort-as </p></section>
                 <section id="attributes">
                         <title>Attributes</title>
                         <p>The following attributes are available on this element: <xref
-                                        href="../attributes/universalAttributes.dita"/> and <xref
+                                        keyref="attributes-universal"/> and <xref
                                         href="../attributes/thekeyrefattribute.dita"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                 </section>

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -103,7 +103,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -104,7 +104,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry id="start">

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -36,7 +36,7 @@
             <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"
           /> (with a narrowed definition of <xmlatt>processing-role</xmlatt>, given below), <xref
             keyref="attributes-topicrefElement"/>, <xref
-            href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
+            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
           attributes defined below.</p>
         <dl>
           <dlentry>
@@ -44,7 +44,7 @@
               <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
             <dd>On this element the <xmlatt>keys</xmlatt> attribute is required, because the purpose
               of the element is to define a key. Otherwise, the attribute is the same as described
-              in <xref href="../attributes/thekeysattribute.dita"/>.</dd>
+              in <xref keyref="attributes-keys"/>.</dd>
           </dlentry>
           <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
             <dt/>

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -32,10 +32,10 @@
       <sectiondiv id="keydef-attributes">
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/>, <xref
-            href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-            <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"
+            keyref="attributes-linkRelationship"/> (with a narrowed definition of
+            <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"
           /> (with a narrowed definition of <xmlatt>processing-role</xmlatt>, given below), <xref
-            href="../attributes/topicrefElementAttributes.dita"/>, <xref
+            keyref="attributes-topicrefElement"/>, <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
           attributes defined below.</p>
         <dl>

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -31,7 +31,7 @@
       <title>Attributes</title>
       <sectiondiv id="keydef-attributes">
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/>, <xref
+            keyref="attributes-universal"/>, <xref
             href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
             <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"
           /> (with a narrowed definition of <xmlatt>processing-role</xmlatt>, given below), <xref

--- a/specification/langRef/base/keywords.dita
+++ b/specification/langRef/base/keywords.dita
@@ -33,7 +33,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -28,9 +28,9 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/displayAttributes.dita"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
-          href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
+          keyref="attributes-display"/>, <xref
+          keyref="attributes-common/xmlspace"/>, and <xref
+          keyref="attributes-specialization/spectitle"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>This is a sample of my favorite sonnet:&lt;/p>
 &lt;lines&gt;

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -27,7 +27,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/displayAttributes.dita"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/xmlspace"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -35,8 +35,8 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
-          href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-role"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;related-links&gt;
   &lt;linkpool type="concept"&gt;

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -34,7 +34,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>, <xref
+          keyref="attributes-linkRelationship"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
     </section>

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -33,7 +33,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -51,13 +51,13 @@ topic/linklist </p></section>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
+          keyref="attributes-commonMap/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
-          href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>, and the attributes
+          keyref="attributes-specialization/spectitle"/>, <xref
+          keyref="attributes-common/mapkeyref"/>, and the attributes
         defined below. This element also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>type</xmlatt> from <xref
-          href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>. </p>
+          keyref="attributes-linkRelationship"/>. </p>
       <dl conref="../../common/conref-attribute.dita#conref-attribute/linklist-and-linkpool">
         <dlentry>
           <dt/>

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -50,7 +50,7 @@ topic/linklist </p></section>
 <section id="attributes"><title>Attributes</title>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>, <xref

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -52,7 +52,7 @@ topic/linklist </p></section>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-commonMap/collection-type"/>, <xref
-          href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
+          keyref="attributes-role"/>, <xref
           keyref="attributes-specialization/spectitle"/>, <xref
           keyref="attributes-common/mapkeyref"/>, and the attributes
         defined below. This element also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -20,7 +20,7 @@ in the DITA topic.</shortdesc>
    <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-commonMap/collection-type"/>, <xref
-          href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
+          keyref="attributes-role"/>, <xref
           keyref="attributes-common/mapkeyref"/>, and the attributes
         defined below. This element also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>type</xmlatt> from <xref

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -18,7 +18,7 @@ in the DITA topic.</shortdesc>
 <section id="attributes"><title>Attributes</title>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
    <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>, and the attributes

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -19,12 +19,12 @@ in the DITA topic.</shortdesc>
       <!--RDA: during 1.3 work, discovered an issue with @collection type: https://lists.oasis-open.org/archives/dita/201312/msg00101.html Update: Discussed at TC Jan 14, 2014, agreed to keep the "tree" value in the DTD, consider it deprecated, do not add to XSD or RNG-->
    <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/commonMapAttributes.dita#topicref-atts/collection-type"/>, <xref
+          keyref="attributes-commonMap/collection-type"/>, <xref
           href="../attributes/theroleattribute.dita#theroleattribute"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>, and the attributes
+          keyref="attributes-common/mapkeyref"/>, and the attributes
         defined below. This element also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>type</xmlatt> from <xref
-          href="../attributes/linkRelationshipAttributes.dita#relational-atts"/>. </p>
+          keyref="attributes-linkRelationship"/>. </p>
    <dl conref="../../common/conref-attribute.dita#conref-attribute/linklist-and-linkpool">
     <dlentry>
      <dt/>

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -18,7 +18,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
+          keyref="attributes-linkRelationship"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -17,7 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -19,7 +19,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -21,7 +21,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -23,7 +23,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>A great person once said the following thing.
 &lt;lq>Examples are the key to any

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -22,7 +22,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
+          keyref="attributes-linkRelationship"/>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>A great person once said the following thing.

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -30,7 +30,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition for
           <xmlatt>type</xmlatt>, given below), and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -33,7 +33,7 @@
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/> (with a narrowed definition for
           <xmlatt>type</xmlatt>, given below), and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry id="reftitle">
@@ -44,7 +44,7 @@
           <dt><xmlatt>type</xmlatt></dt>
           <dd>Indicates the location of the source of the quote. <ph
               conref="../../common/conref-attribute.dita#conref-attribute/nonstandard-type"/> See
-              <xref href="../attributes/thetypeattribute.dita"/> for detailed information on the
+          <xref keyref="attributes-type"/> for detailed information on the
             usual supported values and processing implications. </dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -31,7 +31,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition for
+          keyref="attributes-linkRelationship"/> (with a narrowed definition for
           <xmlatt>type</xmlatt>, given below), and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -31,10 +31,10 @@
       <sectiondiv id="mapref-attributes">
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/>, <xref
-            href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
+            keyref="attributes-linkRelationship"/> (with narrowed definitions of
             <xmlatt>href</xmlatt> and <xmlatt>format</xmlatt>, given below), <xref
-            href="../attributes/commonMapAttributes.dita"/>, <xref
-            href="../attributes/topicrefElementAttributes.dita"/>, <xref
+            keyref="attributes-commonMap"/>, <xref
+            keyref="attributes-topicrefElement"/>, <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -35,8 +35,8 @@
             <xmlatt>href</xmlatt> and <xmlatt>format</xmlatt>, given below), <xref
             keyref="attributes-commonMap"/>, <xref
             keyref="attributes-topicrefElement"/>, <xref
-            href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
-            href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>.</p>
+            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+            keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>.</p>
         <dl>
           <dlentry conref="../../common/conref-attribute.dita#conref-attribute/format-mapref">
             <dt/>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -30,7 +30,7 @@
       <title>Attributes</title>
       <sectiondiv id="mapref-attributes">
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/>, <xref
+            keyref="attributes-universal"/>, <xref
             href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
             <xmlatt>href</xmlatt> and <xmlatt>format</xmlatt>, given below), <xref
             href="../attributes/commonMapAttributes.dita"/>, <xref

--- a/specification/langRef/base/metadata.dita
+++ b/specification/langRef/base/metadata.dita
@@ -31,7 +31,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>Metadata within a topic:</p><codeblock>&lt;prolog&gt;

--- a/specification/langRef/base/metadata.dita
+++ b/specification/langRef/base/metadata.dita
@@ -32,7 +32,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/commonAttributes.dita#common-atts/mapkeyref"/>.</p>
+          keyref="attributes-common/mapkeyref"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>Metadata within a topic:</p><codeblock>&lt;prolog&gt;
   <b>&lt;metadata&gt;</b>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -32,7 +32,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="universal-outputclass">The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attribute
+          keyref="attributes-universal"/> and the attribute
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/navtitle.dita
+++ b/specification/langRef/base/navtitle.dita
@@ -45,7 +45,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><fig>
         <title><xmlelement>navtitle</xmlelement> sample in a topic</title>

--- a/specification/langRef/base/no-topic-nesting.dita
+++ b/specification/langRef/base/no-topic-nesting.dita
@@ -23,7 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attribute is available on this element: <xref
-          href="../attributes/universalAttributes.dita#univ-atts/class"/>.</p>
+          keyref="attributes-universal/class"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p><i>This element is not intended to be used in source files.</i></p></example>
 </refbody>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -23,7 +23,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and the
+                    keyref="attributes-universal"/> and the
                 attributes defined below.</p>
             <dl>
                 <dlentry>

--- a/specification/langRef/base/ol.dita
+++ b/specification/langRef/base/ol.dita
@@ -14,8 +14,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
-          href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
+          keyref="attributes-common/compact"/>, and <xref
+          keyref="attributes-specialization/spectitle"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>Here are the colors of the rainbow in order of appearance from top to bottom:&lt;/p>
 &lt;ol&gt;

--- a/specification/langRef/base/ol.dita
+++ b/specification/langRef/base/ol.dita
@@ -13,7 +13,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -47,7 +47,7 @@
      <dt><xmlatt>translate-content</xmlatt></dt>
      <dd>Indicates whether the <xmlatt>content</xmlatt> attribute of the defined metadata property
       should be translated or not. Allowable values are <keyword>yes</keyword>,
-       <keyword>no</keyword>, and <xref href="../attributes/ditauseconreftarget.dita"
+       <keyword>no</keyword>, and <xref keyref="attributes-useconreftarget"
        >-dita-use-conref-target</xref>.</dd>
     </dlentry>
    </dl>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -27,7 +27,7 @@
   <section id="attributes">
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/> and the attributes defined below.</p>
+     keyref="attributes-universal"/> and the attributes defined below.</p>
    <dl>
     <dlentry id="name">
      <dt><xmlatt>name</xmlatt>

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attributes defined below.</p>
+          keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>name</xmlatt>

--- a/specification/langRef/base/permissions.dita
+++ b/specification/langRef/base/permissions.dita
@@ -19,7 +19,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attribute defined below.</p>
+          keyref="attributes-universal"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="view">
           <dt><xmlatt>view</xmlatt></dt>

--- a/specification/langRef/base/platform.dita
+++ b/specification/langRef/base/platform.dita
@@ -8,5 +8,5 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prodinfo.dita
+++ b/specification/langRef/base/prodinfo.dita
@@ -17,7 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
 <example id="example" otherprops="examples">    <title>Example</title>    <codeblock
 xml:space="preserve">&lt;prolog&gt;

--- a/specification/langRef/base/prodname.dita
+++ b/specification/langRef/base/prodname.dita
@@ -5,5 +5,5 @@ the name of the product that is supported by the information in this topic.</sho
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prognum.dita
+++ b/specification/langRef/base/prognum.dita
@@ -4,5 +4,5 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -19,7 +19,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/>, <xref
+                    keyref="attributes-universal"/>, <xref
                     href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
                     href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -21,7 +21,7 @@
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/>, <xref
                     keyref="attributes-linkRelationship"/>, and <xref
-                    href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+                    keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -20,7 +20,7 @@
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/>, <xref
-                    href="../attributes/linkRelationshipAttributes.dita"/>, and <xref
+                    keyref="attributes-linkRelationship"/>, and <xref
                     href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -32,7 +32,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (apart from <xmlatt>href</xmlatt>), and
           <xref href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
     </section>

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -34,7 +34,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/> (apart from <xmlatt>href</xmlatt>), and
-          <xref href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
+      <xref keyref="attributes-role"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following
 indicates that the two external links are always applicable to this

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -33,7 +33,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (apart from <xmlatt>href</xmlatt>), and
+          keyref="attributes-linkRelationship"/> (apart from <xmlatt>href</xmlatt>), and
           <xref href="../attributes/theroleattribute.dita#theroleattribute"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -37,13 +37,13 @@ restricted by the <xmlatt>linking</xmlatt> attribute of the subjects).</shortdes
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>collection-type</xmlatt>, and a narrowed
         definition of <xmlatt>linking</xmlatt> (given below) from <xref
-          href="../attributes/commonMapAttributes.dita"/>.</p>
+          keyref="attributes-commonMap"/>.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
           <dt/>
@@ -53,7 +53,7 @@ restricted by the <xmlatt>linking</xmlatt> attribute of the subjects).</shortdes
           <dt id="linking"><xmlatt>linking</xmlatt></dt>
           <dd>On this element, the <xmlatt>linking</xmlatt> attribute has a default value of
             "normal". Otherwise, the attribute is the same as defined in <xref
-              href="../attributes/commonMapAttributes.dita"/>.</dd>
+              keyref="attributes-commonMap"/>.</dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -39,8 +39,8 @@ restricted by the <xmlatt>linking</xmlatt> attribute of the subjects).</shortdes
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>. This element
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>collection-type</xmlatt>, and a narrowed
         definition of <xmlatt>linking</xmlatt> (given below) from <xref
           keyref="attributes-commonMap"/>.</p>

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -36,7 +36,7 @@ restricted by the <xmlatt>linking</xmlatt> attribute of the subjects).</shortdes
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -24,9 +24,9 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt>).
+          keyref="attributes-commonMap"/> (without <xmlatt>keyscope</xmlatt>).
         This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-          <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
+          <xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
         />.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -23,7 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt>).
         This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -75,7 +75,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
           <xmlatt>collection-type</xmlatt>). This element also
         uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt> from <xref

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -76,10 +76,10 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
+          keyref="attributes-commonMap"/> (without <xmlatt>keyscope</xmlatt> or
           <xmlatt>collection-type</xmlatt>). This element also
         uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt> from <xref
-          href="../attributes/linkRelationshipAttributes.dita"/>.</p>
+          keyref="attributes-linkRelationship"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In this example, a relationship table is defined with three columns; one for "concept", one for
         "task", and one for "reference". Three cells are defined within one row. The first cell

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -50,7 +50,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
           <xmlatt>collection-type</xmlatt>, and with a narrowed definition of
           <xmlatt>toc</xmlatt>, given below), and the attributes

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -51,11 +51,11 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/commonMapAttributes.dita"/> (without <xmlatt>keyscope</xmlatt> or
+          keyref="attributes-commonMap"/> (without <xmlatt>keyscope</xmlatt> or
           <xmlatt>collection-type</xmlatt>, and with a narrowed definition of
           <xmlatt>toc</xmlatt>, given below), and the attributes
         defined below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-          <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
+          <xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
         />.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/toc-default-no">

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -29,7 +29,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a modified definition of
+          keyref="attributes-universal"/> (with a modified definition of
           <xmlatt>translate</xmlatt>, given below), and the attributes
         defined below.<dl>
 <dlentry>

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -42,7 +42,7 @@ the migrated content should be tagged.</ph></dd>
             <dt><xmlatt>translate</xmlatt></dt>
             <dd>Indicates whether the content of the element should be translated or not. The
               default value for this element is "no"; setting to "yes" will override the default.
-              The <xref href="../attributes/ditauseconreftarget.dita">-dita-use-conref-target</xref>
+              The <xref keyref="attributes-useconreftarget">-dita-use-conref-target</xref>
               value is also available. The DITA architectural specification contains a list of each
               OASIS DITA element and its common processing default for the translate value; because
               this element uses an actual default, it will always be treated as

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -26,7 +26,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below) and the attributes defined below.</p>
       <dl>
         <dlentry id="appname">

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -14,7 +14,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/dateAttributes.dita"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="modified">

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -15,7 +15,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/dateAttributes.dita"/>, and the attribute defined below.</p>
+          keyref="attributes-date"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="modified">
           <dt><xmlatt>modified</xmlatt>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -4,7 +4,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, along with
+          keyref="attributes-universal"/>, along with
         <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
           href="../attributes/calsTableAttributes.dita"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -6,5 +6,5 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, along with
         <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
-          href="../attributes/calsTableAttributes.dita"/>.</p>
+          keyref="attributes-calsTable"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -21,7 +21,7 @@
       <sectiondiv id="standard-topicref-attributes">
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/>, <xref
-            href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
+            keyref="attributes-linkRelationship"/> (with narrowed definitions of
             <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below), <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
             href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -20,7 +20,7 @@
       <title>Attributes</title>
       <sectiondiv id="standard-topicref-attributes">
         <p>The following attributes are available on this element: <xref
-            href="../attributes/universalAttributes.dita"/>, <xref
+            keyref="attributes-universal"/>, <xref
             href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
             <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below), <xref
             href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -23,8 +23,8 @@
             keyref="attributes-universal"/>, <xref
             keyref="attributes-linkRelationship"/> (with narrowed definitions of
             <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below), <xref
-            href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-            href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+            keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>
           <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
             <dt/>

--- a/specification/langRef/base/series.dita
+++ b/specification/langRef/base/series.dita
@@ -5,7 +5,7 @@ information about the product series that the topic supports.</shortdesc><prolog
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;prodinfo&gt;
  &lt;prodname&gt;BatCom&lt;/prodname&gt;
  &lt;vrmlist&gt;&lt;vrm version="5"/&gt;&lt;/vrmlist&gt;

--- a/specification/langRef/base/sl.dita
+++ b/specification/langRef/base/sl.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>,, <xref
+          keyref="attributes-universal"/>,, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/sl.dita
+++ b/specification/langRef/base/sl.dita
@@ -25,8 +25,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>,, <xref
-          href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
-          href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
+          keyref="attributes-common/compact"/>, and <xref
+          keyref="attributes-specialization/spectitle"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In a reference topic that discusses related modules, the following markup could be used:</p>
       <codeblock>&lt;section&gt;

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -86,7 +86,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="only-universal">The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attributes defined below.</p>
+          keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>name</xmlatt></dt>

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -28,7 +28,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition for
+          keyref="attributes-linkRelationship"/> (with a narrowed definition for
           <xmlatt>href</xmlatt>, given below), and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -27,7 +27,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition for
           <xmlatt>href</xmlatt>, given below), and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -30,12 +30,12 @@
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/> (with a narrowed definition for
           <xmlatt>href</xmlatt>, given below), and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry id="href">
           <dt><xmlatt>href</xmlatt></dt>
           <dd>Provides a reference to a resource from which the present resource is derived. See
-              <xref href="../attributes/thehrefattribute.dita"/> for detailed information on
+              <xref keyref="attributes-href"/> for detailed information on
             supported values and processing implications. </dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/state.dita
+++ b/specification/langRef/base/state.dita
@@ -11,7 +11,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="universal-outputclass">The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attributes
+          keyref="attributes-universal"/> and the attributes
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/subjectCell.dita
+++ b/specification/langRef/base/subjectCell.dita
@@ -20,7 +20,7 @@ across columns, other than the fact that they apply to the same content.</shortd
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and <xref
+                    keyref="attributes-universal"/> and <xref
                     href="../attributes/commonMapAttributes.dita"/>. This element also uses
                     <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
                     <xref href="../attributes/linkRelationshipAttributes.dita"/>.</p>

--- a/specification/langRef/base/subjectCell.dita
+++ b/specification/langRef/base/subjectCell.dita
@@ -21,9 +21,9 @@ across columns, other than the fact that they apply to the same content.</shortd
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/> and <xref
-                    href="../attributes/commonMapAttributes.dita"/>. This element also uses
+                    keyref="attributes-commonMap"/>. This element also uses
                     <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
-                    <xref href="../attributes/linkRelationshipAttributes.dita"/>.</p>
+                    <xref keyref="attributes-linkRelationship"/>.</p>
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -23,7 +23,7 @@ controlled values.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>. This element also
+          keyref="attributes-universal"/>. This element also
         uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>, and narrowed definitions of
           <xmlatt>collection-type</xmlatt> and <xmlatt>linking</xmlatt> from <xref
           href="../attributes/commonMapAttributes.dita"/>. <dl>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -26,7 +26,7 @@ controlled values.</shortdesc>
           keyref="attributes-universal"/>. This element also
         uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>, and narrowed definitions of
           <xmlatt>collection-type</xmlatt> and <xmlatt>linking</xmlatt> from <xref
-          href="../attributes/commonMapAttributes.dita"/>. <dl>
+          keyref="attributes-commonMap"/>. <dl>
           <dlentry>
             <dt id="collection-type"><xmlatt>collection-type</xmlatt></dt>
             <dd>Collection types describe how links relate to each other. The processing default is

--- a/specification/langRef/base/subjectRole.dita
+++ b/specification/langRef/base/subjectRole.dita
@@ -30,9 +30,9 @@
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
      keyref="attributes-universal"/> and <xref
-     href="../attributes/topicrefElementAttributes.dita"/>. This element also uses
+     keyref="attributes-topicrefElement"/>. This element also uses
      <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from <xref
-     href="../attributes/linkRelationshipAttributes.dita"/>.</p>
+     keyref="attributes-linkRelationship"/>.</p>
   </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/base/subjectRole.dita
+++ b/specification/langRef/base/subjectRole.dita
@@ -29,7 +29,7 @@
   <section id="attributes">
    <title>Attributes</title>
    <p>The following attributes are available on this element: <xref
-     href="../attributes/universalAttributes.dita"/> and <xref
+     keyref="attributes-universal"/> and <xref
      href="../attributes/topicrefElementAttributes.dita"/>. This element also uses
      <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from <xref
      href="../attributes/linkRelationshipAttributes.dita"/>.</p>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -21,11 +21,11 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"/>
+          <xmlatt>id</xmlatt>, given below), <xref keyref="attributes-commonMap"/>
         (with narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>,
-        given below), <xref href="../attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes
+        given below), <xref keyref="attributes-architectural"/>, and the attributes
         defined below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-          <xmlatt>format</xmlatt> from <xref href="../attributes/linkRelationshipAttributes.dita"
+          <xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
         />.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/map-attribute-id">
@@ -45,7 +45,7 @@
         <dlentry>
           <dt><xmlatt>toc</xmlatt></dt>
           <dd>For this element, the default value for <xmlatt>toc</xmlatt> is "no". Otherwise, the
-            definition matches the one found in <xref href="../attributes/commonMapAttributes.dita"
+            definition matches the one found in <xref keyref="attributes-commonMap"
             />.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -20,7 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"/>
         (with narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>,
         given below), <xref href="../attributes/architecturalAttributes.dita#arch-atts"/>, and the attributes

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -52,7 +52,7 @@
                 <section id="attributes">
                         <title>Attributes</title>
                         <p>The following attributes are available on this element: <xref
-                                        href="../attributes/universalAttributes.dita"/>, <xref
+                                        keyref="attributes-universal"/>, <xref
                                         href="../attributes/topicrefElementAttributes.dita"/>, <xref
                                         href="../attributes/linkRelationshipAttributes.dita"/> (with
                                 a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref href="../attributes/thekeysattribute.dita"

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -55,9 +55,9 @@
                                         keyref="attributes-universal"/>, <xref
                                         keyref="attributes-topicrefElement"/>, <xref
                                         keyref="attributes-linkRelationship"/> (with
-                                a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref href="../attributes/thekeysattribute.dita"
+                                a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
-                                        href="../attributes/thekeyrefattribute.dita"
+                                        keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>. This element also
                                 uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>,
                                         <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>,

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -53,8 +53,8 @@
                         <title>Attributes</title>
                         <p>The following attributes are available on this element: <xref
                                         keyref="attributes-universal"/>, <xref
-                                        href="../attributes/topicrefElementAttributes.dita"/>, <xref
-                                        href="../attributes/linkRelationshipAttributes.dita"/> (with
+                                        keyref="attributes-topicrefElement"/>, <xref
+                                        keyref="attributes-linkRelationship"/> (with
                                 a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref href="../attributes/thekeysattribute.dita"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                         href="../attributes/thekeyrefattribute.dita"
@@ -62,7 +62,7 @@
                                 uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>,
                                         <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>,
                                 and <xmlatt>locktitle</xmlatt> from <xref
-                                        href="../attributes/commonMapAttributes.dita"/>. <dl>
+                                        keyref="attributes-commonMap"/>. <dl>
                                         <dlentry
                                                 conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
                                                 <dt/>

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -21,14 +21,14 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>navtitle</xmlatt> and <xmlatt>query</xmlatt>
-        from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
+        from <xref keyref="attributes-topicrefElement"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of
           <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt> (given below), from <xref
-          href="../attributes/commonMapAttributes.dita"/>.</p>
+          keyref="attributes-commonMap"/>.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
           <dt/>

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -20,7 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>navtitle</xmlatt> and <xmlatt>query</xmlatt>
         from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -24,8 +24,8 @@
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>navtitle</xmlatt> and <xmlatt>query</xmlatt>
         from <xref keyref="attributes-topicrefElement"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of
           <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt> (given below), from <xref
           keyref="attributes-commonMap"/>.</p>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -31,9 +31,9 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xmlatt
           rev="errata-01">frame</xmlatt> and <xmlatt>scale</xmlatt> from <xref
-          href="../attributes/displayAttributes.dita"/>, and the attributes defined below. This
+          keyref="attributes-display"/>, and the attributes defined below. This
         element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>rowheader</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
+          <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
       <dl>
         <dlentry id="orient">
           <dt><xmlatt>orient</xmlatt></dt>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -29,7 +29,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xmlatt
+          keyref="attributes-universal"/>, <xmlatt
           rev="errata-01">frame</xmlatt> and <xmlatt>scale</xmlatt> from <xref
           href="../attributes/displayAttributes.dita"/>, and the attributes defined below. This
         element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -8,7 +8,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and
+          keyref="attributes-universal"/> and
           <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -9,6 +9,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and
-          <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
+          <xmlatt>valign</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -17,7 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attribute
+          keyref="attributes-universal"/> and the attribute
         defined below. This element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
           <xmlatt>align</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
       <dl>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -19,7 +19,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and the attribute
         defined below. This element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>align</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
+          <xmlatt>align</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>cols</xmlatt>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -9,7 +9,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and
+          keyref="attributes-universal"/> and
           <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -10,6 +10,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and
-          <xmlatt>valign</xmlatt> from <xref href="../attributes/calsTableAttributes.dita"/>.</p>
+          <xmlatt>valign</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/title.dita
+++ b/specification/langRef/base/title.dita
@@ -26,7 +26,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (without the Metadata attribute group),
           plus <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
-          href="../attributes/metadataAttributes.dita"/>.</p>
+          keyref="attributes-metadata"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
    <codeblock >&lt;topic id="topicid">

--- a/specification/langRef/base/title.dita
+++ b/specification/langRef/base/title.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (without the Metadata attribute group),
+          keyref="attributes-universal"/> (without the Metadata attribute group),
           plus <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
           href="../attributes/metadataAttributes.dita"/>.</p>
     </section>

--- a/specification/langRef/base/titlealts.dita
+++ b/specification/langRef/base/titlealts.dita
@@ -15,7 +15,7 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <xref
-               href="../attributes/universalAttributes.dita"/>.</p>
+               keyref="attributes-universal"/>.</p>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock
 xml:space="preserve">&lt;task id="progexample"&gt;

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -11,7 +11,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and the attributes defined below.</p>
+          keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>tmtype</xmlatt>

--- a/specification/langRef/base/topicCell.dita
+++ b/specification/langRef/base/topicCell.dita
@@ -20,9 +20,9 @@
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/> and <xref
-                    href="../attributes/commonMapAttributes.dita"/>. This element also uses
+                    keyref="attributes-commonMap"/>. This element also uses
                     <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
-                    <xref href="../attributes/linkRelationshipAttributes.dita"/>.</p>
+                    <xref keyref="attributes-linkRelationship"/>.</p>
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/topicCell.dita
+++ b/specification/langRef/base/topicCell.dita
@@ -19,7 +19,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and <xref
+                    keyref="attributes-universal"/> and <xref
                     href="../attributes/commonMapAttributes.dita"/>. This element also uses
                     <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
                     <xref href="../attributes/linkRelationshipAttributes.dita"/>.</p>

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -20,13 +20,13 @@ can identify a single subject. Additional subjects can be specified by nested
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of
           <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt> (given below), from <xref
-          href="../attributes/commonMapAttributes.dita"/>.</p>
+          keyref="attributes-commonMap"/>.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
           <dt/>

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -22,8 +22,8 @@ can identify a single subject. Additional subjects can be specified by nested
           keyref="attributes-universal"/>, <xref
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>. This element also
         uses <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>, and narrowed definitions of
           <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt> (given below), from <xref
           keyref="attributes-commonMap"/>.</p>

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -19,7 +19,7 @@ can identify a single subject. Additional subjects can be specified by nested
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -44,7 +44,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> and <xref
+          keyref="attributes-universal"/> and <xref
           href="../attributes/commonMapAttributes.dita"/> (except for <xmlatt>locktitle</xmlatt>).</p>
       <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
         from <xref href="../attributes/linkRelationshipAttributes.dita"/> are also available.</p>

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -45,9 +45,9 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          href="../attributes/commonMapAttributes.dita"/> (except for <xmlatt>locktitle</xmlatt>).</p>
+          keyref="attributes-commonMap"/> (except for <xmlatt>locktitle</xmlatt>).</p>
       <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
-        from <xref href="../attributes/linkRelationshipAttributes.dita"/> are also available.</p>
+        from <xref keyref="attributes-linkRelationship"/> are also available.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>Each <xmlelement>topicref</xmlelement> element in the following example inherits the
           <xmlatt>audience</xmlatt> and <xmlatt>linking</xmlatt> attributes. In this way the common

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -40,7 +40,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-href="../attributes/universalAttributes.dita"/>, <xref href="../attributes/commonMapAttributes.dita"
+keyref="attributes-universal"/>, <xref href="../attributes/commonMapAttributes.dita"
 /> (except for <xmlatt>locktitle</xmlatt>), and <xmlatt>copy-to</xmlatt> from <xref
 href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>. This element also uses
 the <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes from <xref

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -40,11 +40,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/>, <xref href="../attributes/commonMapAttributes.dita"
+keyref="attributes-universal"/>, <xref keyref="attributes-commonMap"
 /> (except for <xmlatt>locktitle</xmlatt>), and <xmlatt>copy-to</xmlatt> from <xref
-href="../attributes/topicrefElementAttributes.dita#topicref-element-atts"/>. This element also uses
+keyref="attributes-topicrefElement"/>. This element also uses
 the <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes from <xref
-href="../attributes/linkRelationshipAttributes.dita"/>.</p>
+keyref="attributes-linkRelationship"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>Note that in the following example, the first <xmlelement>topichead</xmlelement> element uses a
           <xmlelement>navtitle</xmlelement> element to provide the title, while the second

--- a/specification/langRef/base/topicset.dita
+++ b/specification/langRef/base/topicset.dita
@@ -30,9 +30,9 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below), <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
-          <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"
-        />, <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
+          <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"
+        />, <xref keyref="attributes-topicrefElement"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/topicset.dita
+++ b/specification/langRef/base/topicset.dita
@@ -33,8 +33,8 @@
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"
         />, <xref keyref="attributes-topicrefElement"/>, <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>id</xmlatt>

--- a/specification/langRef/base/topicset.dita
+++ b/specification/langRef/base/topicset.dita
@@ -28,7 +28,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-universal"/> (with a narrowed definition of
           <xmlatt>id</xmlatt>, given below), <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref href="../attributes/commonMapAttributes.dita"

--- a/specification/langRef/base/topicsetref.dita
+++ b/specification/langRef/base/topicsetref.dita
@@ -46,28 +46,28 @@
           <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below),
           <xref keyref="attributes-commonMap"/>, <xref
           keyref="attributes-topicrefElement"/>, <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry>
           <dt id="href-on-topicsetref"><xmlatt>href</xmlatt></dt>
           <dd>A pointer to the <xmlelement>topicset</xmlelement> represented by
               <xmlelement>topicsetref</xmlelement>. See <xref
-              href="../attributes/thehrefattribute.dita"/> for detailed information on syntax.</dd>
+              keyref="attributes-href"/> for detailed information on syntax.</dd>
         </dlentry>
         <dlentry>
           <dt id="format-on-topicsetref"><xmlatt>format</xmlatt></dt>
           <dd>The <xmlatt>format</xmlatt> attribute identifies the format of the resource being
             referenced. For the <xmlelement>topicsetref</xmlelement> element, this attribute
             defaults to "ditamap", because the element typically references a branch of a map. See
-              <xref href="../attributes/theformatattribute.dita"/> for details on other supported
+          <xref keyref="attributes-format"/> for details on other supported
             values.</dd>
         </dlentry>
         <dlentry>
           <dt id="type-on-topicsetref"><xmlatt>type</xmlatt></dt>
           <dd>Describes the target of a reference. For the <xmlelement>topicsetref</xmlelement>
             element, this attribute defaults to "topicset". See <xref
-              href="../attributes/thetypeattribute.dita"/> for detailed information on other
+            keyref="attributes-type"/> for detailed information on other
             supported values and processing implications.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/topicsetref.dita
+++ b/specification/langRef/base/topicsetref.dita
@@ -42,10 +42,10 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
+          keyref="attributes-linkRelationship"/> (with narrowed definitions of
           <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below),
-          <xref href="../attributes/commonMapAttributes.dita"/>, <xref
-          href="../attributes/topicrefElementAttributes.dita"/>, <xref
+          <xref keyref="attributes-commonMap"/>, <xref
+          keyref="attributes-topicrefElement"/>, <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>, and <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/topicsetref.dita
+++ b/specification/langRef/base/topicsetref.dita
@@ -41,7 +41,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with narrowed definitions of
           <xmlatt>href</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt>, given below),
           <xref href="../attributes/commonMapAttributes.dita"/>, <xref

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -28,13 +28,13 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
+          keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>query</xmlatt>
-        from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref
+        from <xref keyref="attributes-topicrefElement"/>, <xref
           href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
           href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
         uses narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>
-        (given below) from <xref href="../attributes/commonMapAttributes.dita"/>.</p>
+        (given below) from <xref keyref="attributes-commonMap"/>.</p>
       <dl>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
           <dt/>

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -27,7 +27,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/linkRelationshipAttributes.dita"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>query</xmlatt>
         from <xref href="../attributes/topicrefElementAttributes.dita"/>, <xref

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -31,8 +31,8 @@
           keyref="attributes-linkRelationship"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xmlatt>query</xmlatt>
         from <xref keyref="attributes-topicrefElement"/>, <xref
-          href="../attributes/thekeyrefattribute.dita"><xmlatt>keyref</xmlatt></xref>, and <xref
-          href="../attributes/thekeysattribute.dita"><xmlatt>keys</xmlatt></xref>. This element also
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>. This element also
         uses narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>
         (given below) from <xref keyref="attributes-commonMap"/>.</p>
       <dl>

--- a/specification/langRef/base/ul.dita
+++ b/specification/langRef/base/ul.dita
@@ -27,8 +27,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref
-          href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
-          href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
+          keyref="attributes-common/compact"/>, and <xref
+          keyref="attributes-specialization/spectitle"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/ul.dita
+++ b/specification/langRef/base/ul.dita
@@ -26,7 +26,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>, <xref
+          keyref="attributes-universal"/>, <xref
           href="../attributes/commonAttributes.dita#common-atts/compact"/>, and <xref
           href="../attributes/specializationAttributes.dita#specialization-atts/spectitle"/>.</p>
     </section>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -28,7 +28,7 @@
       <p>The following attributes are available on this element: <xref
           href="../attributes/idAttributes.dita"/>, <xref
           href="../attributes/metadataAttributes.dita#select-atts"/>, <xref
-          href="../attributes/universalAttributes.dita#univ-atts/class"/>, and the attributes
+          keyref="attributes-universal/class"/>, and the attributes
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -74,7 +74,7 @@
           <dt id="uxatt-on-top"><xmlatt>on-top</xmlatt></dt>
           <dd>Indicates whether the initial z-order of the target help window is on top of all
             windows on the desktop. Allowable values are: "yes", "no", and <xref
-              href="../attributes/ditauseconreftarget.dita">-dita-use-conref-target</xref>. The
+              keyref="attributes-useconreftarget">-dita-use-conref-target</xref>. The
             default value is "no".</dd>
         </dlentry>
         <dlentry>
@@ -106,7 +106,7 @@
         <dlentry>
           <dt id="uxatt-full-screen"><xmlatt>full-screen</xmlatt></dt>
           <dd>Indicates whether the window is initially displayed in a maximized state. Allowable
-            values are: "yes", "no", and <xref href="../attributes/ditauseconreftarget.dita"
+            values are: "yes", "no", and <xref keyref="attributes-useconreftarget"
               >-dita-use-conref-target</xref>. The default value is "no".</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -26,8 +26,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/idAttributes.dita"/>, <xref
-          href="../attributes/metadataAttributes.dita#select-atts"/>, <xref
+          keyref="attributes-id"/>, <xref
+          keyref="attributes-metadata"/>, <xref
           keyref="attributes-universal/class"/>, and the attributes
         defined below.</p>
       <dl>

--- a/specification/langRef/base/vrm.dita
+++ b/specification/langRef/base/vrm.dita
@@ -13,7 +13,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    href="../attributes/universalAttributes.dita"/> and the attributes defined
+                    keyref="attributes-universal"/> and the attributes defined
                 below.</p>
             <dl>
                 <dlentry id="version">

--- a/specification/langRef/base/vrmlist.dita
+++ b/specification/langRef/base/vrmlist.dita
@@ -16,7 +16,7 @@ of products to which the topic applies.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          href="../attributes/universalAttributes.dita"/>.</p>
+          keyref="attributes-universal"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The recent versions of a hypothetical product might be logged by using the
           <xmlelement>vrmlist</xmlelement> markup:</p><codeblock>&lt;prolog&gt;


### PR DESCRIPTION
- Defines keys for each attribute group or individual attribute topic in the current langRef section
- All keys for attribute links begin with `attributes-`, followed by a meaningful token based on either the group name or the single attribute
- Updates all links from topics to use these keys
- Updates relationship tables to use these keys

With this update, the only remaining URI references to attribute definitions are the ones in the TOC that also define the keys (at least for URI references from `@href`, I didn't double check `@conref`).