### PR TITLE
Update metadata in main grammar files

### DIFF
--- a/doctypes/README.md
+++ b/doctypes/README.md
@@ -1,7 +1,5 @@
-# DITA 1.3 Errata 02 Grammar files
+# DITA 2.0 Draft Grammar files
 
-This directory contains the Relax NG, DTD, and XML Schema versions of the DITA Version 1.3 grammar files. 
-These grammar files are based on DITA Version 1.3 Part 3: All-Inclusive Edition Plus Errata 02:
-http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+This directory contains a draft version the DITA Version 2.0 Relax NG and DTD grammar files. 
 
-This directory also contains extra catalog files used to generate Base and Technical Content editions of the grammar files.
+This draft is a work in progress.

--- a/doctypes/dtd/base/basemap.dtd
+++ b/doctypes/dtd/base/basemap.dtd
@@ -2,16 +2,16 @@
 <!-- ============================================================= -->
 <!--                               HEADER                          -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Base MAP (only base domains)                 -->
-<!--  VERSION:   1.3                                               -->
-<!--  DATE:      March 2014                                        -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                        -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/base/basetopic.dtd
+++ b/doctypes/dtd/base/basetopic.dtd
@@ -2,16 +2,16 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Topic Base (only base domains)               -->
 <!--  VERSION:   2.0                                               -->
-<!--  DATE:      August 2019                                       -->
+<!--  DATE:      [[[Release date]]]                                       -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->

--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -2,16 +2,16 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Map                                          -->
-<!--  VERSION:   1.3                                               -->
-<!--  DATE:      March 2014                                        -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                        -->
 <!--                                                               -->
 <!-- ============================================================= -->
 

--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -2,16 +2,16 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA DITA Topic                                   -->
-<!--  VERSION:   1.3                                               -->
-<!--  DATE:      March 2014                                        -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                        -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/ditaval/ditaval.dtd
+++ b/doctypes/dtd/ditaval/ditaval.dtd
@@ -1,16 +1,16 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA DITAVAL DTD                                  -->
-<!--  VERSION:   1.3                                               -->
-<!--  DATE:      November 2014                                     -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                     -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->

--- a/doctypes/dtd/subjectScheme/subjectScheme.dtd
+++ b/doctypes/dtd/subjectScheme/subjectScheme.dtd
@@ -2,16 +2,16 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
-<!-- OASIS Standard                                           -->
-<!-- 16 January 2018                                           -->
-<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
-<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2019. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--  MODULE:    DITA Subject Scheme Map                           -->
 <!--  VERSION:   2.0                                               -->
-<!--  DATE:      August 2019                                       -->
+<!--  DATE:      [[[Release date]]]                                       -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->

--- a/doctypes/rng/base/basemap.rng
+++ b/doctypes/rng/base/basemap.rng
@@ -11,16 +11,16 @@
 =============================================================
                               HEADER
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 
 ============================================================
  MODULE:    DITA Base MAP (only base domains)
- VERSION:   1.3
- DATE:      March 2014
+ VERSION:   2.0
+ DATE:      [[[Release date]]]
 
 =============================================================
 
@@ -36,7 +36,7 @@ PUBLIC "-//OASIS//DTD DITA Base Map//EN"
 The public ID above refers to the latest version of this DTD.
      To refer to this specific version, you may use this value:
      
-PUBLIC "-//OASIS//DTD DITA 1.3 Base Map//EN"
+PUBLIC "-//OASIS//DTD DITA 2.0 Base Map//EN"
 
 =============================================================
 SYSTEM:     Darwin Information Typing Architecture (DITA)

--- a/doctypes/rng/base/basetopic.rng
+++ b/doctypes/rng/base/basetopic.rng
@@ -9,16 +9,16 @@
 =============================================================
                    HEADER
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 
 ============================================================
  MODULE:    DITA Topic Base (only base domains)
- VERSION:   1.3
- DATE:      March 2014
+ VERSION:   2.0
+ DATE:      [[[Release date]]]
 
 =============================================================
 
