### PR TITLE
Fix typo that made invalid XML

### DIFF
--- a/specification/resources/oasis-errata-cover.dita
+++ b/specification/resources/oasis-errata-cover.dita
@@ -75,7 +75,7 @@
       conref="../common/conref-cover-pages.dita#reuse/related-work"/>
     <section>
       <title>Abstract</title>
-      <p-review">This document contains the Errata 01 for Darwin Information Typing
+      <p>This document contains the Errata 01 for Darwin Information Typing
         Architecture (DITA) Version 1.3.</p>
     </section>
     <section conref="../common/conref-cover-pages.dita#reuse/status"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I'm not sure if this topic is used, but the typo makes the XML invalid, and I get error reports every time I search across the directory.