### PR TITLE
Remove lockmeta attribute #278

### DIFF
--- a/doctypes/dtd/base/ditavalrefDomain.mod
+++ b/doctypes/dtd/base/ditavalrefDomain.mod
@@ -82,12 +82,7 @@
                           (%dvrKeyscopeSuffix;)?))"
 >
 <!ENTITY % ditavalmeta.attributes
-              "lockmeta
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               %ditavalref-univ-atts;"
+              "%ditavalref-univ-atts;"
 >
 <!ELEMENT  ditavalmeta %ditavalmeta.content;>
 <!ATTLIST  ditavalmeta %ditavalmeta.attributes;>

--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -605,12 +605,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA Map//EN"
                           %foreign.unknown.incl;)*)"
 >
 <!ENTITY % topicmeta.attributes
-              "lockmeta
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               %univ-atts;"
+              "%univ-atts;"
 >
 <!ELEMENT  topicmeta %topicmeta.content;>
 <!ATTLIST  topicmeta %topicmeta.attributes;>

--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -564,12 +564,7 @@
                          (%shortdesc;)?)"
 >
 <!ENTITY % subjectHeadMeta.attributes
-              "lockmeta
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               %univ-atts;"
+              "%univ-atts;"
 >
 <!ELEMENT  subjectHeadMeta %subjectHeadMeta.content;>
 <!ATTLIST  subjectHeadMeta %subjectHeadMeta.attributes;>

--- a/doctypes/rng/base/ditavalrefDomain.rng
+++ b/doctypes/rng/base/ditavalrefDomain.rng
@@ -198,15 +198,6 @@ ORIGINAL CREATION DATE:
       </group>
     </define>
     <define name="ditavalmeta.attributes">
-      <optional>
-        <attribute name="lockmeta">
-          <choice>
-            <value>no</value>
-            <value>yes</value>
-            <value>-dita-use-conref-target</value>
-          </choice>
-        </attribute>
-      </optional>
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="ditavalmeta.element">

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -933,15 +933,6 @@ ORIGINAL CREATION DATE:
         </zeroOrMore>
       </define>
       <define name="topicmeta.attributes">
-        <optional>
-          <attribute name="lockmeta">
-            <choice>
-              <value>no</value>
-              <value>yes</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="topicmeta.element">

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -882,15 +882,6 @@ ORIGINAL CREATION DATE:
         </optional>
       </define>
       <define name="subjectHeadMeta.attributes">
-        <optional>
-          <attribute name="lockmeta">
-            <choice>
-              <value>no</value>
-              <value>yes</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="subjectHeadMeta.element">

--- a/specification/archSpec/base/metadata-in-maps-and-topics.dita
+++ b/specification/archSpec/base/metadata-in-maps-and-topics.dita
@@ -2,10 +2,9 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="metadata-in-maps-and-topics" xml:lang="en-us"><title>Metadata in maps and topics</title>
   <shortdesc>Information about topics can be specified as metadata on the map, as attributes on the
-      <xmlelement>topicref</xmlelement> element, or as metadata attributes or elements in the topic
-    itself. By default, metadata in the map supplements or overrides metadata that is specified at
-    the topic level, unless the <xmlatt>lockmeta</xmlatt> attribute of the
-      <xmlelement>topicmeta</xmlelement> element is set to "no".</shortdesc><conbody>
+<xmlelement>topicref</xmlelement> element, or as metadata attributes or elements in the topic
+itself. By default, metadata in the map supplements or overrides metadata that is specified at the
+topic level.</shortdesc><conbody>
     <dl>
       <dlentry>
         <dt>DITA map: Metadata elements</dt>
@@ -38,10 +37,8 @@
       </dlentry>
     </dl>
     <p> When the same metadata element or attribute is specified in both a map and a topic, by
-      default the value in the map takes precedence; the assumption here is that the author of the
-      map has more knowledge of the reusing context than the author of the topic. The
-        <xmlatt>lockmeta</xmlatt> attribute on the <xmlelement>topicmeta</xmlelement> element
-      controls whether map-specified values override values in the referenced topic.</p>
+default the value in the map takes precedence; the assumption here is that the author of the map has
+more knowledge of the reusing context than the author of the topic.</p>
     <p>The <xmlelement>navtitle</xmlelement> element is an exception to the rule of how metadata
       specified by the <xmlelement>topicmeta</xmlelement> element cascades. The content of the
         <xmlelement>navtitle</xmlelement> element is used as a navigation title only if the

