### PR TITLE
Changing "Example" to "Examples" in topics with multiple examples

### DIFF
--- a/specification/langRef/base/data.dita
+++ b/specification/langRef/base/data.dita
@@ -45,7 +45,7 @@ other tools or processors will ignore the specialized <xmlelement>data</xmleleme
       />
     </section>
     <example id="example" otherprops="examples">
-      <title>Example</title>
+      <title>Examples</title>
       <fig>
 <title>Using the <xmlatt>name</xmlatt> attribute on unspecialized <xmlelement>data</xmlelement>
 elements</title>

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -68,7 +68,7 @@ conref="../../common/conref-attribute.dita#conref-attribute/processing-role-defa
 </dl>
 </sectiondiv>
 </section>
-<example id="example" otherprops="examples"><title>Example</title>
+<example id="example" otherprops="examples"><title>Examples</title>
 <p>In the following code sample, several keys are defined that might be used as part of publishing
 this DITA specification.</p>
 <ul id="ul_gzs_1wc_t2b">

--- a/specification/langRef/base/linktext.dita
+++ b/specification/langRef/base/linktext.dita
@@ -28,7 +28,7 @@ specified topic.</p>
       <title>Attributes</title>
       <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
     </section>
-<example id="example" otherprops="examples"><title>Example</title>
+<example id="example" otherprops="examples"><title>Examples</title>
 <fig id="fig_jjs_czc_t2b"><title>Link text with key definitions</title><p>See <xref
 href="keydef.dita"/> for an example of <xmlelement>linktext</xmlelement> used with key
 definitions.</p></fig>

--- a/specification/langRef/base/map.dita
+++ b/specification/langRef/base/map.dita
@@ -44,12 +44,7 @@
       <title>Attributes</title>
       <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/all-map-attributes"/>
     </section>
-<example id="example" otherprops="examples"><title>Example</title>
-      <draft-comment author="Kristen J Eberlein" time="20 June 2018">
-        <p>The example WAS the same as that used in the <xmlelement>topicref</xmlelement> topic.
-          (Robert has now changed it.</p>
-        <p>What do we really need to illustrate here?</p>
-      </draft-comment><p>In this example, there are six <xmlelement>topicref</xmlelement> elements. They are nested and
+<example id="example" otherprops="examples"><title>Example</title><p>In this example, there are six <xmlelement>topicref</xmlelement> elements. They are nested and
         have a hierarchical relationship. The file <filepath>bats.dita</filepath> is the parent
         topic and the other topics are its children. The hierarchy could be used to generate a PDF,
         a navigation pane in an information center, a summary of the topics, or related links


### PR DESCRIPTION
Changing "Example" to "Examples" in topics with multiple examples