### PR TITLE
Switch conref to conkeyref in spec topics

### DIFF
--- a/specification/archSpec/base/basic-concepts.dita
+++ b/specification/archSpec/base/basic-concepts.dita
@@ -21,55 +21,55 @@
   <dl>
    <dlentry>
     <dt>DITA topics</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/topics-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/topics-shortdesc"/> See <xref
                                                 href="topicdefined.dita">DITA topics</xref> for more
                                         information.</dd>
    </dlentry>
    <dlentry>
     <dt>DITA maps</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/maps-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/maps-shortdesc"/> See <xref
                                                 href="definition-of-ditamaps.dita">DITA maps</xref>
                                         for more information.</dd>
    </dlentry>
    <dlentry>
     <dt>Information typing</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/information-typing-shortdesc"/> See
+    <dd><ph conkeyref="reuse-general/information-typing-shortdesc"/> See
                                                 <xref href="information-typing.dita">Information
                                                 typing</xref> for more information.</dd>
    </dlentry>
    <dlentry>
     <dt>DITA addressing</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/addressing-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/addressing-shortdesc"/> See <xref
                                                 href="ditaaddressing.dita">DITA addressing</xref>
                                         for more information.</dd>
    </dlentry>
    <dlentry>
     <dt>Content reuse</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/conref-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/conref-shortdesc"/> See <xref
                                                 href="conref.dita">Content reuse</xref> for more
                                         information</dd>
    </dlentry>
    <dlentry>
     <dt>Conditional processing</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/conditional-processing-shortdesc"/> See
+    <dd><ph conkeyref="reuse-general/conditional-processing-shortdesc"/> See
                                                 <xref href="condproc.dita">Conditional
                                                 processing</xref> for more information.</dd>
    </dlentry>
    <dlentry>
     <dt>Configuration</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/configuration-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/configuration-shortdesc"/> See <xref
                                                 href="configuration.dita"/> for more
                                         information.</dd>
    </dlentry>
    <dlentry>
     <dt>Specialization</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/specialization-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/specialization-shortdesc"/> See <xref
                                                 href="specialization.dita">Specialization</xref> for
                                         more information.</dd>
    </dlentry>
    <dlentry>
     <dt>Constraints</dt>
-    <dd><ph conref="../../common/conref-file.dita#reuse_file/contraints-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/contraints-shortdesc"/> See <xref
                                                 href="constraints.dita">Constraints</xref> for more
                                         information.</dd>
    </dlentry>

--- a/specification/archSpec/base/cascading-in-a-ditamap.dita
+++ b/specification/archSpec/base/cascading-in-a-ditamap.dita
@@ -21,7 +21,7 @@
     <!--<p>The following attributes and metadata elements cascade throughout the entire map:</p><ul><li>Attributes set on the <xmlelement>map</xmlelement> element</li><li>Metadata elements that are contained in the <xmlelement>topicmeta</xmlelement> element that is a child of the <xmlelement>map</xmlelement> element</li></ul><p>Attribute values and metadata elements in relationship tables can be applied to entire columns or rows as well as individual cells, a practice that is particularly useful for attribute and metadata management.</p>-->
     <p>The following attributes cascade when set on the <xmlelement>map</xmlelement> element or when
       set within a map:</p>
-    <ul conref="../../common/conref-file.dita#reuse_file/cascading-attributes" id="ul_f2j_pwn_yl">
+    <ul conkeyref="reuse-general/cascading-attributes" id="ul_f2j_pwn_yl">
       <li/>
     </ul>
     <p>Cascading is additive for attributes that accept multiple values, except when the

--- a/specification/archSpec/base/cascading-of-attributes-from-map-to-map.dita
+++ b/specification/archSpec/base/cascading-of-attributes-from-map-to-map.dita
@@ -15,7 +15,7 @@
   <conbody>
     <p>The following attributes cascade from map to map:<ul id="cascading-attributes">
 <li><xmlatt>rev</xmlatt></li>
-<li><ph conref="../../common/conref-file.dita#reuse_file/propsAndSpecializations"/></li>
+<li><ph conkeyref="reuse-general/propsAndSpecializations"/></li>
         <li><xmlatt>linking</xmlatt>, <xmlatt>toc</xmlatt>, <xmlatt>print</xmlatt>,
             <xmlatt>search</xmlatt></li>
         <li><xmlatt>type</xmlatt></li>

--- a/specification/archSpec/base/cascading-of-metadata-elements-from-map-to-map.dita
+++ b/specification/archSpec/base/cascading-of-metadata-elements-from-map-to-map.dita
@@ -16,7 +16,7 @@
     </prolog>
     <conbody>
         <p>For a complete list of which elements cascade within a map, see the column "<ph
-                conref="../../common/conref-file.dita#reuse_file/does-it-cascade"/>" in the topic
+                conkeyref="reuse-general/does-it-cascade"/>" in the topic
                 <xref href="reconciling-topic-and-map-metadata.dita"/>.</p>
         <note>It is possible that a specialization might define metadata that is intended to replace
             rather than add to metadata in the referenced map, but DITA (by default) does not

--- a/specification/archSpec/base/chunk-attribute-combine.dita
+++ b/specification/archSpec/base/chunk-attribute-combine.dita
@@ -6,7 +6,7 @@
         reference source documents for rendering purposes. A single result document is
         generated.</shortdesc>
 <conbody>
-        <!--<p><ph conref="../../common/conref-file.dita#reuse_file/definitionChunkCombine"/></p>-->
+        <!--<p><ph conkeyref="reuse-general/definitionChunkCombine"/></p>-->
         <draft-comment author="Kristen J Eberlein" time="25 May 2019" audience="tc-reviewers">
             <p>Don't these need to be normative statements?</p>
         </draft-comment>

--- a/specification/archSpec/base/chunk-attribute-overview.dita
+++ b/specification/archSpec/base/chunk-attribute-overview.dita
@@ -14,11 +14,11 @@
 <dl>
 <dlentry>
 <dt><codeph>chunk="combine"</codeph></dt>
-<dd><ph conref="../../common/conref-file.dita#reuse_file/definitionChunkCombine"/></dd>
+<dd><ph conkeyref="reuse-general/definitionChunkCombine"/></dd>
 </dlentry>
 <dlentry>
 <dt><codeph>chunk="split"</codeph></dt>
-<dd><ph conref="../../common/conref-file.dita#reuse_file/definitionChunkSplit"/></dd>
+<dd><ph conkeyref="reuse-general/definitionChunkSplit"/></dd>
 </dlentry>
 </dl>
 

--- a/specification/archSpec/base/conditional-processing-attributes.dita
+++ b/specification/archSpec/base/conditional-processing-attributes.dita
@@ -30,7 +30,7 @@
             <dt><xmlatt>audience</xmlatt></dt>
             <dd>The intended audience of the content.</dd>
          </dlentry>
-         <dlentry conref="../../common/conref-file.dita#reuse_file/deliveryTarget">
+         <dlentry conkeyref="reuse-general/deliveryTarget">
             <dt/>
             <dd/>
          </dlentry>

--- a/specification/archSpec/base/conditional-processing-for-specific-output-types.dita
+++ b/specification/archSpec/base/conditional-processing-for-specific-output-types.dita
@@ -16,7 +16,7 @@
   <section id="deliveryTarget">
    <title><xmlatt>deliveryTarget</xmlatt> attribute</title>
    <dl>
-    <dlentry conref="../../common/conref-file.dita#reuse_file/deliveryTarget">
+    <dlentry conkeyref="reuse-general/deliveryTarget">
      <dt/>
      <dd/>
     </dlentry>

--- a/specification/archSpec/base/condproc.dita
+++ b/specification/archSpec/base/condproc.dita
@@ -4,10 +4,10 @@
 <concept id="condproc" xml:lang="en-us">
     <title>Conditional processing (profiling)</title>
     <shortdesc><ph
-conref="../../common/conref-file.dita#reuse_file/conditional-processing-shortdesc"/></shortdesc>
+conkeyref="reuse-general/conditional-processing-shortdesc"/></shortdesc>
     <conbody>
 <p>DITA defines attributes that can be used to enable filtering and flagging individual elements.
-<ph conref="../../common/conref-file.dita#reuse_file/propsAndSpecializations"/> allow conditions to
+<ph conkeyref="reuse-general/propsAndSpecializations"/> allow conditions to
 be assigned to elements so that the elements can be included, excluded, or flagged during
 processing. The <xmlatt>rev</xmlatt> flagging attribute allows values to be assigned to elements so
 that special formatting can be applied to those elements during processing. A conditional-processing

--- a/specification/archSpec/base/conref-overview.dita
+++ b/specification/archSpec/base/conref-overview.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="conref" xml:lang="en-us">
  <title><ph >Conref overview</ph></title>
- <shortdesc><ph conref="../../common/conref-file.dita#reuse_file/conref-shortdesc"/></shortdesc>
+ <shortdesc><ph conkeyref="reuse-general/conref-shortdesc"/></shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/archSpec/base/constraints.dita
+++ b/specification/archSpec/base/constraints.dita
@@ -3,5 +3,5 @@
 <concept xml:lang="en-us" id="concept_sv4_2gm_vp">
  <title>Constraints</title>
  <shortdesc ><ph
-   conref="../../common/conref-file.dita#reuse_file/contraints-shortdesc"/></shortdesc>
+   conkeyref="reuse-general/contraints-shortdesc"/></shortdesc>
 </concept>

--- a/specification/archSpec/base/definition-of-ditamaps.dita
+++ b/specification/archSpec/base/definition-of-ditamaps.dita
@@ -3,7 +3,7 @@
  "concept.dtd">
 <concept id="definition-of-ditamaps" xml:lang="en-us">
 <title>Definition of DITA maps</title>
-<shortdesc><ph conref="../../common/conref-file.dita#reuse_file/maps-shortdesc"/></shortdesc>
+<shortdesc><ph conkeyref="reuse-general/maps-shortdesc"/></shortdesc>
         <prolog>
                 <metadata>
                         <keywords>

--- a/specification/archSpec/base/ditaaddressing.dita
+++ b/specification/archSpec/base/ditaaddressing.dita
@@ -3,6 +3,6 @@
  "concept.dtd">
 <concept id="id" xml:lang="en-us">
  <title>DITA addressing</title>
- <shortdesc><ph conref="../../common/conref-file.dita#reuse_file/addressing-shortdesc"/></shortdesc>
+ <shortdesc><ph conkeyref="reuse-general/addressing-shortdesc"/></shortdesc>
 </concept>
 

