### PR TITLE
Update travis test to include 2.x docs

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -10,5 +10,5 @@ export DITA_HOME=$PWD/dita-ot-$DITA_OT_VERSION
 # Build beta 2.0 doctype
 #$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/dtd/base/basetopic.dita -f html5
 #$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/dtd/base/basemap.ditamap -f html5
-$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/2.0grammars.ditamap -f html5 --processing-mode=strict
+$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/all-v2-grammars.ditamap -f html5 --processing-mode=strict
 $DITA_HOME/bin/dita -i $PWD/specification/dita-2.0-specification.ditamap -f html5 --processing-mode=strict


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Switches the test map used to verify each grammar file works (parses correctly and is in the catalog).

Earlier version pulled in a sample set that uses a document with each DITA 2.0 public ID, and verified that each grammar file was found and was parsed. I've updated the sample set with robander/metadita-sampledocs@59f38ef to include a 2.x version of each 2.0 doctype.

This pull request updates our Travis test so that it runs both the 2.0 and 2.x files at one time.