### PR TITLE
Fix Java version for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 env:
   global:
   - DITA_OT_VERSION=3.2.1


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fix failing Travis builds by switching Java version.