### PR TITLE
Update class attributes for linktext, shortdesc, and searchtitle

### DIFF
--- a/doctypes/dtd/base/commonElements.ent
+++ b/doctypes/dtd/base/commonElements.ent
@@ -39,6 +39,9 @@
 <!ENTITY % foreign     "foreign"                                     >
 <!ENTITY % title       "title"                                       >
 <!ENTITY % navtitle    "navtitle"                                    >
+<!ENTITY % searchtitle "searchtitle"                                 >
+<!ENTITY % linktext    "linktext"                                    >
+<!ENTITY % shortdesc   "shortdesc"                                   >
 <!ENTITY % desc        "desc"                                        >
 <!ENTITY % p           "p"                                           >
 <!ENTITY % note        "note"                                        >

--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -665,6 +665,41 @@
 <!ELEMENT  navtitle %navtitle.content;>
 <!ATTLIST  navtitle %navtitle.attributes;>
 
+<!--                    LONG NAME: Search Title                    -->
+<!ENTITY % searchtitle.content
+                       "(%words.cnt; |
+                         %ph;)*"
+>
+<!ENTITY % searchtitle.attributes
+              "%univ-atts;"
+>
+<!ELEMENT  searchtitle %searchtitle.content;>
+<!ATTLIST  searchtitle %searchtitle.attributes;>
+
+
+<!--                    LONG NAME: linktext                        -->
+<!ENTITY % linktext.content
+                       "(%words.cnt; |
+                         %ph;)*"
+>
+<!ENTITY % linktext.attributes
+              "%univ-atts;"
+>
+<!ELEMENT  linktext %linktext.content;>
+<!ATTLIST  linktext %linktext.attributes;>
+
+
+<!--                    LONG NAME: Short Description               -->
+<!ENTITY % shortdesc.content
+                       "(%title.cnt; |
+                         %xref;)*"
+>
+<!ENTITY % shortdesc.attributes
+              "%univ-atts;"
+>
+<!ELEMENT  shortdesc %shortdesc.content;>
+<!ATTLIST  shortdesc %shortdesc.attributes;>
+
 
 <!--                    LONG NAME: Description                     -->
 <!ENTITY % desc.content
@@ -1651,6 +1686,7 @@
 <!ATTLIST  keyword        class CDATA "- topic/keyword "    >
 <!ATTLIST  li             class CDATA "- topic/li "         >
 <!ATTLIST  lines          class CDATA "- topic/lines "      >
+<!ATTLIST  linktext       class CDATA "- topic/linktext "   >
 <!ATTLIST  longdescref    class CDATA "- topic/longdescref ">
 <!ATTLIST  longquoteref   class CDATA "- topic/longquoteref ">
 <!ATTLIST  lq             class CDATA "- topic/lq "         >
@@ -1664,6 +1700,8 @@
 <!ATTLIST  pre            class CDATA "- topic/pre "        >
 <!ATTLIST  q              class CDATA "- topic/q "          >
 <!ATTLIST  required-cleanup   class CDATA "- topic/required-cleanup ">
+<!ATTLIST  searchtitle    class CDATA "- topic/searchtitle ">
+<!ATTLIST  shortdesc      class CDATA "- topic/shortdesc "  >
 <!ATTLIST  simpletable    class CDATA "- topic/simpletable ">
 <!ATTLIST  sl             class CDATA "- topic/sl "         >
 <!ATTLIST  sli            class CDATA "- topic/sli "        >

--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -580,41 +580,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
 <!ATTLIST  topicmeta %topicmeta.attributes;>
 
 
