### PR TITLE
Fix DITA version in DITAArchVersion att

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -58,7 +58,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                                   #FIXED 'http://dita.oasis-open.org/architecture/2005/'
               %DITAArchNSPrefix;:DITAArchVersion
                          CDATA
-                                  '1.3'
+                                  '2.0'
   "
 >
 

--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -52,7 +52,7 @@
                                   #FIXED 'http://dita.oasis-open.org/architecture/2005/'
               %DITAArchNSPrefix;:DITAArchVersion
                          CDATA
-                                  '1.3'
+                                  '2.0'
   "
 >
 

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -65,7 +65,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
     <a:documentation>ARCHITECTURE ATTRIBUTES</a:documentation>
     <define name="arch-atts">
       <optional>
-        <attribute name="dita:DITAArchVersion" a:defaultValue="1.3"/>
+        <attribute name="dita:DITAArchVersion" a:defaultValue="2.0"/>
       </optional>
     </define>
 

--- a/doctypes/rng/base/topicMod.rng
+++ b/doctypes/rng/base/topicMod.rng
@@ -62,7 +62,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
     <a:documentation>ARCHITECTURE ATTRIBUTES</a:documentation>
     <define name="arch-atts">
       <optional>
-        <attribute name="dita:DITAArchVersion" a:defaultValue="1.3"/>
+        <attribute name="dita:DITAArchVersion" a:defaultValue="2.0"/>
       </optional>
     </define>
   </div>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

The defaulted version attribute on DITA maps and topics needs to be updated from 1.3 to 2.0.