--- a/specification/archSpec/base/ditamap-attributes.dita
+++ b/specification/archSpec/base/ditamap-attributes.dita
@@ -227,7 +227,7 @@ or replace."</p></draft-comment></p></draft-comment></p>-->
 					<dd>
 						<p>Specifies whether the default rules for the cascading of metadata
 							attributes in a DITA map apply. The following values are specified:</p>
-						<dl conref="../../common/conref-file.dita#reuse_file/cascade-values">
+						<dl conkeyref="reuse-general/cascade-values">
 							<dlentry>
 								<dt/>
 								<dd/>
@@ -275,7 +275,7 @@ or replace."</p></draft-comment></p></draft-comment></p>-->
 					<li><xmlatt>id</xmlatt>, <xmlatt>conref</xmlatt>, <xmlatt>conrefend</xmlatt>,
 							<xmlatt>conkeyref</xmlatt>, <xmlatt>conaction</xmlatt>
 					</li>
-					<li><ph conref="../../common/conref-file.dita#reuse_file/propsAndSpecializations"/></li>
+					<li><ph conkeyref="reuse-general/propsAndSpecializations"/></li>
 					<li><xmlatt>search</xmlatt>
 					</li>
 				</ul></p> 

--- a/specification/archSpec/base/ditamap-elements.dita
+++ b/specification/archSpec/base/ditamap-elements.dita
@@ -111,11 +111,11 @@ make?</draft-comment>-->
       </dlentry>
       <dlentry>
         <dt><xmlelement>anchor</xmlelement></dt>
-        <dd><ph conref="../../common/conref-file.dita#reuse_file/anchor_shortdesc"/></dd>
+        <dd><ph conkeyref="reuse-general/anchor_shortdesc"/></dd>
       </dlentry>
       <dlentry>
         <dt><xmlelement>navref</xmlelement></dt>
-        <dd><ph conref="../../common/conref-file.dita#reuse_file/navtitle_shortdesc"/></dd>
+        <dd><ph conkeyref="reuse-general/navtitle_shortdesc"/></dd>
       </dlentry>
       <dlentry>
         <dt><xmlelement>keydef</xmlelement></dt>

--- a/specification/archSpec/base/document-type-shells.dita
+++ b/specification/archSpec/base/document-type-shells.dita
@@ -3,7 +3,7 @@
 <concept id="createCustomDocType" xml:lang="en-us"> 
   <title>Overview of document-type shells</title> 
   <shortdesc><ph
-	 conref="../../common/conref-file.dita#reuse_file/configuration-shortdesc"/> 
+	 conkeyref="reuse-general/configuration-shortdesc"/> 
   </shortdesc> 
   <conbody> 
 	 <p>A DITA document must either have an associated document-type definition

--- a/specification/archSpec/base/dtd-coding-attribute-domains.dita
+++ b/specification/archSpec/base/dtd-coding-attribute-domains.dita
@@ -9,7 +9,7 @@
     referenced in document-type shells, as well as a text entity that specifies the contribution to
     the <xmlatt>domains</xmlatt> attribute for the attribute domain.</shortdesc>
   <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/dtd-attribute-domain-name"/>
+    <p conkeyref="reuse-general/dtd-attribute-domain-name"/>
     <dl>
       <dlentry>
         <dt>Parameter entity name and value</dt>

--- a/specification/archSpec/base/dtd-coding-constraint-modules.dita
+++ b/specification/archSpec/base/dtd-coding-constraint-modules.dita
@@ -90,7 +90,7 @@
           <dd>
             <p>The constraint module needs to contain a declaration for a text entity with the name
                   <codeph><varname>domain</varname>Domain-constraints</codeph>, where <ph
-                conref="../../common/conref-file.dita#reuse_file/domain-variable-ph"/> The value of
+                conkeyref="reuse-general/domain-variable-ph"/> The value of
               the text entity is the <xmlatt>domains</xmlatt> attribute contribution for the module;
               see <xref href="specialization-domains-attribute.dita"/> for details on how to
               construct this value. </p>

--- a/specification/archSpec/base/example-keys-scope-defining-precedence.dita
+++ b/specification/archSpec/base/example-keys-scope-defining-precedence.dita
@@ -3,7 +3,7 @@
 <concept xml:lang="en-us" id="example-key-precedence-with-scopes">
   <title>Example: How key scopes affect key precedence</title>
   <shortdesc><ph
-      conref="../../common/conref-file.dita#reuse_file/keys-scopes-and-key-precedence-shortdesc"
+      conkeyref="reuse-general/keys-scopes-and-key-precedence-shortdesc"
     /></shortdesc>
   <conbody>
     <p>Within a single key scope, key precedence is determined by which key definition comes first

--- a/specification/archSpec/base/example-subjectScheme-extension.dita
+++ b/specification/archSpec/base/example-subjectScheme-extension.dita
@@ -20,7 +20,7 @@
     <example id="example" otherprops="examples">
       <p>A company uses a common subject scheme map (<filepath>baseOS.ditamap</filepath>) to set the
         values for the <xmlatt>platform</xmlatt> attribute.</p>
-      <codeblock conref="../../common/conref-code-samples.dita#reuse-code-samples/basic-subjectScheme"/>
+      <codeblock conkeyref="reuse-code-samples/basic-subjectScheme"/>
       <p>The following subject scheme map extends the enumeration defined in
           <filepath>baseOS.ditamap</filepath>. It adds "macos" as a child of the existing "os"
         subject; it also adds special versions of Windows as children of the existing "windows"

--- a/specification/archSpec/base/example-subjectScheme-filtering.dita
+++ b/specification/archSpec/base/example-subjectScheme-filtering.dita
@@ -24,7 +24,7 @@
     sub-categories for Linux, Windows, and z/OS, as well as specific Linux variants: Red Hat Linux
     and SuSE Linux. The company then binds the values that are enumerated in the "Operating system"
     category to the <xmlatt>platform</xmlatt> attribute.</p>
-            <codeblock conref="../../common/conref-code-samples.dita#reuse-code-samples/basic-subjectScheme"/>
+   <codeblock conkeyref="reuse-code-samples/basic-subjectScheme"/>
    <p>The enumeration limits valid values for the <xmlatt>platform</xmlatt> attribute to the
     following: "linux", "redhat", "suse", "windows", and "zos". If any other values are encountered,
     processors validating against the scheme will issue a warning.</p>

--- a/specification/archSpec/base/information-typing.dita
+++ b/specification/archSpec/base/information-typing.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="information-typing">
     <title>Information typing</title>
-    <shortdesc><ph conref="../../common/conref-file.dita#reuse_file/information-typing-shortdesc"
+    <shortdesc><ph conkeyref="reuse-general/information-typing-shortdesc"
         /></shortdesc>
     <prolog>
         <metadata>

--- a/specification/archSpec/base/keys-core-concepts.dita
+++ b/specification/archSpec/base/keys-core-concepts.dita
@@ -144,7 +144,7 @@
         <li>Maps referenced solely by key reference have no bearing on key space contents.</li>
       </ul>
       <p><ph
-          conref="../../common/conref-file.dita#reuse_file/keys-scopes-and-key-precedence-shortdesc"/>
+          conkeyref="reuse-general/keys-scopes-and-key-precedence-shortdesc"/>
         <ph otherprops="examples">See <xref href="example-keys-scope-defining-precedence.dita"/> for
           more information.</ph></p>
     </section>

--- a/specification/archSpec/base/merging-of-cascading-attributes.dita
+++ b/specification/archSpec/base/merging-of-cascading-attributes.dita
@@ -6,13 +6,13 @@
         attribute cascading (though it does not turn off cascading altogether). The attribute has
         two predefined values: "merge" and "nomerge".</shortdesc>
     <conbody>
-        <dl conref="../../common/conref-file.dita#reuse_file/cascade-values">
+        <dl conkeyref="reuse-general/cascade-values">
             <dlentry>
                 <dt/>
                 <dd/>
             </dlentry>
         </dl>
-        <p conref="../../common/conref-file.dita#reuse_file/attribute-implementation-tokens"/>
+        <p conkeyref="reuse-general/attribute-implementation-tokens"/>
         <p>For example, a processor might define the token "appToken:audience" in order to specify
             cascading and merging behaviors for <b>only</b> the <xmlatt>audience</xmlatt>
             attribute.</p>

--- a/specification/archSpec/base/reconciling-topic-and-map-metadata.dita
+++ b/specification/archSpec/base/reconciling-topic-and-map-metadata.dita
@@ -43,7 +43,7 @@
 <row valign="bottom">
 <entry colname="col1">Element</entry>
 <entry colname="col2">How does it apply to the topic?</entry>
-<entry colname="COLSPEC0"><ph conref="../../common/conref-file.dita#reuse_file/does-it-cascade"
+<entry colname="COLSPEC0"><ph conkeyref="reuse-general/does-it-cascade"
        /></entry>
 <entry colname="COLSPEC1">What is the purpose when set on the <xmlelement>map</xmlelement>
 element?</entry>

--- a/specification/archSpec/base/relax-ng-coding-attribute-domains.dita
+++ b/specification/archSpec/base/relax-ng-coding-attribute-domains.dita
@@ -6,8 +6,8 @@
     the <xmlatt>props</xmlatt> or <xmlatt>base</xmlatt> attribute. An attribute domain module
     defines exactly one new attribute type.</shortdesc>
  <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/rng-domains-documentation"/>
-    <p conref="../../common/conref-file.dita#reuse_file/rng-attribute-domain-name"/>
+    <p conkeyref="reuse-general/rng-domains-documentation"/>
+    <p conkeyref="reuse-general/rng-attribute-domain-name"/>
    <p>An attribute domain consists of one file, which has three sections:</p>
     <dl>
       <dlentry>

--- a/specification/archSpec/base/relax-ng-coding-constraint-modules.dita
+++ b/specification/archSpec/base/relax-ng-coding-constraint-modules.dita
@@ -23,7 +23,7 @@
   </metadata>
  </prolog>
  <conbody>
-  <p conref="../../common/conref-file.dita#reuse_file/rng-domains-documentation"/>
+  <p conkeyref="reuse-general/rng-domains-documentation"/>
   <p>Constraint modules are implemented by importing the constraint module into a document type
    shell in place of the module that the constraint modifies. The constraint module itself imports
    the base module to be constrained; within the import, the module redefines patterns as needed to

--- a/specification/archSpec/base/relax-ng-coding-element-domains.dita
+++ b/specification/archSpec/base/relax-ng-coding-element-domains.dita
@@ -6,7 +6,7 @@
     element that is extended by the domain. These patterns are used when including the domain module
     in a document-type shell.</shortdesc>
  <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/rng-domains-documentation"/>
