### PR TITLE
Remove duplicate outputclass defn

### DIFF
--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -1308,9 +1308,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
           </zeroOrMore>
         </define>
         <define name="linktext.attributes">
-          <optional>
-            <attribute name="outputclass"/>
-          </optional>
           <ref name="univ-atts"/>
         </define>
         <define name="linktext.element">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

Noticed by @raducoravu -- the `link text` element still defines `@outputclass` in RNG but also picks up that attribute from `univ-atts`. Appears to be the only element that does this.