@@ -34,7 +34,7 @@ PUBLIC "-//OASIS//DTD DITA Base Topic//EN"
 The public ID above refers to the latest version of this DTD.
      To refer to this specific version, you can use this value:
      
-PUBLIC "-//OASIS//DTD DITA 1.3 Base Topic//EN"
+PUBLIC "-//OASIS//DTD DITA 2.0 Base Topic//EN"
 
 =============================================================
 SYSTEM:     Darwin Information Typing Architecture (DITA)

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -11,15 +11,15 @@
 =============================================================
                    HEADER                                    
 ============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 =============================================================
  MODULE:    DITA Map                                         
- VERSION:   1.3                                              
- DATE:      March 2014                                    
+ VERSION:   2.0                                              
+ DATE:      [[[Release date]]]                                    
                                                              
 =============================================================
 

--- a/doctypes/rng/base/topicMod.rng
+++ b/doctypes/rng/base/topicMod.rng
@@ -11,16 +11,16 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 
 ============================================================
  MODULE:    DITA DITA Topic                                  
- VERSION:   1.3                                              
- DATE:      March 2014                                    
+ VERSION:   2.0                                              
+ DATE:      [[[Release date]]]                                    
                                                              
 =============================================================
 

--- a/doctypes/rng/ditaval/ditaval.rng
+++ b/doctypes/rng/ditaval/ditaval.rng
@@ -10,16 +10,16 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 
 ============================================================
  MODULE:    DITA DITAVAL DTD                                 
- VERSION:   1.3                                              
- DATE:      November 2014                                    
+ VERSION:   2.0                                              
+ DATE:      [[[Release date]]]                                    
                                                              
 =============================================================
 
@@ -34,7 +34,7 @@ PUBLIC "-//OASIS//DTD DITA DITAVAL//EN"
 
 The public ID above refers to the latest version of this DTD.
      To refer to this specific version, you may use this value:
-PUBLIC "-//OASIS//DTD DITA 1.3 DITAVAL//EN"                       
+PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"                       
 
 =============================================================
 SYSTEM:     Darwin Information Typing Architecture (DITA)    

--- a/doctypes/rng/subjectScheme/subjectScheme.rng
+++ b/doctypes/rng/subjectScheme/subjectScheme.rng
@@ -11,16 +11,16 @@
 =============================================================
                    HEADER                                    
 =============================================================
-Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
-OASIS Standard
-16 January 2018 
-Copyright (c) OASIS Open 2018. All rights reserved. 
-Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+Darwin Information Typing Architecture (DITA) Version 2.0
+[[[Draft level]]]
+[[[Release date]]] 
+Copyright (c) OASIS Open 2019. All rights reserved. 
+Source: [[[Source link]]]
 
 ============================================================
  MODULE:    DITA Subject Scheme Map                      
- VERSION:   1.3
- DATE:      March 2014                                    
+ VERSION:   2.0
+ DATE:      [[[Release date]]]                                    
                                                              
 =============================================================
 
@@ -36,7 +36,7 @@ PUBLIC "-//OASIS//DTD DITA Subject Scheme Map//EN"
 The public ID above refers to the latest version of this DTD.
      To refer to this specific version, you may use this value:
      
-PUBLIC "-//OASIS//DTD DITA 1.3 Subject Scheme Map//EN"            
+PUBLIC "-//OASIS//DTD DITA 2.0 Subject Scheme Map//EN"            
 
 =============================================================
 SYSTEM:     Darwin Information Typing Architecture (DITA)    


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This corrects minor issues but ones that have been bugging me when I'm in the files. Updates all of the primary grammar files that have required OASIS comments when delivered as part of an official draft. With 1.3 we had tokens for standard level, link, etc that were replaced by a script before publishing. I've reintroduced tokens in the same files now:

- Changed the "Version 1.3 Errata 02" header to read 2.0
- Replaced the "OASIS Standard" in each file with a token that can be used to easily insert the status before publishing
- Replaced the publication date with a similar token
- Replaced the publication link with a similar token
- Updated the more generic headers and public ID samples to change the version from 1.3 to 2.0