+    <p conkeyref="reuse-general/rng-domains-documentation"/>
     <p>For each element type that is extended by the element domain module, the module must define a
       domain extension pattern. The pattern consists of a choice group of references to element-type
       name patterns, with one reference to each extension of the base element type.</p>

--- a/specification/archSpec/base/relax-ng-coding-structural-modules.dita
+++ b/specification/archSpec/base/relax-ng-coding-structural-modules.dita
@@ -5,7 +5,7 @@
  <shortdesc>A structural vocabulary module defines a new topic or map type as a specialization of a
     topic or map type.</shortdesc>
  <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/rng-domains-documentation"/>
+    <p conkeyref="reuse-general/rng-domains-documentation"/>
   <section id="architectural-attributes">
       <title>Required topic and map element attributes</title>
       <p>The topic or map element type must reference the <codeph>arch-atts</codeph> pattern, which

--- a/specification/archSpec/base/sort-as-processing.dita
+++ b/specification/archSpec/base/sort-as-processing.dita
@@ -41,7 +41,7 @@
    example, one processor might be configured to sort English terms before non-English terms, while
    another might be configured to sort them after. The grouping and sorting of content is subject to
    local editorial rules. </p>
-  <p conref="../../common/conref-file.dita#reuse_file/sort-as-1" />
-  <p conref="../../common/conref-file.dita#reuse_file/sort-as-2" />
+  <p conkeyref="reuse-general/sort-as-1" />
+  <p conkeyref="reuse-general/sort-as-2" />
  </conbody>
 </concept>

--- a/specification/archSpec/base/specialization.dita
+++ b/specification/archSpec/base/specialization.dita
@@ -5,6 +5,6 @@
   id="specialize" xml:lang="en-us">
   <title>Specialization</title>
   <shortdesc>
-    <ph conref="../../common/conref-file.dita#reuse_file/specialization-shortdesc"/></shortdesc>
+    <ph conkeyref="reuse-general/specialization-shortdesc"/></shortdesc>
 </concept>
 

--- a/specification/archSpec/base/table-of-contents.dita
+++ b/specification/archSpec/base/table-of-contents.dita
@@ -10,7 +10,7 @@
       integrate the navigation tree of the referenced map with the navigation tree of the
       referencing map at the point of reference. In this way, a deliverable can be compiled from
       multiple DITA maps.</p>
-    <note conref="../../common/conref-file.dita#reuse_file/mapref-with-child-elements"/>
+    <note conkeyref="reuse-general/mapref-with-child-elements"/>
   <p>The effective navigation title is used for the value of the TOC node. A TOC node is generated
    for every <xmlelement>topicref</xmlelement> element that references a topic or specifies a
    navigation title, except in the following cases:</p>

--- a/specification/archSpec/base/topicdefined.dita
+++ b/specification/archSpec/base/topicdefined.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="topicdefined" xml:lang="en-US">
  <title>The topic as the basic unit of information</title>
- <shortdesc><ph conref="../../common/conref-file.dita#reuse_file/topics-shortdesc"/></shortdesc>
+ <shortdesc><ph conkeyref="reuse-general/topics-shortdesc"/></shortdesc>
  <prolog>
   <metadata>
    <keywords>

--- a/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
+++ b/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
@@ -12,7 +12,7 @@
 <p>Groups can be used to organize classification metadata into subcategories. This is intended to
 support situations where a predefined metadata attribute applies to multiple specialized
 subcategories. The grouping syntax exactly matches the syntax used for generalized attributes,
-making it valid inside <ph conref="../../common/conref-file.dita#reuse_file/propsAndSpecializations"
+making it valid inside <ph conkeyref="reuse-general/propsAndSpecializations"
 />.</p>
 <p otherprops="examples"> For example, the <xmlatt>product</xmlatt> attribute can be used to
 classify an element based on both related databases and related application servers. Using groups
@@ -20,7 +20,7 @@ for these subcategories allows each category to be processed independently; when
 exclude all applicable databases within a group, the element can be safely excluded, regardless of
 any other <xmlatt>product</xmlatt> conditions.</p>
 <p>Groups can be used within <ph
-conref="../../common/conref-file.dita#reuse_file/propsAndSpecializations"/>. The following rules
+conkeyref="reuse-general/propsAndSpecializations"/>. The following rules
 apply:</p>
     <ul >
       <li>Groups consist of a name immediately followed by a parenthetical group of zero or more

--- a/specification/archSpec/base/xsd-coding-attribute-domains.dita
+++ b/specification/archSpec/base/xsd-coding-attribute-domains.dita
@@ -6,7 +6,7 @@
   <shortdesc>An attribute domain vocabulary module declares one new attribute specialized from
     either the <xmlatt>props</xmlatt> or <xmlatt>base</xmlatt> attribute.</shortdesc>
   <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/xsd-domains-documentation"/>
+    <p conkeyref="reuse-general/xsd-domains-documentation"/>
     <p>An attribute domain consists of one file. The file must have a single attribute group
       definition that contains the definition of the attribute itself, where the attribute group is
       named <codeph><varname>attname</varname>Att-d-attribute</codeph>. </p>

--- a/specification/archSpec/base/xsd-coding-constraint-modules.dita
+++ b/specification/archSpec/base/xsd-coding-constraint-modules.dita
@@ -25,7 +25,7 @@
     </metadata>
   </prolog>
   <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/xsd-domains-documentation"/>
+    <p conkeyref="reuse-general/xsd-domains-documentation"/>
     <p><ph >For each vocabulary module with a content model or attributes to be
         constrained</ph>, there <ph >must</ph> be <ph 
         >an</ph>

--- a/specification/archSpec/base/xsd-coding-structural-modules.dita
+++ b/specification/archSpec/base/xsd-coding-structural-modules.dita
@@ -7,7 +7,7 @@
     pair of XSD documents, one that defines groups used to integrate and override the type and one
     that defines the element types specific to the type.</shortdesc>
   <conbody>
-    <p conref="../../common/conref-file.dita#reuse_file/xsd-domains-documentation"/>
+    <p conkeyref="reuse-general/xsd-domains-documentation"/>
     <section id="module-files">
       <title>Module files</title>
       <p>A structural vocabulary module has two files:</p>

--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -6,6 +6,7 @@
     <keydef keys="rendering" href="conref-rendering-expectations.dita"/>
     <!-- Key definitions for reuse topics -->
     <keydef keys="reuse-attributes" href="conref-attribute.dita"/>
+    <keydef keys="reuse-examples" href="conref-examples.dita"/>
     <keydef keys="reuse-alt" href="reuse-w-lwdita/reuse-alt.dita"/>
     <keydef keys="reuse-audio" href="reuse-w-lwdita/reuse-audio.dita"/>
     <keydef keys="reuse-b" href="reuse-w-lwdita/reuse-b.dita"/>

--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -8,6 +8,7 @@
     <keydef keys="reuse-general" href="conref-file.dita"/>
     <keydef keys="reuse-attributes" href="conref-attribute.dita"/>
     <keydef keys="reuse-examples" href="conref-examples.dita"/>
+    <keydef keys="reuse-code-samples" href="conref-code-samples.dita"/>
     <keydef keys="reuse-alt" href="reuse-w-lwdita/reuse-alt.dita"/>
     <keydef keys="reuse-audio" href="reuse-w-lwdita/reuse-audio.dita"/>
     <keydef keys="reuse-b" href="reuse-w-lwdita/reuse-b.dita"/>

--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -5,6 +5,7 @@
     <!--<keydef keys="library-short-descriptions" href="conref-short-descriptions.dita"/>-->
     <keydef keys="rendering" href="conref-rendering-expectations.dita"/>
     <!-- Key definitions for reuse topics -->
+    <keydef keys="reuse-general" href="conref-file.dita"/>
     <keydef keys="reuse-attributes" href="conref-attribute.dita"/>
     <keydef keys="reuse-examples" href="conref-examples.dita"/>
     <keydef keys="reuse-alt" href="reuse-w-lwdita/reuse-alt.dita"/>

--- a/specification/langRef/attributes/calsTableAttributes.dita
+++ b/specification/langRef/attributes/calsTableAttributes.dita
@@ -41,7 +41,7 @@
         <dt>char </dt>
         <dd>Use the character specified on the <xmlatt>char</xmlatt> attribute for alignment. </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+       <dlentry conkeyref="reuse-attributes/ditauseconref">
         <dt>-dita-use-conref-target </dt>
         <dd> </dd>
        </dlentry>
@@ -107,7 +107,7 @@
          column headers. Applies when <xmlatt>rowheader</xmlatt> is used on the
           <xmlelement>table</xmlelement> element.</dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+       <dlentry conkeyref="reuse-attributes/ditauseconref">
         <dt/>
         <dd/>
        </dlentry>
@@ -139,7 +139,7 @@
         <dt>middle </dt>
         <dd>Align the text to the middle of the table entry (cell). </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+       <dlentry conkeyref="reuse-attributes/ditauseconref">
         <dt>-dita-use-conref-target </dt>
         <dd> </dd>
        </dlentry>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -39,7 +39,7 @@
                 <dt>no </dt>
                 <dd>Indicates expanded spacing. </dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>

--- a/specification/langRef/attributes/commonMapAttributes.dita
+++ b/specification/langRef/attributes/commonMapAttributes.dita
@@ -72,7 +72,7 @@
     <dlentry id="linking" platform="dita">
      <dt><xmlatt>linking</xmlatt></dt>
      <dd>Defines some specific linking characteristics of a topic&apos;s current location in the
-      map. <ph conref="../../common/conref-attribute.dita#conref-attribute/inherit-in-map"/>
+      map. <ph conkeyref="reuse-attributes/inherit-in-map"/>
       Allowable values are:<dl>
        <dlentry>
         <dt>targetonly </dt>
@@ -91,7 +91,7 @@
         <dt>none </dt>
         <dd>A topic cannot be linked to or link to other topics. </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+       <dlentry conkeyref="reuse-attributes/ditauseconref">
         <dt> </dt>
         <dd> </dd>
        </dlentry>
@@ -115,7 +115,7 @@
          <dd>The content of the <xmlelement>navtitle</xmlelement> element is ignored. This is the
           processing default. </dd>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref"
+        <dlentry conkeyref="reuse-attributes/ditauseconref"
          platform="dita">
          <dt> </dt>
          <dd> </dd>
@@ -126,7 +126,7 @@
      <dt><xmlatt>processing-role</xmlatt></dt>
      <dd>Describes the processing role of the referenced topic. The processing default is
        <keyword>normal</keyword>. <ph
