### PR TITLE
Update examples (phase 2 work)

### DIFF
--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -24,8 +24,8 @@
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-      <p>In the following code sample, the cite element is used to mark up the title of an
-        article.</p><codeblock>&lt;p&gt;The online article <b>&lt;cite&gt;</b>Specialization in the Darwin Information Typing
+      <p>In the following code sample, the <xmlelement>cite</xmlelement> element is used to mark up
+        the title of an article.</p><codeblock>&lt;p&gt;The online article <b>&lt;cite&gt;</b>Specialization in the Darwin Information Typing
 Architecture<b>&lt;/cite&gt;</b> provides a detailed explanation of how to define new
 topic types.&lt;/p&gt;</codeblock>     </example>
 </refbody>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -75,7 +75,7 @@
 Where's the usage information for this section?
 &lt;/draft-comment&gt;</codeblock>
       <p>Processors might render the information from the highlighted attributes at viewing or
-        publishing time. Authors might use the value of the status <xmlatt>attribute</xmlatt> to
+        publishing time. Authors might use the value of the  <xmlatt>status</xmlatt> attribute to
         track the work that remains to be done on a content collection.</p>
     </example>
 </refbody>

--- a/specification/langRef/base/harvested-content-base.dita
+++ b/specification/langRef/base/harvested-content-base.dita
@@ -58,6 +58,11 @@
     The <xmlelement>keywords</xmlelement> element only appears in the
      <xmlelement>topicmeta</xmlelement> or <xmlelement>prolog</xmlelement> elements; it is used to
     specify keywords that apply to the topic.</p>
+      <p>With DITA 1.2, another option for reusable text is the <xref href="text.dita"/> element,
+        which is designed to be free of any extra semantic information. The
+          <xmlelement>text</xmlelement> element is available within
+        <xmlelement>keyword</xmlelement>, and at least one of those elements should be available to
+        allow content reuse in any context.</p>
   </section>
   <section>
    <title><xmlelement>lq</xmlelement></title>

--- a/specification/langRef/base/keyword.dita
+++ b/specification/langRef/base/keyword.dita
@@ -8,17 +8,16 @@
       text.<!--The <xmlelement>keyword</xmlelement> element identifies a keyword or token, such as a single value from an enumerated list, the name of a command or parameter, product name, or a lookup key for a message.--></shortdesc>
 <prolog><metadata>
 <keywords><indexterm>elements<indexterm>body<indexterm><xmlelement>keyword</xmlelement></indexterm></indexterm></indexterm>
+            <keyword>XXX</keyword>
 </keywords>
 </metadata></prolog>
 <refbody>
-      <section id="usage-information">
-         <title>Usage information</title>
-         <p>When used within the <xmlelement>keywords</xmlelement> element, the content of a
-               <xmlelement>keyword</xmlelement> element is considered to be metadata.</p>
-         <!--<p>With DITA 1.2, another option for reusable text is the <xref href="text.dita"/> element, which is designed to be free of any extra semantic information. The <xmlelement>text</xmlelement> element is available within <xmlelement>keyword</xmlelement>, and at least one of those elements should be available to allow content reuse in any context.</p>-->
-      </section>
+      <!--<section id="usage-information"><title>Usage information</title></section>-->
       <section id="processing-expectations">
          <title>Processing expectations</title>
+         <p>When used within the <xmlelement>keywords</xmlelement> element, the content of a
+               <xmlelement>keyword</xmlelement> element is considered to be metadata and should be
+            processed as appropriate for the given output medium.</p>
          <p>Elements that are specialized from the <xmlelement>keyword</xmlelement>element might
             have extended processing, such as specific formatting or automatic indexing. </p>
       </section>
@@ -27,15 +26,26 @@
 <p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples">
+         <title>Example</title>
          <fig>
             <title><xmlelement>keyword</xmlelement> element used to store a product name</title>
-            <p>In the following code sample ...</p>
-            <codeblock>XXX</codeblock>
+            <p>In the following code sample, the <xmlelement>keyword</xmlelement> element holds a
+               product name.</p>
+            <codeblock>&lt;keyword id="acme-bird-feeder">ACME Bird Feeder&lt;/keyword></codeblock>
+            <p>The product name can be referenced using one of the DITA reuse mechanisms: content
+               reference (conref), content key reference (conkeyref), or key reference (keyref).</p>
          </fig>
          <fig>
             <title><xmlelement>keyword</xmlelement> element as metadata</title>
