### PR TITLE
Fix broken attlist for change-historylist

### DIFF
--- a/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -59,7 +59,10 @@
                        "(%change-item;)*"
 >
 <!ENTITY % change-historylist.attributes
-              "%changehistory.data.atts;"
+              "%univ-atts;
+               mapkeyref
+                          CDATA
+                                    #IMPLIED"
 >
 <!ELEMENT  change-historylist %change-historylist.content;>
 <!ATTLIST  change-historylist %change-historylist.attributes;>

--- a/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -109,7 +109,11 @@ PUBLIC "-//OASIS//ENTITIES DITA Release Management Domain//EN"
         </zeroOrMore>
       </define>
       <define name="change-historylist.attributes">
-        <ref name="changehistory.data.atts"/>
+        <ref name="univ-atts"/>
+        <optional>
+          <attribute name="mapkeyref"/>
+        </optional>
+      </define>
       </define>
       <define name="change-historylist.element">
         <element name="change-historylist" dita:longName="Change History List"

--- a/doctypes/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
@@ -133,7 +133,8 @@
       </xs:sequence>
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
-      <xs:attributeGroup ref="changehistory.data.atts"/>
+      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>
    <xs:element name="change-item">

--- a/doctypes/schema/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/doctypes/schema/technicalContent/xsd/releaseManagementDomain.xsd
@@ -133,7 +133,8 @@
       </xs:sequence>
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
-      <xs:attributeGroup ref="changehistory.data.atts"/>
+      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>
    <xs:element name="change-item">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Cleans up attribute list for `change-historylist`, which is technically incorrect in the 1.3 grammar files (but correct in the written spec), as discussed at TC December 10, 2019.