-       conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/> Allowable values are:<dl>
+       conkeyref="reuse-attributes/may-inherit"/> Allowable values are:<dl>
        <dlentry>
         <dt>normal </dt>
         <dd>Normal topic that is a readable part of the information. </dd>
@@ -137,7 +137,7 @@
          included in a rendered table of contents, and the topic should not be rendered on its own.
         </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref"
+       <dlentry conkeyref="reuse-attributes/ditauseconref"
         platform="dita">
         <dt> </dt>
         <dd> </dd>
@@ -147,7 +147,7 @@
     <dlentry id="search" platform="dita">
      <dt><xmlatt>search</xmlatt></dt>
      <dd>Describes whether the target is available for searching. <ph
-       conref="../../common/conref-attribute.dita#conref-attribute/inherit-in-map"/> Allowable
+       conkeyref="reuse-attributes/inherit-in-map"/> Allowable
       values are: <dl>
        <dlentry>
         <dt>yes </dt>
@@ -167,7 +167,7 @@
     <dlentry id="toc" platform="dita">
      <dt><xmlatt>toc</xmlatt></dt>
      <dd>Specifies whether a topic appears in the table of contents (TOC). <ph
-       conref="../../common/conref-attribute.dita#conref-attribute/inherit-in-map"/> Allowable
+       conkeyref="reuse-attributes/inherit-in-map"/> Allowable
       values are:<dl>
        <dlentry>
         <dt>yes </dt>
@@ -183,7 +183,7 @@
        </dlentry>
       </dl></dd>
     </dlentry>
-    <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref"
+    <dlentry conkeyref="reuse-attributes/ditauseconref"
      platform="dita">
      <dt> </dt>
      <dd> </dd>

--- a/specification/langRef/attributes/displayAttributes.dita
+++ b/specification/langRef/attributes/displayAttributes.dita
@@ -38,7 +38,7 @@
         <dd>Aligns the element with the left (for left to right presentation) or right (for right to
          left presentation) margin of the current text line and takes indention into account. </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref"
+       <dlentry conkeyref="reuse-attributes/ditauseconref"
         platform="dita">
         <dt> </dt>
         <dd> </dd>
@@ -78,7 +78,7 @@
         <dt>topbot </dt>
         <dd>Draw a line both before and after the element </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref"
+       <dlentry conkeyref="reuse-attributes/ditauseconref"
         platform="dita">
         <dt> </dt>
         <dd> </dd>

--- a/specification/langRef/attributes/displayAttributes.dita
+++ b/specification/langRef/attributes/displayAttributes.dita
@@ -43,7 +43,7 @@
         <dt> </dt>
         <dd> </dd>
        </dlentry>
-      </dl><p conref="../../common/conref-file.dita#reuse_file/pgwide-explain" platform="dita"
+      </dl><p conkeyref="reuse-general/pgwide-explain" platform="dita"
        /><p>Some DITA processors or output formats might not be able to support all values.
       </p></dd>
     </dlentry>

--- a/specification/langRef/attributes/metadataAttributes.dita
+++ b/specification/langRef/attributes/metadataAttributes.dita
@@ -33,8 +33,8 @@
         <dlentry id="props">
           <dt><xmlatt>props</xmlatt></dt>
           <dd>Root attribute from which new metadata attributes can be specialized. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/propertyvalueattr"/>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/propertyvalueattr"/>
+            <ph conkeyref="reuse-attributes/may-inherit"/>
           </dd>
           <dd>The <xmlatt>props</xmlatt> attribute takes a space-delimited set of values. However,
             when acting as a container for generalized attributes, the attribute values will be more
@@ -54,13 +54,13 @@
         <dlentry id="audience">
           <dt><xmlatt>audience</xmlatt></dt>
           <dd>Indicates the intended audience for the element. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="deliveryTarget">
           <dt><xmlatt>deliveryTarget</xmlatt></dt>
           <dd><ph conref="../../common/conref-file.dita#reuse_file/deliveryTarget-simpleDefinition"/>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/></dd>
+            <ph conkeyref="reuse-attributes/may-inherit"/></dd>
         </dlentry>
         <dlentry id="otherprops">
           <dt><xmlatt>otherprops</xmlatt></dt>
@@ -68,19 +68,19 @@
             an audience, or to provide selection criteria for the element. Alternatively, the
               <xmlatt>props</xmlatt> attribute <ph>can</ph> be specialized to provide a new metadata
             attribute instead of using the general <xmlatt>otherprops</xmlatt> attribute. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="platform">
           <dt><xmlatt>platform</xmlatt></dt>
           <dd>Indicates operating system and hardware. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="product">
           <dt><xmlatt>product</xmlatt></dt>
           <dd>Contains the name of the product to which the element applies. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
       </dl>
@@ -100,7 +100,7 @@
           <dd>Indicates a revision level of an element that identifies when the element was added or
             modified. It can be used to flag outputs when it matches a run-time parameter; it cannot
             be used for filtering. It is not sufficient to be used for version control. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/>
+              conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="status">

--- a/specification/langRef/attributes/metadataAttributes.dita
+++ b/specification/langRef/attributes/metadataAttributes.dita
@@ -59,7 +59,7 @@
         </dlentry>
         <dlentry id="deliveryTarget">
           <dt><xmlatt>deliveryTarget</xmlatt></dt>
-          <dd><ph conref="../../common/conref-file.dita#reuse_file/deliveryTarget-simpleDefinition"/>
+          <dd><ph conkeyref="reuse-general/deliveryTarget-simpleDefinition"/>
             <ph conkeyref="reuse-attributes/may-inherit"/></dd>
         </dlentry>
         <dlentry id="otherprops">

--- a/specification/langRef/attributes/theformatattribute.dita
+++ b/specification/langRef/attributes/theformatattribute.dita
@@ -33,7 +33,7 @@
                                     because relationship tables are only valid as children of a map,
                                     referenced relationship tables are treated as children of the
                                     referencing map. <note
-                                          conref="../../common/conref-file.dita#reuse_file/mapref-with-child-elements"
+                                          conkeyref="reuse-general/mapref-with-child-elements"
                                     /></dd>
                         </dlentry>
                         <dlentry>

--- a/specification/langRef/attributes/theformatattribute.dita
+++ b/specification/langRef/attributes/theformatattribute.dita
@@ -4,7 +4,7 @@
 <reference id="theformatattribute" xml:lang="en-us">
 <title>The <xmlatt>format</xmlatt> attribute</title>
 <shortdesc>The <xmlatt>format</xmlatt> attribute identifies the format of the resource that is
-            referenced. <ph conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"
+            referenced. <ph conkeyref="reuse-attributes/may-inherit"
             /></shortdesc>
       <prolog>
             <metadata>

--- a/specification/langRef/attributes/thekeysattribute.dita
+++ b/specification/langRef/attributes/thekeysattribute.dita
@@ -19,7 +19,7 @@
  </prolog>
  <refbody>
   <section id="section-1">
-   <p conref="../../common/conref-file.dita#reuse_file/keys-attribute-syntax"/>
+   <p conkeyref="reuse-general/keys-attribute-syntax"/>
    <p>A key <ph >cannot</ph> resolve to sub-topic elements, although a
      <xmlatt>keyref</xmlatt> attribute <ph >can</ph> do so by combining a key
     with a sub-topic element id.</p>

--- a/specification/langRef/attributes/theroleattribute.dita
+++ b/specification/langRef/attributes/theroleattribute.dita
@@ -54,7 +54,7 @@ not a parent, child, sibling, next, or previous.</dd>
 <dd>Indicates any other kind of relationship or role. Enter that role as the value for the
                             <xmlatt>otherrole</xmlatt> attribute.</dd>
 </dlentry>
-                <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+                <dlentry conkeyref="reuse-attributes/ditauseconref">
                     <dt> </dt>
                     <dd> </dd>
                 </dlentry></dl>

--- a/specification/langRef/attributes/thescopeattribute.dita
+++ b/specification/langRef/attributes/thescopeattribute.dita
@@ -27,7 +27,7 @@
 <li>See <xref keyref="attributes-useconreftarget"></xref> for more information
 on -dita-use-conref-target.</li>
 </ul><p ><ph
-                    conref="../../common/conref-attribute.dita#conref-attribute/may-inherit"/> The
+                    conkeyref="reuse-attributes/may-inherit"/> The
                 processing default is determined by the value of the <xmlatt>href</xmlatt>
                 attribute. In most cases, the processing default is "local". However the processing
                 default is "external" whenever the absolute URI in the <xmlatt>href</xmlatt>

--- a/specification/langRef/attributes/thetypeattribute.dita
+++ b/specification/langRef/attributes/thetypeattribute.dita
@@ -76,7 +76,7 @@ include:</p><dl><dlentry>
 if available. If the type cannot be determined, the default should
 be treated as "topic".</dd>
 </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+        <dlentry conkeyref="reuse-attributes/ditauseconref">
           <dt> </dt>
           <dd> </dd>
         </dlentry></dl><p>Other values can be used to indicate other types of topics or elements as targets. Processing is
@@ -136,7 +136,7 @@ be treated as "topic".</dd>
 <dt>other</dt>
 <dd>This is something other than a normal note.</dd>
 </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+        <dlentry conkeyref="reuse-attributes/ditauseconref">
           <dt> </dt>
           <dd> </dd>
         </dlentry></dl></section>

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -65,7 +65,7 @@
 		</section>
 		<section id="attributes">
 			<title>Attributes</title>
-<p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+<p conkeyref="reuse-attributes/only-universal"/>
 		</section>
 <example id="example" otherprops="examples"><title>Example: <xmlelement>abstract</xmlelement> with phrase-level short description</title><codeblock id="example-code">&lt;abstract&gt;The abstract is being used to provide more complex content. 
 	&lt;shortdesc&gt;The shortdesc must be directly contained by the abstract.&lt;/shortdesc&gt;

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -30,7 +30,7 @@
       <dl>
         <dlentry>
           <dt><xmlatt>id</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Provides an integration point that another map <ph>can</ph> reference in order to
             insert its navigation into the current navigation tree. The <xmlatt>anchorref</xmlatt>
             attribute on a map <ph>can</ph> be used to reference this attribute. See <xref

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -3,7 +3,7 @@
  "reference.dtd">
 <reference id="anchor" xml:lang="en-us">
 <title><xmlelement>anchor</xmlelement></title>
-<shortdesc><ph conref="../../common/conref-file.dita#reuse_file/anchor_shortdesc"/></shortdesc>
+<shortdesc><ph conkeyref="reuse-general/anchor_shortdesc"/></shortdesc>
 <prolog><metadata>
 <keywords><indexterm>elements<indexterm>basic map<indexterm><xmlelement>anchor</xmlelement></indexterm></indexterm></indexterm>
 </keywords>
