### PR TITLE
Moving "Formatting expectations" content

### DIFF
--- a/specification/common/conref-formatting-expectations.dita
+++ b/specification/common/conref-formatting-expectations.dita
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
+<reference id="conref-formatting-expectations">
+    <title>Formatting expectations reused with LwDITA</title>
+    <refbody>
+        <section id="b">
+            <title>Formatting expectations</title>
+            <p>Processors typically apply bold highlighting to the contents of the
+                    <xmlelement>b</xmlelement> element.</p>
+        </section>
+        <section id="dl">
+            <title>Formatting expectations</title>
+            <p>Processors typically use the following conventions:</p>
+            <ul>
+                <li>The term (<xmlelement>dt</xmlelement>) is usually against the starting margin of
+                    the page or column.</li>
+                <li>The description or definition (<xmlelement>dd</xmlelement>) is either indented
+                    and on the next line or on the same line after the term.</li>
+                <li>The <xmlelement>dlhead</xmlelement> looks like a table heading row.</li>
+            </ul>
+        </section>
+        <section id="i">
+            <title>Formatting expectations</title>
+            <p>In Western languages, processors typically apply italic highlighting to the contents
+                of the <xmlelement>i</xmlelement> element. Owing to the influence from calligraphy,
+                italics normally slant slightly to the right. </p>
+        </section>
+        <section id="li">
+            <title>Formatting expectations</title>
+            <p>Processors typically use the following conventions for displaying the contents of
+                    <xmlelement>li</xmlelement> elements:</p>
+            <ul>
+                <li>In ordered lists, list items are indicated by numbers or alphabetical
+                    characters.</li>
+                <li>In unordered lists, list items are indicated by bullets or dashes.</li>
+            </ul>
+        </section>
+        <section id="note">
+            <title>Formatting expectations</title>
+            <p>Processors typically render a label for notes. The content of the label depends on
+                the values of the <xmlatt>type</xmlatt> attribute.</p>
+            <p>A note typically is formatted in a way that stands out from the surrounding
+                content.</p>
+        </section>
+        <section id="pre">
+            <title>Formatting expectations</title>
+            <p>Processors typically render the content of a <xmlelement>pre</xmlelement> element in
+                a monospaced font.</p>
+        </section>
+        <section id="sub">
+            <title>Formatting expectations</title>
+            <p>Processors typically render the contents of the <xmlelement>sub</xmlelement> element
+                lower in relationship to the surrounding text. Subscripted text often is a smaller
+                font than the surrounding text.</p>
+        </section>
+        <section id="sup">
+            <title>Formatting expectations</title>
+            <p>Processors typically render the contents of the <xmlelement>sup</xmlelement> element
+                higher in relationship to the surrounding text. Superscript text often is a smaller
+                font than the surrounding text.</p>
+        </section>
+        <section id="u">
+            <title>Formatting expectations</title>
+            <p>Processors typically apply underlining to the contents of the
+                    <xmlelement>u</xmlelement> element.</p>
+        </section>
+    </refbody>
+</reference>

--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -4,4 +4,5 @@
     <title>Key definitions: Library topics</title>
     <keydef keys="library-short-descriptions" href="conref-short-descriptions.dita"/>
     <keydef keys="library-processing-expectations" href="conref-processing-expectations.dita"/>
+    <keydef href="conref-formatting-expectations.dita" keys="library-formatting-expectations"/>
 </map>

--- a/specification/langRef/base/b.dita
+++ b/specification/langRef/base/b.dita
@@ -9,11 +9,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-  <section id="formatting-expectations">
-   <title>Formatting expectations</title>
-   <p>Processors typically apply bold highlighting to the contents of the <xmlelement>b</xmlelement>
-        element.</p>
-  </section>
+    <section conkeyref="library-formatting-expectations/b"><title/><p/></section>
   <section id="specialization-hierarchy">
    <title>Specialization hierarchy</title>
    <p>The <xmlelement>b</xmlelement> element is specialized from <xmlelement>ph</xmlelement>. It is

--- a/specification/langRef/base/dl.dita
+++ b/specification/langRef/base/dl.dita
@@ -16,17 +16,7 @@
   </metadata>
  </prolog>
 <refbody>
-  <section id="formatting-expectations">
-   <title>Formatting expectations</title>
-   <p>Processors typically use the following conventions:</p>
-   <ul>
-    <li>The term (<xmlelement>dt</xmlelement>) is usually against the starting margin of the page or
-column.</li>
-    <li>The description or definition (<xmlelement>dd</xmlelement>) is either indented and on the
-next line or on the same line after the term.</li>
-    <li>The <xmlelement>dlhead</xmlelement> looks like a table heading row.</li>
-   </ul>
-  </section>
+    <section conkeyref="library-formatting-expectations/dl"><title/><p/></section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"

