### PR TITLE
Changing "Processing expectations" to "Rendering expectations"

### DIFF
--- a/specification/common/conref-rendering-expectations.dita
+++ b/specification/common/conref-rendering-expectations.dita
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
-<reference id="conref-processing-expectations">
-    <title>Processing expectations for element-reference topics</title>
-    <shortdesc>This topic contains "Processing expectations" sections for certain element-reference
+<reference id="conref-rendering-expectations">
+    <title>Rendering expectations for element-reference topics</title>
+    <shortdesc>This topic contains "Rendering expectations" sections for certain element-reference
         topics. These element-reference topics are for elements that exist in both DITA and
         LwDITA.</shortdesc>
     <refbody>
         <section id="data">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>By default, processors <term outputclass="RFC-2119">SHOULD</term> treat
                     <xmlelement>data</xmlelement> elements as unknown metadata; the contents of
                     <xmlelement>data</xmlelement> elements <term outputclass="RFC-2119">SHOULD
@@ -17,7 +17,7 @@
                 specialized rendering.</p>
         </section>
         <section id="desc">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>When used in conjunction with <xmlelement>fig</xmlelement>
                 <ph props="full-dita"> or <xmlelement>table</xmlelement>
                 </ph>elements, processors <term outputclass="RFC-2119">SHOULD</term> consider the
@@ -29,7 +29,7 @@
                     <xmlelement>desc</xmlelement> elements as hover help.</p>
         </section>
         <section id="fn">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>The two footnote types typically produce different types of output:</p>
             <dl>
                 <dlentry>
@@ -61,7 +61,7 @@
                 for certain types of publications.</p>
         </section>
         <section id="image">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>The image addressed by the <xmlatt>keyref</xmlatt> or <xmlatt>href</xmlatt> attribute
                 on <xmlelement>image</xmlelement> typically is rendered in the main flow of the
                 content.</p>
@@ -81,7 +81,7 @@
             </ul>
         </section>
         <section id="map">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>When rendering a map, processors might make use of the relationships defined in the
                 map to create a Table of Contents (TOC), aggregate topics into a PDF document, or
                 create links between topics in the output.</p>
@@ -92,18 +92,18 @@
                 submap are aggregated into a larger publication.</p>
         </section>
         <section id="pre">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve line the breaks and
                 spaces that are present in a <xmlelement>pre</xmlelement> element.</p>
         </section>
         <section id="section">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>Processors <term outputclass="RFC-2119">SHOULD</term> treat the presence of more than
                 one <xmlelement>title</xmlelement> element in a <xmlelement>section</xmlelement>
                 element as an error.</p>
         </section>
         <section id="shortdesc">
-            <title>Processing expectations</title>
+            <title>Rendering expectations</title>
             <p>Processors <term outputclass="RFC-2119">SHOULD</term> render the content of the
                     <xmlelement>shortdesc</xmlelement> element as the initial paragraph of the
                 topic.</p>

--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -3,6 +3,6 @@
 <map>
     <title>Key definitions: Library topics</title>
     <keydef keys="library-short-descriptions" href="conref-short-descriptions.dita"/>
-    <keydef href="conref-usage-information.dita" keys="library-usage-information"/>
-    <keydef keys="library-processing-expectations" href="library-processing-expectations.dita"/>
+    <keydef keys="library-usage-information" href="conref-usage-information.dita"/>
+    <keydef keys="library-rendering-expectations" href="conref-rendering-expectations.dita"/>
 </map>

--- a/specification/langRef/base/data.dita
+++ b/specification/langRef/base/data.dita
@@ -11,7 +11,7 @@
 </metadata></prolog>
 <refbody>
     <section conkeyref="library-usage-information/data"><title/><p/></section>
-    <section conkeyref="library-processing-expectations/data"><title/><p/></section>
+    <section conkeyref="library-rendering-expectations/data"><title/><p/></section>
     <section id="attributes">
       <title>Attributes</title>
       <p

--- a/specification/langRef/base/desc.dita
+++ b/specification/langRef/base/desc.dita
@@ -14,7 +14,7 @@
 </metadata></prolog>
 <refbody>
     <section conkeyref="library-usage-information/desc"><title/><p/></section>
-    <section conkeyref="library-processing-expectations/desc"/>
+    <section conkeyref="library-rendering-expectations/desc"/>
     <section id="attributes">
       <title>Attributes</title>
     <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>

--- a/specification/langRef/base/fn.dita
+++ b/specification/langRef/base/fn.dita
@@ -10,7 +10,7 @@
 </metadata></prolog>
 <refbody>
     <section conkeyref="library-usage-information/fn"><title/><p/></section>
-    <section conkeyref="library-processing-expectations/fn"/>
+    <section conkeyref="library-rendering-expectations/fn"/>
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/fn-attributes"/>

--- a/specification/langRef/base/image.dita
+++ b/specification/langRef/base/image.dita
@@ -13,7 +13,7 @@
 </metadata></prolog>
 <refbody>
     <!--<section id="usage-information"><title>Usage information</title></section>-->
-    <section conkeyref="library-processing-expectations/image"/>
+    <section conkeyref="library-rendering-expectations/image"/>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref

--- a/specification/langRef/base/map.dita
+++ b/specification/langRef/base/map.dita
@@ -38,7 +38,7 @@
         </dlentry>
       </dl>
     </section>
-    <section conkeyref="library-processing-expectations/map"/>
+    <section conkeyref="library-rendering-expectations/map"/>
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/all-map-attributes"/>

--- a/specification/langRef/base/pre.dita
+++ b/specification/langRef/base/pre.dita
@@ -12,7 +12,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-      <section conkeyref="library-processing-expectations/pre"/>
+      <section conkeyref="library-rendering-expectations/pre"/>
       <section id="attributes">
          <title>Attributes</title>
          <p conref="../../common/conref-attribute.dita#conref-attribute/pre-attributes"/>

--- a/specification/langRef/base/section.dita
+++ b/specification/langRef/base/section.dita
@@ -29,7 +29,7 @@
         <p>Tom: Is the above true about RNG?</p>
       </draft-comment>
     </section>
-    <section conkeyref="library-processing-expectations/section"/>
+    <section conkeyref="library-rendering-expectations/section"/>
     <section id="attributes">
       <title>Attributes</title>
 <p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle"/>

--- a/specification/langRef/base/shortdesc.dita
+++ b/specification/langRef/base/shortdesc.dita
@@ -34,7 +34,7 @@
       <p>When a <xmlelement>shortdesc</xmlelement> element applies to an entire DITA map, it serves
         as description only.</p>
     </section>
-    <section conkeyref="library-processing-expectations/shortdesc"/>
+    <section conkeyref="library-rendering-expectations/shortdesc"/>
     <section id="attributes">
       <title>Attributes</title>
     <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>


### PR DESCRIPTION
Changing "Processing expectations" to "Rendering expectations" in topics that exist in both DITA and LwDITA