@@ -39,7 +39,7 @@
         </dlentry>
       </dl>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p conref="../../common/conref-file.dita#reuse_file/anchor"/><p conref="../../common/conref-file.dita#reuse_file/anchoref"/></example>
+<example id="example" otherprops="examples"><title>Example</title><p conkeyref="reuse-general/anchor"/><p conkeyref="reuse-general/anchoref"/></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/area.dita
+++ b/specification/langRef/base/area.dita
@@ -18,7 +18,7 @@ coordinates of that shape, and a link target for the area.</shortdesc>
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;area>
  &lt;shape>rect&lt;/shape>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -29,11 +29,11 @@
                 <dlentry>
                     <dt><xmlatt>name</xmlatt>
                         <ph
-                            conref="../../common/conref-attribute.dita#conref-attribute/required-attr"
+                            conkeyref="reuse-attributes/required-attr"
                         /></dt>
                     <dd>Specifies the attribute that is bound to a set of enumerated values</dd>
                 </dlentry>
-                <dlentry conref="../../common/conref-attribute.dita#conref-attribute/translate-NO">
+                <dlentry conkeyref="reuse-attributes/translate-NO">
                     <dt/>
                     <dd/>
                 </dlentry>

--- a/specification/langRef/base/author.dita
+++ b/specification/langRef/base/author.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/author-attributes"/>
+      <sectiondiv conkeyref="reuse-attributes/author-attributes"/>
     </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/base/bodydiv.dita
+++ b/specification/langRef/base/bodydiv.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;topic id="sample" xml:lang="en">
  &lt;title>Sample for bodydiv&lt;/title>

--- a/specification/langRef/base/consequence.dita
+++ b/specification/langRef/base/consequence.dita
@@ -17,7 +17,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"> 			<title>Example</title>
       <p>In the following code sample, a hazard statement is assigned a "CAUTION" signal word. The

--- a/specification/langRef/base/coords.dita
+++ b/specification/langRef/base/coords.dita
@@ -45,7 +45,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <sectiondiv
-                conref="../../common/conref-attribute.dita#conref-attribute/univ-outputclass-keyref-translate-NO"
+                conkeyref="reuse-attributes/univ-outputclass-keyref-translate-NO"
             />
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;area>

--- a/specification/langRef/base/copyright.dita
+++ b/specification/langRef/base/copyright.dita
@@ -24,7 +24,7 @@ legal ownership of the content.</shortdesc>
    <p>The following attributes are available on this element: <xref
      keyref="attributes-universal"/> and the attribute defined below.</p>
    <dl>
-    <!--<dlhead conref="../../common/conref-file.dita#reuse_file/attributeDlhead"><dthd/><ddhd/></dlhead>-->
+    <!--<dlhead conkeyref="reuse-general/attributeDlhead"><dthd/><ddhd/></dlhead>-->
     <dlentry id="type">
      <dt><xmlatt>type</xmlatt></dt>
      <dd>Indicates the legal status of the copyright holder. <ph

--- a/specification/langRef/base/copyright.dita
+++ b/specification/langRef/base/copyright.dita
@@ -28,7 +28,7 @@ legal ownership of the content.</shortdesc>
     <dlentry id="type">
      <dt><xmlatt>type</xmlatt></dt>
      <dd>Indicates the legal status of the copyright holder. <ph
-       conref="../../common/conref-attribute.dita#conref-attribute/nonstandard-type"/> Beginning
+       conkeyref="reuse-attributes/nonstandard-type"/> Beginning
       with DITA 1.2, values in this attribute are not limited to a small number of choices; the
       following values were used in DITA 1.0 and DITA 1.1, and are still provided as sample values: <dl>
        <dlentry>
@@ -39,7 +39,7 @@ legal ownership of the content.</shortdesc>
         <dt>secondary </dt>
         <dd>An additional copyright holder who is not primary </dd>
        </dlentry>
-       <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+       <dlentry conkeyref="reuse-attributes/ditauseconref">
         <dt> </dt>
         <dd> </dd>
        </dlentry>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -19,7 +19,7 @@
       <dl>
         <dlentry id="date">
           <dt><xmlatt>date</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The document creation date. Enter the date as YYYY-MM-DD where YYYY is the year, MM is
             the month from 01 to 12, and DD is the day from 01-31. See <xref format="html"
               href="http://www.cl.cam.ac.uk/~mgk25/iso-time.html" scope="external">A Summary of the

--- a/specification/langRef/base/ddhd.dita
+++ b/specification/langRef/base/ddhd.dita
@@ -20,7 +20,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>See <xref keyref="elements-dl"/>.</p></example>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -27,7 +27,7 @@
         also uses <xmlatt>processing-role</xmlatt>, <xmlatt>locktitle</xmlatt>, and
           <xmlatt>toc</xmlatt> from <xref keyref="attributes-commonMap"/>.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+        <dlentry conkeyref="reuse-attributes/href-on-topicref">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/ditavalmeta.dita
+++ b/specification/langRef/base/ditavalmeta.dita
@@ -31,6 +31,6 @@
         domain).</p>
     </section>
 <example id="example" otherprops="examples"
-conref="../../common/conref-examples.dita#conref-examples/ditavalref"/>
+conkeyref="reuse-examples/ditavalref"/>
   </refbody>
 </reference>

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -141,7 +141,7 @@
       </dl>
     </section>
 <example id="example" otherprops="examples"
-conref="../../common/conref-examples.dita#conref-examples/ditavalref"/>
+conkeyref="reuse-examples/ditavalref"/>
   </refbody>
 </reference>
 

--- a/specification/langRef/base/div.dita
+++ b/specification/langRef/base/div.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/dlhead.dita
+++ b/specification/langRef/base/dlhead.dita
@@ -20,7 +20,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
 <fig id="complexexample">

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -42,7 +42,7 @@
           <dt><xmlatt>time</xmlatt></dt>
           <dd>Describes when the draft comment was created.</dd>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/translate-NO"
+        <dlentry conkeyref="reuse-attributes/translate-NO"
           id="translate">
           <dt/>
           <dd/>

--- a/specification/langRef/base/dthd.dita
+++ b/specification/langRef/base/dthd.dita
@@ -16,7 +16,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
 <p>See <xref keyref="elements-dl"/>.</p></example>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -22,7 +22,7 @@
         value of the <xmlelement>dvrResourcePrefix</xmlelement> element contributes to the
         effective file names of resources that are referenced within the branch. The effective
         resource file name starts with the value of the <xmlelement>dvrResourcePrefix</xmlelement>
-        element. <ph conref="../../common/conref-file.dita#reuse_file/ditavalref-copyto"/></p>
+        element. <ph conkeyref="reuse-general/ditavalref-copyto"/></p>
       <p>Some resources are not eligible for renaming, such as those marked with
           <codeph>scope="external"</codeph>. Rules for which resources are eligible for renaming,
         and what names are allowed as valid resource names, are the same as those for the

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -24,7 +24,7 @@
         name consists of the portion of the file name after any directory information, and before
         any period followed by the file extension. For example, in the original file name
           <filepath>task/install.dita</filepath>, the base portion of the file name is "install".
-          <ph conref="../../common/conref-file.dita#reuse_file/ditavalref-copyto"/></p>
+          <ph conkeyref="reuse-general/ditavalref-copyto"/></p>
       <p>Some resources are not eligible for renaming, such as those marked with
           <codeph>scope="external"</codeph>. Rules for which resources are eligible for renaming,
         and what names are allowed as valid resource names, are the same as those for the

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -25,10 +25,10 @@
       <dl>
         <dlentry>
           <dt><xmlatt>name</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the element to which the set of controlled values are bound </dd>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/translate-NO">
+        <dlentry conkeyref="reuse-attributes/translate-NO">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -35,7 +35,7 @@
                 <dt>0</dt>
                 <dd>No rotation <ph>occurs</ph>.</dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt/>
                 <dd/>
               </dlentry>

--- a/specification/langRef/base/example.dita
+++ b/specification/langRef/base/example.dita
@@ -23,7 +23,7 @@ Hence, in a DITA topic, to represent programming code and results within the dis
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/universal-spectitle"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;example id="example">
   &lt;title>Example&lt;/title>

--- a/specification/langRef/base/figgroup.dita
+++ b/specification/langRef/base/figgroup.dita
@@ -18,7 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;fig>
   &lt;title>Sample complex figure&lt;/title>

--- a/specification/langRef/base/foreign.dita
+++ b/specification/langRef/base/foreign.dita
@@ -80,7 +80,7 @@ stroke:rgb(0,0,100);stroke-width:2"/&gt;
 &lt;/p&gt; </codeblock>
     </example>
 <section id="attributes"><title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
 </section>
 </refbody>
 </reference>

--- a/specification/langRef/base/hasInstance.dita
+++ b/specification/langRef/base/hasInstance.dita
@@ -18,7 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/scheme-HAS-elements"/>
+      <sectiondiv conkeyref="reuse-attributes/scheme-HAS-elements"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample specifies that New York City, Reykjavik, and Moscow are each specific
         instances of a city.</p>

--- a/specification/langRef/base/hasKind.dita
+++ b/specification/langRef/base/hasKind.dita
@@ -18,7 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/scheme-HAS-elements"/>
+      <sectiondiv conkeyref="reuse-attributes/scheme-HAS-elements"/>
     </section>
 <example id="example"  otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/hasNarrower.dita
+++ b/specification/langRef/base/hasNarrower.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/scheme-HAS-elements"/>
+      <sectiondiv conkeyref="reuse-attributes/scheme-HAS-elements"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample specifies that "Planting roses" is a narrower subject category than
         "Horticulture", although it is part of the "Horticulture" subject.</p>

--- a/specification/langRef/base/hasPart.dita
+++ b/specification/langRef/base/hasPart.dita
@@ -16,7 +16,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/scheme-HAS-elements"/>
+      <sectiondiv conkeyref="reuse-attributes/scheme-HAS-elements"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample specifies that a tire and a horn are each a part of a car.</p>
       <codeblock>&lt;subjectScheme>

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -26,7 +26,7 @@
             keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+          <dlentry conkeyref="reuse-attributes/href-on-topicref">
             <dt/>
             <dd/>
           </dlentry>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -36,35 +36,35 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-href">
