### PR TITLE
Add starter set of glossary topics

### DIFF
--- a/specification/glossary/base-sort-phrase.dita
+++ b/specification/glossary/base-sort-phrase.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary//EN" "glossary.dtd">
+<glossentry id="base-sort-phrase">
+    <glossterm>base sort phrase</glossterm>
+    <glossdef>The text by which an element is sorted in the absence of a <xmlelement>sort-as </xmlelement> element. This
+        text might be literal content in the DITA XML source, or it might be generated based on the semantics of the
+        element involved; for example, it could be constructed from various attribute or metadata values.</glossdef>
+</glossentry>

--- a/specification/glossary/glossary.dita
+++ b/specification/glossary/glossary.dita
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glossgroup PUBLIC "-//OASIS//DTD DITA Glossary Group//EN" "glossgroup.dtd">
+<glossgroup id="glossgroup_kl2_zjz_vq">
+  <title>Glossary</title>
+  <glossentry id="glossentry_h3m_dkz_vq">
+    <glossterm>base element types</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_jgl_xlz_vq">
+    <glossterm>cascading</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_dyt_cmz_vq">
+    <glossterm>constraint compatibility</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_hn4_glz_vq">
+    <glossterm>constraints</glossterm>
+  </glossentry>
+  <glossentry id="ddl">
+    <glossterm>constraint modules</glossterm>
+    <glossdef></glossdef>
+  </glossentry>
+  <glossentry id="glossentry_fgd_bkz_vq">
+    <glossterm>content model</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_x24_ylz_vq">
+    <glossterm>containment</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_xjv_1mz_vq">
+    <glossterm>content reference</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_wty_mkz_vq">
+    <glossterm>class attribute</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_nbn_5kz_vq">
+    <glossterm>document types</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_ejw_5kz_vq">
+    <glossterm>document type shells</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_m3d_dlz_vq">
+    <glossterm>domain modules</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_alz_blz_vq">
+    <glossterm>domains</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_myc_jkz_vq">
+    <glossterm>domains attribute</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_rff_wkz_vq">
+    <glossterm>domains attribute contribution</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_lky_bkz_vq">
+    <glossterm>element types</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_qtj_ckz_vq">
+    <glossterm>extension elements</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_bhw_tlz_vq">
+    <glossterm>generalization</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_kt1_fkz_vq">
+    <glossterm>grammar</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_xps_5lz_vq">
+    <glossterm>inheritance</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_npp_yzn_fy">
+    <glossterm>key reference</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_pcv_klz_vq">
+    <glossterm>parameter entities</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_s4s_rlz_vq">
+    <glossterm>processors</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_pn1_tkz_vq">
+    <glossterm>strong constraints</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_fl5_qlz_vq">
+    <glossterm>structural modules</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_vt5_jlz_vq">
+    <glossterm>text entities</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_zvb_3lz_vq">
+    <glossterm>vocabulary modules</glossterm>
+  </glossentry>
+  <glossentry id="glossentry_fqk_skz_vq">
+    <glossterm>weak constraints</glossterm>
+  </glossentry>
+</glossgroup>

--- a/specification/glossary/sort-phrase.dita
+++ b/specification/glossary/sort-phrase.dita
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary//EN" "glossary.dtd">
+<glossentry id="sort-phrase">
+    <glossterm>sort phrase</glossterm>
+    <glossdef>A string specified by the <xmlelement>sort-as</xmlelement> element that determines how
+        an element is sorted or grouped.</glossdef>
+</glossentry>


### PR DESCRIPTION
These topics were developed in October 2016. The glossgroup
topic simply contains a starter list of terms.

Signed-off-by: Kristen James Eberlein <kris@eberleinconsulting.com>