--- a/specification/archSpec/base/processing-key-references-general.dita
+++ b/specification/archSpec/base/processing-key-references-general.dita
@@ -19,13 +19,11 @@
         <section id="combining-attributes">
             <title>Determining effective attributes on the key-referencing element</title>
             <p>The attributes that are common to the key-defining element and the key-referencing
-                element, other than the <xmlatt>keys</xmlatt>,<ph>
-                    <xmlatt>processing-role</xmlatt>,</ph> and <xmlatt>id</xmlatt> attributes, are
-                combined as for content references, including the special processing for the
-                    <xmlatt>xml:lang</xmlatt>, <xmlatt>dir</xmlatt>, and <xmlatt>translate</xmlatt>
-                attributes. There is no special processing associated with either the
-                    <xmlatt>locktitle</xmlatt> or the <xmlatt>lockmeta</xmlatt> attributes when
-                attributes are combined.</p>
+element, other than the <xmlatt>keys</xmlatt>,<ph>
+<xmlatt>processing-role</xmlatt>,</ph> and <xmlatt>id</xmlatt> attributes, are combined as for
+content references, including the special processing for the <xmlatt>xml:lang</xmlatt>,
+<xmlatt>dir</xmlatt>, and <xmlatt>translate</xmlatt> attributes. There is no special processing
+associated with the <xmlatt>locktitle</xmlatt> attribute when attributes are combined.</p>
         </section>
         <section id="keys-and-condproc">
             <title>Keys and conditional processing</title>

--- a/specification/archSpec/base/processing-keyref-on-topicref.dita
+++ b/specification/archSpec/base/processing-keyref-on-topicref.dita
@@ -30,9 +30,8 @@
                 <dt>Combining metadata</dt>
                 <dd>
                     <p>Content from a key-defining element cascades to the key-referencing element
-                        following the rules for combining metadata between maps and other maps and
-                        between maps and topics. The <xmlatt>lockmeta</xmlatt> attribute is honored
-                        when metadata content is combined.</p>
+following the rules for combining metadata between maps and other maps and between maps and
+topics.</p>
                     <p>The combined attributes and content cascade from one map to another or from a
                         map to a topic, but this is controlled by existing rules for cascading,
                         which are not affected by the use of key references.</p>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -384,22 +384,7 @@ of map.-->
                                 </dl>
                         </sectiondiv><sectiondiv id="standard-topicmeta-attributes">
                                 <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"
-                                        /> and the attribute defined below.</p>
-                                <dl>
-                                        <dlentry>
-                                                <dt><xmlatt>lockmeta</xmlatt></dt>
-                                                <dd >
-                                                  <p>Determines whether the metadata that is
-                                                  specified in the map supplements or overrides the
-                                                  metadata that is specified in the topic. When the
-                                                  <xmlatt>lockmeta</xmlatt> attribute is set to
-                                                  "yes", the topic metadata is overriden. Allowable
-                                                  values are "yes", "no", and <xref
-                                                  keyref="attributes-useconreftarget"/>.</p>
-                                                </dd>
-                                        </dlentry>
-                                </dl>
+                                                keyref="attributes-universal"/>.</p>
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>, also <coords> equivalents in L&T domain-->
                                 <p>The following attributes are available on this element: <xref

--- a/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
@@ -27,19 +27,7 @@
       <title>Attributes</title>
       <div platform="dita">
         <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and the attribute defined below.</p>
-        <dl>
-          <dlentry>
-            <dt><xmlatt>lockmeta</xmlatt></dt>
-            <dd>
-              <p>Specifies whether the map metadata supplements or overrides the metadata that is
-                specified in the topic. When the <xmlatt>lockmeta</xmlatt> attribute is set to
-                  <keyword>yes</keyword>, the topic metadata is overriden. Allowable values are
-                  <keyword>yes</keyword>, <keyword>no</keyword>, and <xref
-                  keyref="attributes-useconreftarget">"-dita-use-conref-target"</xref>.</p>
-            </dd>
-          </dlentry>
-        </dl>
+            keyref="attributes-universal"/>.</p>
       </div>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-localization"/> and <xref keyref="attributes-universal/class"


### PR DESCRIPTION
Removes `@lockmeta` from DITA 2.0. 

- [done] Remove definition from grammar files
- [done] Remove all mention of `@lockmeta' from topics about combining metadata with keys + cascading metadata from map to topic
- [done] Remove from reuse topic used by lwdita
- [done] Remove from common attribute definitions used for `topicmeta` and its specializations