+        <dlentry conkeyref="reuse-attributes/image-href">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-scope">
+        <dlentry conkeyref="reuse-attributes/image-scope">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-height">
+        <dlentry conkeyref="reuse-attributes/image-height">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-width">
+        <dlentry conkeyref="reuse-attributes/image-width">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-align">
+        <dlentry conkeyref="reuse-attributes/image-align">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-scale">
+        <dlentry conkeyref="reuse-attributes/image-scale">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-scalefit">
+        <dlentry conkeyref="reuse-attributes/image-scalefit">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-placement">
+        <dlentry conkeyref="reuse-attributes/image-placement">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/howtoavoid.dita
+++ b/specification/langRef/base/howtoavoid.dita
@@ -20,7 +20,7 @@ not use solvents to clean the drum surface."</shortdesc>
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample illustrates a hazard statement with the signal word of "NOTICE",

--- a/specification/langRef/base/imagemap.dita
+++ b/specification/langRef/base/imagemap.dita
@@ -38,7 +38,7 @@
 		</section>
 		<section id="attributes">
 			<title>Attributes</title>
-			<p conref="../../common/conref-attribute.dita#conref-attribute/fig-attributes"/>
+			<p conkeyref="reuse-attributes/fig-attributes"/>
 		</section>
 		<example id="example" otherprops="examples">
 			<title>Example</title>

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -60,7 +60,7 @@ index entry would be sorted.</shortdesc>
                                 give an error message, and might recover from this error condition
                                 by ignoring all but the last
                                 <xmlelement>index-sort-as</xmlelement>.</p>
-                        <p><ph conref="../../common/conref-file.dita#reuse_file/index-sort-as"
+                        <p><ph conkeyref="reuse-general/index-sort-as"
                                         id="sort-as-error"/></p>
                 </section>
                 <section id="specialization-hierarchy">

--- a/specification/langRef/base/itemgroup.dita
+++ b/specification/langRef/base/itemgroup.dita
@@ -20,7 +20,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+   <p conkeyref="reuse-attributes/only-universal"/>
   </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;li&gt;Second point of a list.
  &lt;itemgroup&gt;related discourse&lt;/itemgroup&gt;

--- a/specification/langRef/base/keyword.dita
+++ b/specification/langRef/base/keyword.dita
@@ -23,7 +23,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-<p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
+<p conkeyref="reuse-attributes/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/base/line-through.dita
+++ b/specification/langRef/base/line-through.dita
@@ -17,7 +17,7 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p><ph conref="../../common/conref-file.dita#reuse_file/highlight-caution"/></p>
+      <p><ph conkeyref="reuse-general/highlight-caution"/></p>
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>

--- a/specification/langRef/base/line-through.dita
+++ b/specification/langRef/base/line-through.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/linkinfo.dita
+++ b/specification/langRef/base/linkinfo.dita
@@ -23,7 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;linklist&gt;
   &lt;title&gt;Repairing widgets&lt;/title&gt;

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -55,7 +55,7 @@
           keyref="attributes-common/mapkeyref"/>, and the attributes defined below. This element
         also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>type</xmlatt> from
           <xref keyref="attributes-linkRelationship"/>. </p>
-      <dl conref="../../common/conref-attribute.dita#conref-attribute/linklist-and-linkpool">
+      <dl conkeyref="reuse-attributes/linklist-and-linkpool">
         <dlentry>
           <dt/>
           <dd/>

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -27,7 +27,7 @@
         defined below. This element also uses <xmlatt>format</xmlatt>, <xmlatt>scope</xmlatt>, and
           <xmlatt>type</xmlatt> from <xref
           keyref="attributes-linkRelationship"/>. </p>
-   <dl conref="../../common/conref-attribute.dita#conref-attribute/linklist-and-linkpool">
+   <dl conkeyref="reuse-attributes/linklist-and-linkpool">
     <dlentry>
      <dt/>
      <dd/>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -32,7 +32,7 @@
         <dlentry id="type">
           <dt><xmlatt>type</xmlatt></dt>
           <dd>Indicates the location of the source of the quote. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/nonstandard-type"/> See
+              conkeyref="reuse-attributes/nonstandard-type"/> See
           <xref keyref="attributes-type"/> for detailed information on the
             usual supported values and processing implications. </dd>
         </dlentry>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -54,11 +54,11 @@
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
             keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>.</p>
         <dl>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/format-mapref">
+          <dlentry conkeyref="reuse-attributes/format-mapref">
             <dt/>
             <dd/>
           </dlentry>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+          <dlentry conkeyref="reuse-attributes/href-on-topicref">
             <dt/>
             <dd/>
           </dlentry>

--- a/specification/langRef/base/messagepanel.dita
+++ b/specification/langRef/base/messagepanel.dita
@@ -20,7 +20,7 @@ hazard.</shortdesc>
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/universal-spectitle-compact"/>
+      <p conkeyref="reuse-attributes/universal-spectitle-compact"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample generates an ANSI Z535.6 grouped safety message that specifies

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -44,7 +44,7 @@
         </dlentry>
         <dlentry>
           <dt><xmlatt>keyref</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/deprecated-attr"/></dt>
+            <ph conkeyref="reuse-attributes/deprecated-attr"/></dt>
           <dd>The <xmlatt>keyref</xmlatt> attribute was unintentionally defined for
               <xmlelement>navref</xmlelement> in the original DITA grammar files. It is retained for
             backwards compatibility. The attribute will be removed in a future release, and

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -4,7 +4,7 @@
  "reference.dtd">
 <reference id="navref" xml:lang="en-us">
 <title><xmlelement>navref</xmlelement></title>
-<shortdesc><ph conref="../../common/conref-file.dita#reuse_file/navtitle_shortdesc"/></shortdesc>
+<shortdesc><ph conkeyref="reuse-general/navtitle_shortdesc"/></shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -132,11 +132,11 @@
                     <dd>Contains a message to be displayed while an object is loading.
                         <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
                 </dlentry>
-                <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-height">
+                <dlentry conkeyref="reuse-attributes/image-height">
                     <dt/>
                     <dd/>
                 </dlentry>
-                <dlentry conref="../../common/conref-attribute.dita#conref-attribute/image-width">
+                <dlentry conkeyref="reuse-attributes/image-width">
                     <dt/>
                     <dd/>
                 </dlentry>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -31,14 +31,14 @@
    <dl>
     <dlentry id="name">
      <dt><xmlatt>name</xmlatt>
-      <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+      <ph conkeyref="reuse-attributes/required-attr"/></dt>
      <dd>The name of the metadata property.
       <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
      </dd>
     </dlentry>
     <dlentry id="content">
      <dt><xmlatt>content</xmlatt>
-      <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+      <ph conkeyref="reuse-attributes/required-attr"/></dt>
      <dd>The value for the property named in the <xmlatt>name</xmlatt> attribute.
       <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
      </dd>

--- a/specification/langRef/base/overline.dita
+++ b/specification/langRef/base/overline.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/overline.dita
+++ b/specification/langRef/base/overline.dita
@@ -15,7 +15,7 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p><ph conref="../../common/conref-file.dita#reuse_file/highlight-caution"/></p>
+      <p><ph conkeyref="reuse-general/highlight-caution"/></p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -28,7 +28,7 @@
       <dl>
         <dlentry>
           <dt><xmlatt>name</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The name of the parameter.
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
         </dlentry>
@@ -58,7 +58,7 @@
                   identifier that refers to an object declaration in the document. The identifier
                   must be the value of the ID attribute set for the declared object element. </dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt/>
                 <dd/>
               </dlentry>
@@ -68,7 +68,7 @@
           <dt><xmlatt>type</xmlatt></dt>
           <dd>This attribute specifies for a user agent the type of values that will be found at the
             URI designated by <xmlatt>value</xmlatt>. <ph
-              conref="../../common/conref-attribute.dita#conref-attribute/nonstandard-type"/>
+              conkeyref="reuse-attributes/nonstandard-type"/>
             <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
             <ol id="ol_svg_2c2_z1b">
               <li>When <xmlatt>valuetype</xmlatt> is set to "ref", this attribute directly specifies

--- a/specification/langRef/base/permissions.dita
+++ b/specification/langRef/base/permissions.dita
@@ -44,7 +44,7 @@
                 <dt>entitled </dt>
                 <dd>Special folks, only. </dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>

--- a/specification/langRef/base/q.dita
+++ b/specification/langRef/base/q.dita
@@ -24,7 +24,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+         <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title>
          <p>In the following code sample, the <xmlelement>q</xmlelement> element contains a

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -47,7 +47,7 @@
         definition of <xmlatt>linking</xmlatt> (given below) from <xref
           keyref="attributes-commonMap"/>.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+        <dlentry conkeyref="reuse-attributes/href-on-topicref">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/relheader.dita
+++ b/specification/langRef/base/relheader.dita
@@ -18,7 +18,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
 href="reltable.dita"></xref>.</p></example>

--- a/specification/langRef/base/relrow.dita
+++ b/specification/langRef/base/relrow.dita
@@ -20,7 +20,7 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+         <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
 href="reltable.dita"></xref>.</p></example>

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -60,7 +60,7 @@
           <xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
         />.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/toc-default-no">
+        <dlentry conkeyref="reuse-attributes/toc-default-no">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -20,7 +20,7 @@
       <dl>
         <dlentry id="modified">
           <dt><xmlatt>modified</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The last modification date, entered as YYYY-MM-DD, where YYYY is the year, MM is the
             month from 01 to 12, and DD is the day from 01-31.</dd>
         </dlentry>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -27,11 +27,11 @@
             keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <dl>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+          <dlentry conkeyref="reuse-attributes/href-on-topicref">
             <dt/>
             <dd/>
           </dlentry>
-          <dlentry conref="../../common/conref-attribute.dita#conref-attribute/format-mapref">
+          <dlentry conkeyref="reuse-attributes/format-mapref">
             <dt/>
             <dd/>
           </dlentry>

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-    <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+    <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the
 following example, the general title "Programming Example" is likely

--- a/specification/langRef/base/sectiondiv.dita
+++ b/specification/langRef/base/sectiondiv.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the example below, the <xmlelement>sectiondiv</xmlelement> element is used to group content
         that can be reused elsewhere.</p><codeblock>&lt;section>

--- a/specification/langRef/base/shape.dita
+++ b/specification/langRef/base/shape.dita
@@ -44,7 +44,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <sectiondiv
-                conref="../../common/conref-attribute.dita#conref-attribute/univ-outputclass-keyref-translate-NO"
+                conkeyref="reuse-attributes/univ-outputclass-keyref-translate-NO"
             />
         </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;area>

--- a/specification/langRef/base/shortdesc.dita
+++ b/specification/langRef/base/shortdesc.dita
@@ -23,7 +23,7 @@
         <title>Short description in a topic</title>
         <p>The following code sample shows how a <xmlelement>shortdesc</xmlelement> element can be
           used in a topic:</p>