--- a/specification/langRef/base/i.dita
+++ b/specification/langRef/base/i.dita
@@ -10,12 +10,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-        <section id="formatting-expectations">
-            <title>Formatting expectations</title>
-            <p>In Western languages, processors typically apply italic highlighting to the contents
-                of the <xmlelement>i</xmlelement> element. Owing to the influence from calligraphy,
-                italics normally slant slightly to the right. </p>
-        </section>
+        <section conkeyref="library-formatting-expectations/i"><title/><p/></section>
         <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>i</xmlelement> element is specialized from

--- a/specification/langRef/base/li.dita
+++ b/specification/langRef/base/li.dita
@@ -15,16 +15,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-        <section id="formatting-expecttions">
-            <title>Formatting expectations</title>
-            <p>Processors typically use the following conventions for displaying the contents of
-                    <xmlelement>li</xmlelement> elements:</p>
-            <ul>
-                <li>In ordered lists, list items are indicated by numbers or alphabetical
-                    characters.</li>
-                <li>In unordered lists, list items are indicated by bullets or dashes.</li>
-            </ul>
-        </section>
+        <section conkeyref="library-formatting-expectations/li"><title/><p/></section>
         <section id="attributes">
             <title>Attributes</title>
         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>

--- a/specification/langRef/base/note.dita
+++ b/specification/langRef/base/note.dita
@@ -17,13 +17,7 @@
                 etc.) can be indicated through values selected on the <xmlatt>type</xmlatt>
                 attribute.</p>
         </section>
-        <section id="formatting-expectations">
-            <title>Formatting expectations</title>
-            <p>Processors typically render a label for notes. The content of the label depends on
-                the values of the <xmlatt>type</xmlatt> attribute.</p>
-            <p>A note typically is formatted in a way that stands out from the surrounding
-                content.</p>
-        </section>
+        <section conkeyref="library-formatting-expectations/note"><title/><p/></section>
         <section id="attributes">
             <title>Attributes</title>
             <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/note-attributes"

--- a/specification/langRef/base/pre.dita
+++ b/specification/langRef/base/pre.dita
@@ -15,11 +15,7 @@
 </metadata></prolog>
 <refbody>
       <!--<section id="usage-information"><title>Usage information</title><p>Authors should not use the <xmlelement>pre</xmlelement> when a more semantically-specific element is available, such as <xmlelement>codeblock</xmlelement>.</p></section>-->
-      <section id="formatting-expecttions">
-         <title>Formatting expectations</title>
-         <p>Processors typically render the content of a <xmlelement>pre</xmlelement> element in a
-            monospaced font.</p>
-      </section>
+      <section conkeyref="library-formatting-expectations/pre"/>
       <section conkeyref="library-processing-expectations/pre"/>
       <section id="attributes">
          <title>Attributes</title>

--- a/specification/langRef/base/sub.dita
+++ b/specification/langRef/base/sub.dita
@@ -11,12 +11,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-        <section id="formatting-expectations">
-            <title>Formatting expectations</title>
-            <p>Processors typically render the contents of the <xmlelement>sub</xmlelement> element
-                lower in relationship to the surrounding text. Subscripted text often is a smaller
-                font than the surrounding text.</p>
-        </section>
+        <section conkeyref="library-formatting-expectations/sub"><title/><p/></section>
         <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>sub</xmlelement> element is specialized from

--- a/specification/langRef/base/sup.dita
+++ b/specification/langRef/base/sup.dita
@@ -11,12 +11,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-        <section id="formatting-expectations">
-            <title>Formatting expectations</title>
-            <p>Processors typically render the contents of the <xmlelement>sup</xmlelement> element
-                higher in relationship to the surrounding text. Superscript text often is a smaller
-                font than the surrounding text.</p>
-        </section>
+        <section conkeyref="library-formatting-expectations/sup"><title/><p/></section>
 <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>sup</xmlelement> element is specialized from

--- a/specification/langRef/base/u.dita
+++ b/specification/langRef/base/u.dita
@@ -9,11 +9,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-      <section id="formatting-expectations">
-         <title>Formatting expectations</title>
-         <p>Processors typically apply underlining to the contents of the <xmlelement>u</xmlelement>
-            element.</p>
-      </section>
+      <section conkeyref="library-formatting-expectations/u"><title/><p/></section>
       <section id="specialization-hierarchy">
          <title>Specialization hierarchy</title>
          <p>The <xmlelement>u</xmlelement> element is specialized from <xmlelement>ph</xmlelement>.


### PR DESCRIPTION
Moving "Formatting expectations" content for intersection topics into a reuse topic