### PR TITLE
Declare attribute extensions in domains att

### DIFF
--- a/doctypes/dtd/base/basemap.dtd
+++ b/doctypes/dtd/base/basemap.dtd
@@ -154,7 +154,11 @@
 
 <!ENTITY included-domains
                           "&mapgroup-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &ditavalref-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/base/basetopic.dtd
+++ b/doctypes/dtd/base/basetopic.dtd
@@ -150,7 +150,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY included-domains
-                          "&deliveryTargetAtt-d-att;
+                          "&audienceAtt-d-att;
+                           &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &hazard-d-att;
                            &hi-d-att;
                            &media-d-att;


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

The 4 filter attributes that we moved to domains were not declared in the `@domains` attribute -- oversight in the update for that proposal.