-        <codeblock conref="../../common/conref-file.dita#reuse_file/concept-codeblock" id="shortdesc-in-concept"/>
+        <codeblock conkeyref="reuse-general/concept-codeblock" id="shortdesc-in-concept"/>
       </fig>
       <fig>
         <title>Short description in a map</title>

--- a/specification/langRef/base/sli.dita
+++ b/specification/langRef/base/sli.dita
@@ -14,7 +14,7 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+         <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="sl.dita"></xref>.</p></example>
 </refbody>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -82,8 +82,8 @@
           <li>Sort phrases are determined after filtering and content reference resolution
             occur.</li>
         </ul></p>
-      <p conref="../../common/conref-file.dita#reuse_file/sort-as-1"/>
-      <p conref="../../common/conref-file.dita#reuse_file/sort-as-2"/>
+      <p conkeyref="reuse-general/sort-as-1"/>
+      <p conkeyref="reuse-general/sort-as-2"/>
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/base/state.dita
+++ b/specification/langRef/base/state.dita
@@ -16,12 +16,12 @@
       <dl>
         <dlentry>
           <dt><xmlatt>name</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The name of the property whose state is being described.</dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>value</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The state of the property identified by the <xmlatt>name</xmlatt> attribute.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -41,7 +41,7 @@ controlled values.</shortdesc>
                   <dd>Indicates that the order of the child topics is significant; output processors
                     will typically link between them in order. </dd>
                 </dlentry>
-                <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+                <dlentry conkeyref="reuse-attributes/ditauseconref">
                   <dt/>
                   <dd/>
                 </dlentry>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -56,7 +56,7 @@ controlled values.</shortdesc>
           </dlentry>
         </dl></p>
     </section>
-<example conref="../../common/conref-examples.dita#conref-examples/example-subjectHead" id="example" otherprops="examples"/>
+<example conkeyref="reuse-examples/example-subjectHead" id="example" otherprops="examples"/>
 <!--<example id="example"><title>Example</title><p>In this example the <q>Server setup</q> label doesn't classify content but, when selected, is equivalent to the union of its child subjects. That is, the heading covers content about planning for any application, installing for any application, any task for web servers, or any task for database servers.</p><codeblock>&lt;subjectScheme toc="yes" search="no">
   ...
   &lt;subjectHead>

--- a/specification/langRef/base/subjectHeadMeta.dita
+++ b/specification/langRef/base/subjectHeadMeta.dita
@@ -20,6 +20,6 @@ description to be associated with a subject heading. </shortdesc>
    <sectiondiv
     conkeyref="reuse-attributes/standard-topicmeta-attributes"/>
   </section>
-<example conref="../../common/conref-examples.dita#conref-examples/example-subjectHead" id="example" otherprops="examples"/>
+<example conkeyref="reuse-examples/example-subjectHead" id="example" otherprops="examples"/>
 </refbody>
 </reference>

--- a/specification/langRef/base/subjectHeadMeta.dita
+++ b/specification/langRef/base/subjectHeadMeta.dita
@@ -18,7 +18,7 @@ description to be associated with a subject heading. </shortdesc>
   <section id="attributes">
    <title>Attributes</title>
    <sectiondiv
-    conref="../../common/conref-attribute.dita#conref-attribute/standard-topicmeta-attributes"/>
+    conkeyref="reuse-attributes/standard-topicmeta-attributes"/>
   </section>
 <example conref="../../common/conref-examples.dita#conref-examples/example-subjectHead" id="example" otherprops="examples"/>
 </refbody>

--- a/specification/langRef/base/subjectRel.dita
+++ b/specification/langRef/base/subjectRel.dita
@@ -22,7 +22,7 @@ the subjects instead of links between topic documents.</shortdesc>
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/subjectRelHeader.dita
+++ b/specification/langRef/base/subjectRelHeader.dita
@@ -27,7 +27,7 @@ subjects in associations.</shortdesc>
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
 <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/subjectRelTable.dita
+++ b/specification/langRef/base/subjectRelTable.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/reltable-minus-title"
+      <sectiondiv conkeyref="reuse-attributes/reltable-minus-title"
       />
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -28,17 +28,17 @@
           <xmlatt>format</xmlatt> from <xref keyref="attributes-linkRelationship"
         />.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/map-attribute-id">
+        <dlentry conkeyref="reuse-attributes/map-attribute-id">
           <dt/>
           <dd/>
         </dlentry>
         <dlentry
-          conref="../../common/conref-attribute.dita#conref-attribute/map-attribute-anchorref">
+          conkeyref="reuse-attributes/map-attribute-anchorref">
           <dt/>
           <dd/>
         </dlentry>
         <dlentry
-          conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
+          conkeyref="reuse-attributes/processing-role-default-resource-only">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -50,7 +50,7 @@
         </dlentry>
       </dl>
     </section>
-    <example conref="../../common/conref-examples.dita#conref-examples/example-subjectScheme"
+    <example conkeyref="reuse-examples/example-subjectScheme"
       id="example" otherprops="examples"/>
   </refbody>
 </reference>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -59,7 +59,7 @@
                                 and <xmlatt>locktitle</xmlatt> from <xref
                                         keyref="attributes-commonMap"/>. <dl>
                                         <dlentry
-                                                conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+                                                conkeyref="reuse-attributes/href-on-topicref">
                                                 <dt/>
                                                 <dd/>
                                         </dlentry>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -65,7 +65,7 @@
                                         </dlentry>
                                 </dl></p>
                 </section>
-<example conref="../../common/conref-examples.dita#conref-examples/example-subjectScheme" id="example" otherprops="examples"/>
+<example conkeyref="reuse-examples/example-subjectScheme" id="example" otherprops="examples"/>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -29,16 +29,16 @@
           <xmlatt>linking</xmlatt>, and narrowed definitions of <xmlatt>processing-role</xmlatt> and
           <xmlatt>toc</xmlatt> (given below), from <xref keyref="attributes-commonMap"/>.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+        <dlentry conkeyref="reuse-attributes/href-on-topicref">
           <dt/>
           <dd/>
         </dlentry>
         <dlentry
-          conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
+          conkeyref="reuse-attributes/processing-role-default-resource-only">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/toc-default-no">
+        <dlentry conkeyref="reuse-attributes/toc-default-no">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -44,7 +44,7 @@
         </dlentry>
       </dl>
     </section>
-    <example conref="../../common/conref-examples.dita#conref-examples/example-subjectref"/>
+    <example conkeyref="reuse-examples/example-subjectref"/>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -46,7 +46,7 @@
                 <dt>land</dt>
                 <dd>90 degrees counterclockwise from the text flow.</dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt/>
                 <dd/>
               </dlentry>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -21,7 +21,7 @@
         description that is parallel with figure description. See <xref href="simpletable.dita"/>
         for a simplified table model that can be specialized to represent more regular relationships
         of data.</p>
-      <p conref="../../common/conref-file.dita#reuse_file/pgwide-explain"/>
+      <p conkeyref="reuse-general/pgwide-explain"/>
       <note>The <xmlatt>scale</xmlatt> attribute represents a stylistic markup property that is
         currently maintained in tables for legacy purposes. External stylesheets should enable less
         dependency on this attribute. Use the <xmlatt>scale</xmlatt> attribute judiciously.</note>

--- a/specification/langRef/base/term.dita
+++ b/specification/langRef/base/term.dita
@@ -21,7 +21,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/universal-keyref"/>
+         <p conkeyref="reuse-attributes/universal-keyref"/>
       </section>
 <example id="example" otherprops="examples"
          ><title>Example</title><codeblock>&lt;p&gt;A &lt;term&gt;reference implementation&lt;/term&gt; of DITA implements the standard, 

--- a/specification/langRef/base/text.dita
+++ b/specification/langRef/base/text.dita
@@ -20,7 +20,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+         <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;p>This an example of &lt;keyword>&lt;text id="reuse">Text
    that is reusable&lt;/text>&lt;/keyword>, with no extra 

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -22,7 +22,7 @@
       <dl>
         <dlentry>
           <dt><xmlatt>cols</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Indicates the number of columns in a <xmlelement>tgroup</xmlelement>.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -15,7 +15,7 @@
       <dl>
         <dlentry>
           <dt><xmlatt>tmtype</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the trademark type. Allowable values are: <dl>
               <dlentry>
                 <dt>tm</dt>
@@ -29,7 +29,7 @@
                 <dt>service</dt>
                 <dd>service mark (service)</dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt/>
                 <dd/>
               </dlentry>

--- a/specification/langRef/base/topicSubjectHeader.dita
+++ b/specification/langRef/base/topicSubjectHeader.dita
@@ -34,7 +34,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/topicSubjectRow.dita
+++ b/specification/langRef/base/topicSubjectRow.dita
@@ -23,7 +23,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/topicSubjectTable.dita
+++ b/specification/langRef/base/topicSubjectTable.dita
@@ -38,7 +38,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conref="../../common/conref-attribute.dita#conref-attribute/reltable-minus-title"
+      <sectiondiv conkeyref="reuse-attributes/reltable-minus-title"
       />
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -33,16 +33,16 @@ can identify a single subject. Additional subjects can be specified by nested
           <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt> (given below), from <xref
           keyref="attributes-commonMap"/>.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+        <dlentry conkeyref="reuse-attributes/href-on-topicref">
           <dt/>
           <dd/>
         </dlentry>
         <dlentry
-          conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
+          conkeyref="reuse-attributes/processing-role-default-resource-only">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/toc-default-no">
+        <dlentry conkeyref="reuse-attributes/toc-default-no">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -55,7 +55,7 @@
         </dlentry>
       </dl>
     </section>
-    <example conref="../../common/conref-examples.dita#conref-examples/example-subjectref"/>
+    <example conkeyref="reuse-examples/example-subjectref"/>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -40,16 +40,16 @@
         uses narrowed definitions of <xmlatt>processing-role</xmlatt> and <xmlatt>toc</xmlatt>
         (given below) from <xref keyref="attributes-commonMap"/>.</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/href-on-topicref">
+        <dlentry conkeyref="reuse-attributes/href-on-topicref">
           <dt/>
           <dd/>
         </dlentry>
         <dlentry
-          conref="../../common/conref-attribute.dita#conref-attribute/processing-role-default-resource-only">
+          conkeyref="reuse-attributes/processing-role-default-resource-only">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/toc-default-no">
+        <dlentry conkeyref="reuse-attributes/toc-default-no">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/base/tt.dita
+++ b/specification/langRef/base/tt.dita
@@ -23,7 +23,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+         <p conkeyref="reuse-attributes/only-universal"/>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/base/tt.dita
+++ b/specification/langRef/base/tt.dita
@@ -12,7 +12,7 @@
 <refbody>
       <section id="usage-information">
          <title>Usage information</title>
