### PR TITLE
Remove extra declaration of outputclass

### DIFF
--- a/doctypes/dtd/base/dtd/topic.mod
+++ b/doctypes/dtd/base/dtd/topic.mod
@@ -331,10 +331,7 @@
                          %ph;)*"
 >
 <!ENTITY % searchtitle.attributes
-              "outputclass
-                          CDATA
-                                    #IMPLIED
-               %univ-atts;"
+              "%univ-atts;"
 >
 <!ELEMENT  searchtitle %searchtitle.content;>
 <!ATTLIST  searchtitle %searchtitle.attributes;>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Somehow missed this one when removing independent declarations of `@outputclass`. It is now part of `univ-atts`, so the search title right now defines it twice - this one was either missed or accidentally added back when removing the extra definitions from other elements.