### PR TITLE
Add outputclass to ditaval #252

### DIFF
--- a/doctypes/dtd/ditaval/ditaval.dtd
+++ b/doctypes/dtd/ditaval/ditaval.dtd
@@ -53,6 +53,7 @@
   att       CDATA       #IMPLIED
   val       CDATA       #IMPLIED
   action    (flag|include|exclude|passthrough)  #REQUIRED
+  outputclass CDATA     #IMPLIED
   color     CDATA       #IMPLIED
   backcolor CDATA       #IMPLIED
   style     NMTOKENS    #IMPLIED  
@@ -76,6 +77,7 @@
 <!ATTLIST revprop
   val       CDATA       #IMPLIED
   action    (include|passthrough|flag)  #REQUIRED
+  outputclass CDATA     #IMPLIED
   changebar CDATA       #IMPLIED
   color     CDATA       #IMPLIED
   backcolor CDATA       #IMPLIED

--- a/doctypes/rng/ditaval/ditaval.rng
+++ b/doctypes/rng/ditaval/ditaval.rng
@@ -127,6 +127,9 @@ ORIGINAL CREATION DATE: 2005
       </choice>
     </attribute>
     <optional>
+      <attribute name="outputclass"/>
+    </optional>
+    <optional>
       <attribute name="color"/>
     </optional>
     <optional>
@@ -199,6 +202,9 @@ ORIGINAL CREATION DATE: 2005
         <value>flag</value>
       </choice>
     </attribute>
+    <optional>
+      <attribute name="outputclass"/>
+    </optional>
     <optional>
       <attribute name="changebar"/>
     </optional>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -769,6 +769,16 @@ keyref="attributes-universal"/> (with a narrowed definition of
                         <section id="section-8">
                                 <title>DITAVAL related common attributes</title>
                                 <dl>
+<dlentry id="ditaval-outputclass">
+<dt><xmlatt>outputclass</xmlatt></dt>
+<dd>If flag has been set, treat the flagged element as if the full <xmlatt>outputclass</xmlatt>
+value in the DITAVAL was specified on that element's <xmlatt>outputclass</xmlatt> attribute. If two
+or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same element, treat the
+flagged element as if each value was specified on that element's <xmlatt>outputclass</xmlatt>
+attribute; in that case, the order of those DITAVAL-based tokens is undefined. If the flagged
+element already specifies <xmlatt>outputclass</xmlatt>, treat the flagged element as if all
+DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</dd>
+</dlentry>
                                         <dlentry id="ditaval-color">
                                                 <dt><xmlatt>color</xmlatt></dt>
                                                 <dd>If flag has been set, the color to use to flag

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -70,7 +70,7 @@ the attribute, to take an action on. The identified attribute is a conditional-p
         </dlentry>
         <dlentry>
           <dt><xmlatt>action</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+<ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
           <dd>Specifies the action to be taken. Allowable values are:<dl>
               <dlentry>
                 <dt>include</dt>
@@ -98,6 +98,10 @@ the attribute, to take an action on. The identified attribute is a conditional-p
               </dlentry>
             </dl></dd>
         </dlentry>
+<dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-outputclass">
+<dt/>
+<dd/>
+</dlentry>
         <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-color">
           <dt/>
           <dd/>

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -87,6 +87,10 @@
                             according to the changebar support of the target output format. If flag
                             has not been set, this attribute is ignored.</dd>
                     </dlentry>
+<dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-outputclass">
+<dt/>
+<dd/>
+</dlentry>
                     <dlentry
                         conref="../../common/conref-attribute.dita#conref-attribute/ditaval-color">
                         <dt/>


### PR DESCRIPTION
Implements #252, adding `@outputclass` to DITAVAL elements.