### PR TITLE
Fix missing filter att declarations

### DIFF
--- a/doctypes/dtd/subjectScheme/subjectScheme.dtd
+++ b/doctypes/dtd/subjectScheme/subjectScheme.dtd
@@ -139,7 +139,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY included-domains
-                          "&deliveryTargetAtt-d-att;
+                          "&audienceAtt-d-att;
+                           &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
   "
 >
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Subject scheme "included-domains" entity for DTD only had the `deliveryTarget` attribute contribution, didn't have the other four audience/platform/product/otherprops contributions.

RNG version was correct.