### PR TITLE
Rework keydef topic for new template

### DIFF
--- a/specification/common/conref-short-descriptions.dita
+++ b/specification/common/conref-short-descriptions.dita
@@ -29,15 +29,10 @@
   <shortdesc id="i"> Italic text is a way to emphasize the key points in printed text, or when
    quoting a speaker, a way to show which words the speaker stressed.</shortdesc>
   <shortdesc id="image">An image is a reference to artwork that is stored outside of the content. </shortdesc>
-  <shortdesc id="keydef"><draft-comment author="robander">Need to take care when converting this to
-    use natural language; our definition of the "key definition" as an element has to be distinct
-    from our concept of a "key defintion" in the DITA architecture.</draft-comment>The
-    <xmlelement>keydef</xmlelement> element is a convenience element that is used to define keys
-   without any of the other effects that occur when using a <xmlelement>topicref</xmlelement>
-   element: no content is included in output, no title is included in the table of contents, and no
-   linking or other relationships are defined. The <xmlelement>keydef</xmlelement> element is not
-   the only way to define keys; its purpose is to simplify the process by defaulting several
-   attributes to achieve the described behaviors.</shortdesc>
+  <shortdesc id="keydef">The key definition convenience element provides a simple way to define a
+key without making the definition itself a part of rendered content. As with any key definition, the
+resource will still be rendered when the key is
+referenced.<!--The <xmlelement>keydef</xmlelement> element is a convenience element that is used to define keys without any of the other effects that occur when using a <xmlelement>topicref</xmlelement> element: no content is included in output, no title is included in the table of contents, and no linking or other relationships are defined. The <xmlelement>keydef</xmlelement> element is not the only way to define keys; its purpose is to simplify the process by defaulting several attributes to achieve the described behaviors.--></shortdesc>
   <shortdesc id="li">A list item is an item in either an ordered or unordered list.</shortdesc>
   <shortdesc id="linktext">Link text is the label for a link or resource.</shortdesc>
   <shortdesc id="map">A DITA map is the mechanism for aggregating topics. It consists of references

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -17,41 +17,57 @@
     </metadata>
   </prolog>
 <refbody>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ map/topicref mapgroup-d/keydef</p>
-    </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <sectiondiv id="keydef-attributes">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref
-            keyref="attributes-linkRelationship"/> (with a narrowed definition of
-            <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-commonMap"
-          /> (with a narrowed definition of <xmlatt>processing-role</xmlatt>, given below), <xref
-            keyref="attributes-topicrefElement"/>, <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
-          attributes defined below.</p>
-        <dl>
-          <dlentry>
-            <dt><xmlatt>keys</xmlatt>
-              <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
-            <dd>On this element the <xmlatt>keys</xmlatt> attribute is required, because the purpose
-              of the element is to define a key. Otherwise, the attribute is the same as described
-              in <xref keyref="attributes-keys"/>.</dd>
-          </dlentry>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
-            <dt/>
-            <dd/>
-          </dlentry>
-          <dlentry
-            conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
-            <dt/>
-            <dd/>
-          </dlentry>
-        </dl>
-      </sectiondiv>
-    </section>
+<section id="usage-information">
+<title>Usage information</title>
+<p>The <xmlelement>keydef</xmlelement> element is a convenience element, which means that anything
+it does can also be accomplished with a <xmlelement>topicref</xmlelement> element: where
+<xmlelement>keydef</xmlelement> uses defaulted attributes to do things like keeping the definition
+out of a table of contents, a <xmlelement>topicref</xmlelement> element could do the same thing by
+explicitly setting <xmlatt>toc</xmlatt> to "no". These defaulted attributes on
+<xmlelement>keydef</xmlelement> ensure that these simple definitions do not appear in the TOC, do
+not add extra links, and are not rendered as topics unless referenced as part of the normal
+content.</p>
+</section>
+<section id="processing-expectations">
+<title>Processing expectations</title>
+<p>The <xmlelement>keydef</xmlelement> element has several defaulted attribute values that
+processors may want to be aware of; as long as the default values are respected, no additional
+processing expectations exist beyond what those same attributes do for
+<xmlelement>topicref</xmlelement>.</p>
+</section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>keydef</xmlelement> element is specialized from
+<xmlelement>topicref</xmlelement>. It is defined in the mapgroup-domain module.</p>
+</section>
+<section id="attributes">
+<title>Attributes</title>
+<sectiondiv id="keydef-attributes">
+<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>,
+<xref keyref="attributes-linkRelationship"/> (with a narrowed definition of <xmlatt>href</xmlatt>,
+given below), <xref keyref="attributes-commonMap"/> (with a narrowed definition of
+<xmlatt>processing-role</xmlatt>, given below), <xref keyref="attributes-topicrefElement"/>, <xref
+keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
+<dl>
+<dlentry>
+<dt><xmlatt>keys</xmlatt>
+<ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+<dd>On this element the <xmlatt>keys</xmlatt> attribute is required, because the purpose of the
+element is to define a key. Otherwise, the attribute is the same as described in <xref
+keyref="attributes-keys"/>.</dd>
+</dlentry>
+<dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+<dt/>
+<dd/>
+</dlentry>
+<dlentry
+conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
+<dt/>
+<dd/>
+</dlentry>
+</dl>
+</sectiondiv>
+</section>
 <example id="example" otherprops="examples"><title>Example</title>
 <p>In the following code sample, several keys are defined that might be used as part of publishing
 this DITA specification.</p>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Reworks the `keydef` element reference topic using the new DITA 2.0 template.