-<!--                    LONG NAME: Short Description               -->
-<!ENTITY % shortdesc.content
-                       "(%title.cnt; |
-                         %xref;)*"
->
-<!ENTITY % shortdesc.attributes
-              "%univ-atts;"
->
-<!ELEMENT  shortdesc %shortdesc.content;>
-<!ATTLIST  shortdesc %shortdesc.attributes;>
-
-
-<!--                    LONG NAME: Link Text                       -->
-<!ENTITY % linktext.content
-                       "(%words.cnt; |
-                         %ph;)*"
->
-<!ENTITY % linktext.attributes
-              "%univ-atts;"
->
-<!ELEMENT  linktext %linktext.content;>
-<!ATTLIST  linktext %linktext.attributes;>
-
-
-<!--                    LONG NAME: Search Title                    -->
-<!ENTITY % searchtitle.content
-                       "(%words.cnt;)*"
->
-<!ENTITY % searchtitle.attributes
-              "%univ-atts;"
->
-<!ELEMENT  searchtitle %searchtitle.content;>
-<!ATTLIST  searchtitle %searchtitle.attributes;>
-
-
 <!--                    LONG NAME: User Experience Window          -->
 <!ENTITY % ux-window.content
                        "EMPTY"
@@ -678,9 +643,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
 <!ATTLIST  relrow         class CDATA "- map/relrow "       >
 <!ATTLIST  relcell        class CDATA "- map/relcell "      >
 <!ATTLIST  topicmeta      class CDATA "- map/topicmeta "    >
-<!ATTLIST  linktext       class CDATA "- map/linktext "     >
-<!ATTLIST  searchtitle    class CDATA "- map/searchtitle "  >
-<!ATTLIST  shortdesc      class CDATA "- map/shortdesc "    >
 <!ATTLIST  ux-window      class CDATA "- map/ux-window "    >
 
 <!-- ================== End of DITA Map Module ==================== -->

--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -291,30 +291,6 @@
 <!ATTLIST  titlealts %titlealts.attributes;>
 
 
-<!--                    LONG NAME: Search Title                    -->
-<!ENTITY % searchtitle.content
-                       "(%words.cnt; |
-                         %ph;)*"
->
-<!ENTITY % searchtitle.attributes
-              "%univ-atts;"
->
-<!ELEMENT  searchtitle %searchtitle.content;>
-<!ATTLIST  searchtitle %searchtitle.attributes;>
-
-
-<!--                    LONG NAME: Short Description               -->
-<!ENTITY % shortdesc.content
-                       "(%title.cnt; |
-                         %xref;)*"
->
-<!ENTITY % shortdesc.attributes
-              "%univ-atts;"
->
-<!ELEMENT  shortdesc %shortdesc.content;>
-<!ATTLIST  shortdesc %shortdesc.attributes;>
-
-
 <!--                    LONG NAME: Abstract                        -->
 <!ENTITY % abstract.content
                        "(%abstract.cnt;)*"
@@ -453,18 +429,6 @@
 <!ATTLIST  link %link.attributes;>
 
 
-<!--                    LONG NAME: linktext                        -->
-<!ENTITY % linktext.content
-                       "(%words.cnt; |
-                         %ph;)*"
->
-<!ENTITY % linktext.attributes
-              "%univ-atts;"
->
-<!ELEMENT  linktext %linktext.content;>
-<!ATTLIST  linktext %linktext.attributes;>
-
-
 <!--                    LONG NAME: linklist                        -->
 <!ENTITY % linklist.content
                        "((%title;)?,
@@ -551,16 +515,13 @@
 <!ATTLIST  linkinfo       class CDATA "- topic/linkinfo "   >
 <!ATTLIST  linklist       class CDATA "- topic/linklist "   >
 <!ATTLIST  linkpool       class CDATA "- topic/linkpool "   >
-<!ATTLIST  linktext       class CDATA "- topic/linktext "   >
 <!ATTLIST  no-topic-nesting   class CDATA "- topic/no-topic-nesting ">
 <!ATTLIST  prolog         class CDATA "- topic/prolog "     >
 <!ATTLIST  related-links   class CDATA "- topic/related-links ">
-<!ATTLIST  searchtitle    class CDATA "- topic/searchtitle ">
 <!ATTLIST  section        class CDATA "- topic/section "    >
 <!ATTLIST  sectiondiv     class CDATA "- topic/sectiondiv " >
 <!ATTLIST  titlealts      class CDATA "- topic/titlealts "  >
 <!ATTLIST  topic          class CDATA "- topic/topic "      >