-            <p>In the following code sample ...</p>
-            <codeblock>XXX</codeblock>
+            <p>In the following code sample, "Big data" is specified as metadata that applies to the
+               topic.</p>
+            <codeblock>&lt;prolog>
+  &lt;metadata>
+    &lt;keywords>
+      &lt;keyword>Big data&lt;/keyword>
+    &lt;/keywords>
+  &lt;/metadata>
+&lt;/prolog></codeblock>
          </fig></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -26,9 +26,23 @@
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-            <p>In the following code sample ...</p><codeblock>&lt;p>A great person once said the following thing.
+            <draft-comment author="Kristen J Eberlein" time="05 August 2018">
+                <p>When trying to craft a new example for this element, I realized I don't
+                    understand  what value it provides that is not already available in
+                        <xmlelement>lq</xmlelement>.</p>
+            </draft-comment>
+            <p>In the following code sample, the <xmlelement>longdescref</xmlelement> element
+                references an online version of <cite>As You Like It</cite>.</p>
+            <codeblock>&lt;p>The following is one of the most frequently used quotations from a Shakespearean play:
+  &lt;lq>All the world's a stage, and all the men and women merely players. They have 
+      their exits and their entrances; And one man in his time plays many parts.’
+    &lt;longquoteref href="http://www.example.org/shakespeare/as-you-like-it" scope="external"/>
+  &lt;/lq>
+&lt;/p>
+  </codeblock>
+            <!--<codeblock>&lt;p>A great person once said the following thing.
 &lt;lq>Examples are the key to any
-specification.&lt;longquoteref href="http://www.example.org/quotes" scope="external"/>&lt;/lq>&lt;/p></codeblock></example>
+specification.&lt;longquoteref href="http://www.example.org/quotes" scope="external"/>&lt;/lq>&lt;/p></codeblock>--></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/q.dita
+++ b/specification/langRef/base/q.dita
@@ -19,7 +19,6 @@
       </metadata>
    </prolog>
 <refbody>
-      <!--<section id="usage-information"><title>Usage information</title><p>Authors should not add quote punctuation manually when using the <xmlelement>q</xmlelement> element. Use the long quote element (<xmlelement>lq</xmlelement>) for quotations that should be set off from the surrounding text or that contain multiple paragraphs.</p></section>-->
       <section id="formatting-expectations">
          <title>Formatting expectations</title>
          <p>Processors typically render a quotation inline.</p>
@@ -35,7 +34,11 @@
          <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title>
-         <p>In the following code sample ...</p><codeblock>George said, &lt;q&gt;Disengage the power supply before servicing the unit.&lt;/q&gt;</codeblock></example>
+         <p>In the following code sample, the <xmlelement>q</xmlelement> element contains a
+            quotation. Note that no quotation marks are included; locale-specific quotation marks
+            will be generated during processing.</p><codeblock>&lt;p>
+George said, &lt;q&gt;Disengage the power supply before servicing the unit.&lt;/q&gt;
+&lt;/p></codeblock></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/term.dita
+++ b/specification/langRef/base/term.dita
@@ -23,7 +23,8 @@
          <title>Attributes</title>
          <p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
       </section>
-<example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p&gt;A &lt;term&gt;reference implementation&lt;/term&gt; of DITA implements the standard, 
+<example id="example" otherprops="examples"
+         ><title>Example</title><codeblock>&lt;p&gt;A &lt;term&gt;reference implementation&lt;/term&gt; of DITA implements the standard, 
 fallback behaviors intended for DITA elements.&lt;/p&gt;</codeblock> </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -45,10 +45,10 @@
         </dlentry>
         <dlentry>
           <dt><xmlatt>tmclass</xmlatt></dt>
-          <dd>Classification of the trademark. This <ph>can</ph> be used to differentiate different
-            groupings of trademarks.</dd>
+          <dd>Classification of the trademark. This can be used to differentiate different groupings
+            of trademarks.</dd>
         </dlentry>
       </dl>
-    </section><example id="example" otherprops="examples"><title>Example</title><codeblock xml:space="preserve">&lt;p&gt;The advantages of using &lt;tm trademark="DB2 Universal Database" tmtype="tm"&gt;
+    </section><example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p&gt;The advantages of using &lt;tm trademark="DB2 Universal Database" tmtype="tm"&gt;
 &lt;tm trademark="DB2" tmtype="reg" tmclass="ibm"&gt;DB2&lt;/tm&gt; Universal Database&lt;/tm&gt; are 
 well known.&lt;/p&gt;</codeblock></example></refbody></reference>


### PR DESCRIPTION
* Added examples for <keyword>, <longquoteref>, and <q> topics
* Removed xml:space="preserve on code blocks