### PR TITLE
Fix catalog entry for classification domain

### DIFF
--- a/doctypes/rng/subjectScheme/catalog.xml
+++ b/doctypes/rng/subjectScheme/catalog.xml
@@ -3,9 +3,9 @@
 <!--DITA Subject Classification Domain-->
 
    <group><!-- System ID (URL) catalog entries -->
-      <system systemId="urn:oasis:tc:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"
+      <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"
               uri="classifyDomain.rng"/>
-<!--      <system systemId="urn:oasis:tc:tc:dita:spec:classification:rng:classifyDomain.rng"
+<!--      <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng"
               uri="classifyDomain.rng"/>
 -->      <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:subjectScheme.rng:2.0"
               uri="subjectScheme.rng"/>
@@ -17,9 +17,9 @@
               uri="subjectSchemeMod.rng"/>
 -->   </group>
    <group><!-- Public ID (URN) catalog entries -->
-      <uri name="urn:oasis:tc:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"
+      <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"
            uri="classifyDomain.rng"/>
-<!--      <uri name="urn:oasis:tc:tc:dita:spec:classification:rng:classifyDomain.rng"
+<!--      <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng"
            uri="classifyDomain.rng"/>
 -->      <uri name="urn:oasis:names:tc:dita:spec:classification:rng:subjectScheme.rng:2.0"
            uri="subjectScheme.rng"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This was fixed in 1.3 in errata but 2.0 catalog picked up the errata version rather than the fixed version. Missed because no shell in the base refers to this domain.