-<!ATTLIST  shortdesc      class CDATA "- topic/shortdesc "  >
 
 <!-- ================== End of DITA Topic Module ==================== -->
  

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -144,6 +144,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     <define name="lines">
       <ref name="lines.element"/>
     </define>
+    <define name="linktext">
+      <ref name="linktext.element"/>
+    </define>
     <define name="longdescref">
       <ref name="longdescref.element"/>
     </define>
@@ -182,6 +185,12 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     </define>
     <define name="required-cleanup">
       <ref name="required-cleanup.element"/>
+    </define>
+    <define name="searchtitle">
+      <ref name="searchtitle.element"/>
+    </define>
+    <define name="shortdesc">
+      <ref name="shortdesc.element"/>
     </define>
     <define name="sl">
       <ref name="sl.element"/>
@@ -1231,6 +1240,93 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
 
 
+      </div>
+      <div>
+        <a:documentation>LONG NAME: Search Title</a:documentation>
+        
+        <define name="searchtitle.content">
+          <zeroOrMore>
+            <choice>
+              <ref name="words.cnt"/>
+              <ref name="ph"/>
+            </choice>
+          </zeroOrMore>
+        </define>
+        <define name="searchtitle.attributes">
+          <ref name="univ-atts"/>
+        </define>
+        <define name="searchtitle.element">
+          <element name="searchtitle" dita:longName="Search Title">
+            <a:documentation>When your DITA topic is transformed to XHTML, the &lt;searchtitle> element is used to create a title element at the top of the resulting HTML file. This title is normally
+              used in search result summaries by some search engines, such as that in Eclipse (http://eclipse.org); if not set, the XHTML's title element defaults to the source topic's title content
+              (which may not be as well optimized for search summaries) Category: Topic elements</a:documentation>
+            <ref name="searchtitle.attlist"/>
+            <ref name="searchtitle.content"/>
+          </element>
+        </define>
+        <define name="searchtitle.attlist" combine="interleave">
+          <ref name="searchtitle.attributes"/>
+        </define>
+        
+      </div>
+      <div>
+        <a:documentation>LONG NAME: Short Description</a:documentation>
+        <define name="shortdesc.content">
+          <zeroOrMore>
+            <choice>
+              <ref name="title.cnt"/>
+              <ref name="xref" dita:since="1.3"/>
+            </choice>
+          </zeroOrMore>
+        </define>
+        <define name="shortdesc.attributes">
+          <ref name="univ-atts"/>
+        </define>
+        <define name="shortdesc.element">
+          <element name="shortdesc" dita:longName="Short Description">
+            <a:documentation>The short description (&lt;shortdesc>) element occurs between the topic title and the topic body, as the initial paragraph-like content of a topic, or it can be embedded
+              in an abstract element. The short description, which represents the purpose or theme of the topic, is also intended to be used as a link preview and for searching. When used within a
+              DITA map, the short description of the &lt;topicref> can be used to override the short description in the topic. Category: Topic elements</a:documentation>
+            <ref name="shortdesc.attlist"/>
+            <ref name="shortdesc.content"/>
+          </element>
+        </define>
+        <define name="shortdesc.attlist" combine="interleave">
+          <ref name="shortdesc.attributes"/>
+        </define>
+        
+      </div>
+      <div>
+        <a:documentation>LONG NAME: Link Text</a:documentation>
+        
+        <define name="linktext.content">
+          <zeroOrMore>
+            <choice>
+              <ref name="words.cnt"/>
+              <ref name="ph"/>
+            </choice>
+          </zeroOrMore>
+        </define>
+        <define name="linktext.attributes">
+          <optional>
+            <attribute name="outputclass"/>
+          </optional>
+          <ref name="univ-atts"/>
+        </define>
+        <define name="linktext.element">
+          <element name="linktext" dita:longName="linktext">
+            <a:documentation>The &lt;linktext> element provides the literal label or line of text for a link. In most cases, the text of a link can be resolved during processing by cross reference
+              with the target resource. Use the &lt;linktext> element only when the target cannot be reached, such as when it is a peer or external link, or the target is local but not in DITA format.
+              When used inside a topic, it will be used as the text for the specified link; when used within a map, it will be used as the text for generated links that point to the specified topic.
+              Category: Related Links elements</a:documentation>
+            <ref name="linktext.attlist"/>
+            <ref name="linktext.content"/>
+          </element>
+        </define>
+        <define name="linktext.attlist" combine="interleave">
+          <ref name="linktext.attributes"/>
+        </define>
+        
       </div>
     </div>
     <div>
@@ -3057,6 +3153,11 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         <attribute name="class" a:defaultValue="- topic/lines "/>
       </optional>
     </define>
+    <define name="linktext.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="- topic/linktext "/>
+      </optional>
+    </define>
     <define name="longdescref.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/longdescref "/>
@@ -3120,6 +3221,16 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     <define name="required-cleanup.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/required-cleanup "/>
+      </optional>
+    </define>
+    <define name="searchtitle.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="- topic/searchtitle "/>
+      </optional>
+    </define>
+    <define name="shortdesc.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="- topic/shortdesc "/>
       </optional>
     </define>
     <define name="simpletable.attlist" combine="interleave">

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -89,9 +89,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
     <define name="anchor">
       <ref name="anchor.element"/>
     </define>
-    <define name="linktext">
-      <ref name="linktext.element"/>
-    </define>
     <define name="navref">
       <ref name="navref.element"/>
     </define>
@@ -109,12 +106,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
     </define>
     <define name="reltable">
       <ref name="reltable.element"/>
-    </define>
-    <define name="searchtitle">
-      <ref name="searchtitle.element"/>
-    </define>
-    <define name="shortdesc">
-      <ref name="shortdesc.element"/>
     </define>
     <define name="topicmeta">
       <ref name="topicmeta.element"/>
@@ -916,86 +907,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       <define name="topicmeta.attlist" combine="interleave">
         <ref name="topicmeta.attributes"/>
       </define>
-
     </div>
-      <div>
-        <a:documentation>LONG NAME: Short Description</a:documentation>
-        <define name="shortdesc.content">
-          <zeroOrMore>
-            <choice>
-              <ref name="title.cnt"/>
-              <ref name="xref" dita:since="1.3"/>
-            </choice>
-          </zeroOrMore>
-        </define>
-        <define name="shortdesc.attributes">
-          <ref name="univ-atts"/>
-        </define>
-        <define name="shortdesc.element">
-          <element name="shortdesc" dita:longName="Short Description">
-            <a:documentation>The short description (&lt;shortdesc>) element occurs between the topic title and the topic body, as the initial paragraph-like content of a topic, or it can be embedded
-              in an abstract element. The short description, which represents the purpose or theme of the topic, is also intended to be used as a link preview and for searching. When used within a
-              DITA map, the short description of the &lt;topicref> can be used to override the short description in the topic. Category: Topic elements</a:documentation>
-            <ref name="shortdesc.attlist"/>
-            <ref name="shortdesc.content"/>
-          </element>
-        </define>
-        <define name="shortdesc.attlist" combine="interleave">
-          <ref name="shortdesc.attributes"/>
-        </define>
-
-      </div>
-    <div>
-      <a:documentation>LONG NAME: Link Text</a:documentation>
-      <define name="linktext.content">
-        <zeroOrMore>
-          <choice>
-            <ref name="words.cnt"/>
-            <ref name="ph"/>
-          </choice>
-        </zeroOrMore>
-      </define>
-      <define name="linktext.attributes">
-        <ref name="univ-atts"/>
-      </define>
-      <define name="linktext.element">
-        <a:documentation>The &lt;linktext> element provides the literal label or line of text for a link. In most cases, the text of a link can be resolved during processing by cross reference with
-          the target resource. Use the &lt;linktext> element only when the target cannot be reached, such as when it is a peer or external link, or the target is local but not in DITA format. When
-          used inside a topic, it will be used as the text for the specified link; when used within a map, it will be used as the text for generated links that point to the specified topic. Category:
-          Related Links elements</a:documentation>
-        <element name="linktext" dita:longName="Link Text">
-          <ref name="linktext.attlist"/>
-          <ref name="linktext.content"/>
-        </element>
-      </define>
-      <define name="linktext.attlist" combine="interleave">
-        <ref name="linktext.attributes"/>
-      </define>
-
-    </div>
-    <div>
-      <a:documentation>LONG NAME: Search Title</a:documentation>
-      <define name="searchtitle.content">
-        <zeroOrMore>
-          <ref name="words.cnt"/>
-        </zeroOrMore>
-      </define>
-      <define name="searchtitle.attributes">
-        <ref name="univ-atts"/>
-      </define>
-      <define name="searchtitle.element">
-        <a:documentation>When your DITA topic is transformed to XHTML, the &lt;searchtitle> element is used to create a title element at the top of the resulting HTML file. This title is normally used
-          in search result summaries by some search engines, such as that in Eclipse (http://eclipse.org); if not set, the XHTML's title element defaults to the source topic's title content (which may
-          not be as well optimized for search summaries). Category: Topic elements</a:documentation>
-        <element name="searchtitle" dita:longName="Search Title">
-          <ref name="searchtitle.attlist"/>
-          <ref name="searchtitle.content"/>
-        </element>
-      </define>
-      <define name="searchtitle.attlist" combine="interleave">
-        <ref name="searchtitle.attributes"/>
-      </define>
-    </div>    
     <div>
       <a:documentation>LONG NAME: User Experience Window</a:documentation>
       <define name="ux-window.content">
@@ -1114,21 +1026,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
     <define name="topicmeta.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- map/topicmeta "/>
-      </optional>
-    </define>
-    <define name="linktext.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/linktext "/>
-      </optional>
-    </define>
-    <define name="searchtitle.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/searchtitle "/>
-      </optional>
-    </define>
-    <define name="shortdesc.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/shortdesc "/>
       </optional>
     </define>
     <define name="ux-window.attlist" combine="interleave">

--- a/doctypes/rng/base/topicMod.rng
+++ b/doctypes/rng/base/topicMod.rng
@@ -102,26 +102,17 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
     <define name="linkpool">
       <ref name="linkpool.element"/>
     </define>
-    <define name="linktext">
-      <ref name="linktext.element"/>
-    </define>
     <define name="prolog">
       <ref name="prolog.element"/>
     </define>
     <define name="related-links">
       <ref name="related-links.element"/>
     </define>
-    <define name="searchtitle">
-      <ref name="searchtitle.element"/>
-    </define>
     <define name="section">
       <ref name="section.element"/>
     </define>
     <define name="sectiondiv">
       <ref name="sectiondiv.element"/>
-    </define>
-    <define name="shortdesc">
-      <ref name="shortdesc.element"/>
     </define>
     <define name="titlealts">
       <ref name="titlealts.element"/>
@@ -366,61 +357,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
         <ref name="titlealts.attributes"/>
       </define>
     </div>
-    <div>
-      <a:documentation>LONG NAME: Search Title</a:documentation>
-
-      <define name="searchtitle.content">
-        <zeroOrMore>
-          <choice>
-            <ref name="words.cnt"/>
-            <ref name="ph"/>
-          </choice>
-        </zeroOrMore>
-      </define>
-      <define name="searchtitle.attributes">
-        <ref name="univ-atts"/>
-      </define>
-      <define name="searchtitle.element">
-        <element name="searchtitle" dita:longName="Search Title">
-          <a:documentation>When your DITA topic is transformed to XHTML, the &lt;searchtitle> element is used to create a title element at the top of the resulting HTML file. This title is normally
-            used in search result summaries by some search engines, such as that in Eclipse (http://eclipse.org); if not set, the XHTML's title element defaults to the source topic's title content
-            (which may not be as well optimized for search summaries) Category: Topic elements</a:documentation>
-          <ref name="searchtitle.attlist"/>
-          <ref name="searchtitle.content"/>
-        </element>
-      </define>
-      <define name="searchtitle.attlist" combine="interleave">
-        <ref name="searchtitle.attributes"/>
-      </define>
-
-    </div>
-      <div>
-        <a:documentation>LONG NAME: Short Description</a:documentation>
-        <define name="shortdesc.content">
-          <zeroOrMore>
-            <choice>
-              <ref name="title.cnt"/>
-              <ref name="xref" dita:since="1.3"/>
-            </choice>
-          </zeroOrMore>
-        </define>
-        <define name="shortdesc.attributes">
-          <ref name="univ-atts"/>
-        </define>
-        <define name="shortdesc.element">
-          <element name="shortdesc" dita:longName="Short Description">
-            <a:documentation>The short description (&lt;shortdesc>) element occurs between the topic title and the topic body, as the initial paragraph-like content of a topic, or it can be embedded
-              in an abstract element. The short description, which represents the purpose or theme of the topic, is also intended to be used as a link preview and for searching. When used within a
-              DITA map, the short description of the &lt;topicref> can be used to override the short description in the topic. Category: Topic elements</a:documentation>
-            <ref name="shortdesc.attlist"/>
-            <ref name="shortdesc.content"/>
-          </element>
-        </define>
-        <define name="shortdesc.attlist" combine="interleave">
-          <ref name="shortdesc.attributes"/>
-        </define>
-
-      </div>
+ 
     <div>
       <a:documentation>LONG NAME: Abstract</a:documentation>
 
@@ -738,35 +675,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
 
       </div>
       <div>
-        <a:documentation>LONG NAME: Link Text</a:documentation>
-
-        <define name="linktext.content">
-          <zeroOrMore>
-            <choice>
-              <ref name="words.cnt"/>
-              <ref name="ph"/>
-            </choice>
-          </zeroOrMore>
-        </define>
-        <define name="linktext.attributes">
-          <ref name="univ-atts"/>
-        </define>
-        <define name="linktext.element">
-          <element name="linktext" dita:longName="linktext">
-            <a:documentation>The &lt;linktext> element provides the literal label or line of text for a link. In most cases, the text of a link can be resolved during processing by cross reference
-              with the target resource. Use the &lt;linktext> element only when the target cannot be reached, such as when it is a peer or external link, or the target is local but not in DITA format.
-              When used inside a topic, it will be used as the text for the specified link; when used within a map, it will be used as the text for generated links that point to the specified topic.
-              Category: Related Links elements</a:documentation>
-            <ref name="linktext.attlist"/>
-            <ref name="linktext.content"/>
-          </element>
-        </define>
-        <define name="linktext.attlist" combine="interleave">
-          <ref name="linktext.attributes"/>
-        </define>
-
-      </div>
-      <div>
         <a:documentation>LONG NAME: Link List</a:documentation>
 
         <define name="linklist.content">
@@ -954,11 +862,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
         <attribute name="class" a:defaultValue="- topic/linkpool "/>
       </optional>
     </define>
-    <define name="linktext.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- topic/linktext "/>
-      </optional>
-    </define>
     <define name="no-topic-nesting.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/no-topic-nesting "/>
@@ -972,11 +875,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
     <define name="related-links.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/related-links "/>
-      </optional>
-    </define>
-    <define name="searchtitle.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- topic/searchtitle "/>
       </optional>
     </define>
     <define name="section.attlist" combine="interleave">
@@ -997,11 +895,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
     <define name="topic.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic "/>
-      </optional>
-    </define>
-    <define name="shortdesc.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- topic/shortdesc "/>
       </optional>
     </define>
   </div>


### PR DESCRIPTION
Implements #21 (also makes #309 obsolete, which was implemented early and at this point has a lot of merge conflicts). 

I copied in the same changes Eliot made for RNG, and made equivalent changes in DTD.