-         <p><ph conref="../../common/conref-file.dita#reuse_file/highlight-caution"/> For example,
+         <p><ph conkeyref="reuse-general/highlight-caution"/> For example,
             for specific items such as inline code fragments, use the
                <xmlelement>codeph</xmlelement> element.</p>
       </section>

--- a/specification/langRef/base/typeofhazard.dita
+++ b/specification/langRef/base/typeofhazard.dita
@@ -17,7 +17,7 @@ a description of the type of hazard, for example, "Hot surfaces inside."</shortd
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample generate a "CAUTION" hazard statement, which warns users against

--- a/specification/langRef/base/unknown.dita
+++ b/specification/langRef/base/unknown.dita
@@ -17,7 +17,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/only-universal"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>This example features a specialized <xmlelement>unknown</xmlelement> element that includes other
         non-DITA content. If this specialization is imported to a DTD or schema, the DTD or schema

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -33,7 +33,7 @@
       <dl>
         <dlentry>
           <dt id="uxatt-name"><xmlatt>name</xmlatt>
-            <ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The value used to refer to this window definition.</dd>
         </dlentry>
         <dlentry>
@@ -97,7 +97,7 @@
                 <dd>The window dimensions specified on this element are relative to the calling
                   window.</dd>
               </dlentry>
-              <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditauseconref">
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt/>
                 <dd/>
               </dlentry>

--- a/specification/langRef/base/vrm.dita
+++ b/specification/langRef/base/vrm.dita
@@ -20,7 +20,7 @@
                 <dlentry id="version">
                     <dt><xmlatt>version</xmlatt>
                         <ph
-                            conref="../../common/conref-attribute.dita#conref-attribute/required-attr"
+                            conkeyref="reuse-attributes/required-attr"
                         /></dt>
                     <dd>Indicates the released version number of the product(s) that the document
                         describes.</dd>

--- a/specification/langRef/ditaval/ditaval-alt-text.dita
+++ b/specification/langRef/ditaval/ditaval-alt-text.dita
@@ -19,7 +19,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conref="../../common/conref-attribute.dita#conref-attribute/no-atts"/>
+      <p conkeyref="reuse-attributes/no-atts"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="val"/>.</p></example>
 </refbody>

--- a/specification/langRef/ditaval/ditaval-endflag.dita
+++ b/specification/langRef/ditaval/ditaval-endflag.dita
@@ -22,7 +22,7 @@
       <title>Attributes</title>
       <p>The following attribute is available on this element:</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-imageref">
+        <dlentry conkeyref="reuse-attributes/ditaval-imageref">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -27,14 +27,14 @@ the attribute, to take an action on. The identified attribute is a conditional-p
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
       <p
-        conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/color-backcolor-style"/>
+        conkeyref="rendering/color-backcolor-style"/>
       <p
-        conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/style-attr"/>
+        conkeyref="rendering/style-attr"/>
       <p
-        conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/other-tokens-style"
+        conkeyref="rendering/other-tokens-style"
       />
     </section>
-    <!--<section conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/rendering-expectations-prop-and-revprop"><title/><p/></section>-->
+    <!--<section conkeyref="rendering/rendering-expectations-prop-and-revprop"><title/><p/></section>-->
     <section id="processing-expectations">
       <title>Processing expectations</title>
       <p>Recovery from the following errors are implementation dependent;  processors <term

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -70,7 +70,7 @@ the attribute, to take an action on. The identified attribute is a conditional-p
         </dlentry>
         <dlentry>
           <dt><xmlatt>action</xmlatt>
-<ph conref="../../common/conref-attribute.dita#conref-attribute/required-attr"/></dt>
+<ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the action to be taken. Allowable values are:<dl>
               <dlentry>
                 <dt>include</dt>
@@ -98,19 +98,19 @@ the attribute, to take an action on. The identified attribute is a conditional-p
               </dlentry>
             </dl></dd>
         </dlentry>
-<dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-outputclass">
+<dlentry conkeyref="reuse-attributes/ditaval-outputclass">
 <dt/>
 <dd/>
 </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-color">
+        <dlentry conkeyref="reuse-attributes/ditaval-color">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-backcolor">
+        <dlentry conkeyref="reuse-attributes/ditaval-backcolor">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-style">
+        <dlentry conkeyref="reuse-attributes/ditaval-style">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -30,11 +30,11 @@
                         <xmlelement>revprop</xmlelement> end of change is a localized translation of
                     "End of change". </ph></p>
             <p
-                conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/color-backcolor-style"/>
+                conkeyref="rendering/color-backcolor-style"/>
             <p
-                conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/style-attr"/>
+                conkeyref="rendering/style-attr"/>
             <p
-                conref="../../common/conref-rendering-expectations.dita#conref-rendering-expectations/other-tokens-style"/>
+                conkeyref="rendering/other-tokens-style"/>
         </section>
         <section id="processing-expectations">
             <title>Processing expectations</title>

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -55,7 +55,7 @@
                     <dlentry>
                         <dt><xmlatt>action</xmlatt>
                             <ph
-                                conref="../../common/conref-attribute.dita#conref-attribute/required-attr"
+                                conkeyref="reuse-attributes/required-attr"
                             /></dt>
                         <dd>The action to be taken. Allowable values are:<dl>
                                 <dlentry>
@@ -87,22 +87,22 @@
                             according to the changebar support of the target output format. If flag
                             has not been set, this attribute is ignored.</dd>
                     </dlentry>
-<dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-outputclass">
+<dlentry conkeyref="reuse-attributes/ditaval-outputclass">
 <dt/>
 <dd/>
 </dlentry>
                     <dlentry
-                        conref="../../common/conref-attribute.dita#conref-attribute/ditaval-color">
+                        conkeyref="reuse-attributes/ditaval-color">
                         <dt/>
                         <dd/>
                     </dlentry>
                     <dlentry
-                        conref="../../common/conref-attribute.dita#conref-attribute/ditaval-backcolor">
+                        conkeyref="reuse-attributes/ditaval-backcolor">
                         <dt/>
                         <dd/>
                     </dlentry>
                     <dlentry
-                        conref="../../common/conref-attribute.dita#conref-attribute/ditaval-style">
+                        conkeyref="reuse-attributes/ditaval-style">
                         <dt/>
                         <dd/>
                     </dlentry>

--- a/specification/langRef/ditaval/ditaval-startflag.dita
+++ b/specification/langRef/ditaval/ditaval-startflag.dita
@@ -23,7 +23,7 @@
       <title>Attributes</title>
       <p>The following attribute is available on this element:</p>
       <dl>
-        <dlentry conref="../../common/conref-attribute.dita#conref-attribute/ditaval-imageref">
+        <dlentry conkeyref="reuse-attributes/ditaval-imageref">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/ditaval/ditaval-val.dita
+++ b/specification/langRef/ditaval/ditaval-val.dita
@@ -19,7 +19,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p conref="../../common/conref-attribute.dita#conref-attribute/no-atts"/>
+         <p conkeyref="reuse-attributes/no-atts"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><fig><title>Sample
 DITAVAL file</title>

--- a/specification/non-normative/dtd-public-identifiers.dita
+++ b/specification/non-normative/dtd-public-identifiers.dita
@@ -22,7 +22,7 @@
         OASIS. The keyword "DITA" is a convention that indicates that the artifact is
         DITA-related.</p>
     </section>
-    <!--<section><title>Topic and topic-based specializations</title><p conref="../../common/conref-file.dita#reuse_file/module-version-xpl"/><dl><dlentry product="base"><dt>Base topic</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Topic//EN" "basetopic.dtd"
+    <!--<section><title>Topic and topic-based specializations</title><p conkeyref="reuse-general/module-version-xpl"/><dl><dlentry product="base"><dt>Base topic</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Topic//EN" "basetopic.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.3 Base Topic//EN" "basetopic.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.x Base Topic//EN" "basetopic.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Concept</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.3 Concept//EN" "concept.dtd"
@@ -55,7 +55,7 @@ PUBLIC "-//OASIS//DTD DITA 1.3 Task//EN" "task.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.x Task//EN" "task.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Topic</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.3 Topic//EN" "topic.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.x Topic//EN" "topic.dtd"</lines></dd></dlentry></dl></section>-->
-    <!--<section><title>Map and map-based specializations</title><p conref="../../common/conref-file.dita#reuse_file/module-version-xpl"/><dl><dlentry product="base"><dt>Base map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Map//EN" "basemap.dtd"
+    <!--<section><title>Map and map-based specializations</title><p conkeyref="reuse-general/module-version-xpl"/><dl><dlentry product="base"><dt>Base map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Map//EN" "basemap.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.1 Base Map//EN" "basemap.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.0 Base Map//EN" "basemap.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Bookmap</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA BookMap//EN" "bookmap.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN" "bookmap.dtd"
@@ -74,7 +74,7 @@ PUBLIC "-//OASIS//DTD DITA 1.1 Map//EN" "map.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.0 Map//EN" "map.dtd"</lines></dd></dlentry><dlentry product="base"><dt>Subject scheme</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Subject Scheme Map//EN" "subjectScheme.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.x Subject Scheme Map//EN" "subjectScheme.dtd"
 PUBLIC "-//OASIS//DTD DITA Subject Scheme Map//EN" "subjectScheme.dtd"</lines></dd></dlentry></dl></section>-->
-    <!--<section><title>DITAVAL for conditional processing</title><p conref="../../common/conref-file.dita#reuse_file/module-version-xpl"/><lines>PUBLIC "-//OASIS//DTD DITA DITAVAL//EN" "ditaval.dtd"
+    <!--<section><title>DITAVAL for conditional processing</title><p conkeyref="reuse-general/module-version-xpl"/><lines>PUBLIC "-//OASIS//DTD DITA DITAVAL//EN" "ditaval.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.x DITAVAL//EN" "ditaval.dtd"
 PUBLIC "-//OASIS//DTD DITA 1.3 DITAVAL//EN" "ditaval.dtd"</lines></section>-->
   </refbody>


### PR DESCRIPTION
Several updates to spec topics:

- [X] Switches attribute reuse from `conref` to `conkeyref` (this topic already had a key, and several spec topics already used `conkeyref`)
- [X] Switches "rendering" reuse from `conref` to use the existing key and `conkeyref`
- [X] Defines a key for the attribute reuse topic (following the key naming pattern), and updates topics to use that key
- [X] Define a key for the more general purpose `conref-file.dita` (`reuse-general`) and update `conref` references to use that
- [X] Define a key for `reuse-code-samples.dita` and update `conref` references to use that