### PR TITLE
DRAFT: Move keys from langRef TOC into key maps

### DIFF
--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -32,8 +32,9 @@
 	<frontmatter>
 		<mapref href="dita-2.0-specification-subjectScheme.ditamap" type="subjectScheme"/>
 		<mapref href="dita-2.0-key-definitions-cover-pages.ditamap" processing-role="resource-only"/>
-		<mapref href="common/key-definitions-library-topics.ditamap" format="ditamap"/>
-		<mapref href="langRef/key-definitions-base-elements.ditamap" format="ditamap"/>
+		<mapref href="common/key-definitions-library-topics.ditamap"/>
+		<mapref href="langRef/key-definitions-base-elements.ditamap"/>
+		<mapref href="langRef/attributes/key-definitions-ditaref-attributes.ditamap"/>
 		<mapref href="base-relationship-tables.ditamap"/>
 		<notices platform="dita-tc-publishing">
 			<topicref href="resources/oasis-cover.dita" linking="none" toc="no"/>

--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -33,6 +33,7 @@
 		<mapref href="dita-2.0-specification-subjectScheme.ditamap" type="subjectScheme"/>
 		<mapref href="dita-2.0-key-definitions-cover-pages.ditamap" processing-role="resource-only"/>
 		<mapref href="common/key-definitions-library-topics.ditamap" format="ditamap"/>
+		<mapref href="langRef/key-definitions-base-elements.ditamap" format="ditamap"/>
 		<mapref href="base-relationship-tables.ditamap"/>
 		<notices platform="dita-tc-publishing">
 			<topicref href="resources/oasis-cover.dita" linking="none" toc="no"/>

--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -2,41 +2,39 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map id="ditaref-commonatts" xml:lang="en-us">
  <title>Common attribute definitions used by each version of the guide</title>
- <topicref href="attributes.dita">
-  <topicref href="universalAttributes.dita" keys="attributes-universal">
-   <topicref href="idAttributes.dita" keys="attributes-id"/>
-   <topicref href="metadataAttributes.dita" keys="attributes-metadata"/>
-   <topicref href="localizationAttributes.dita" keys="attributes-localization"/>
+ <topicref keyref="attributes-container-topic">
+  <topicref keyref="attributes-universal">
+   <topicref keyref="attributes-id"/>
+   <topicref keyref="attributes-metadata"/>
+   <topicref keyref="attributes-localization"/>
   </topicref>
-  <topicref href="architecturalAttributes.dita" keys="attributes-architectural"/>
-  <topicref href="commonMapAttributes.dita" keys="attributes-commonMap"/>
-  <topicref href="calsTableAttributes.dita" keys="attributes-calsTable" platform="dita"/>
-  <topicref href="dataElementAttributes.dita" keys="attributes-dataElement"/>
-  <topicref href="dateAttributes.dita" keys="attributes-date" platform="dita"/>
-  <topicref href="displayAttributes.dita" keys="attributes-display"/>
-  <topicref href="linkRelationshipAttributes.dita" keys="attributes-linkRelationship"/>
-<topicref href="inclusionAttributes.dita" keys="attributes-includeElement"/>
-  <topicref href="commonAttributes.dita" keys="attributes-common"/>
-  <topicref href="simpletableAttributes.dita" keys="attributes-simpletableElement" platform="dita"/>
-  <topicref href="specializationAttributes.dita" keys="attributes-specialization" platform="dita"/>
-  <topicref href="topicrefElementAttributes.dita" keys="attributes-topicrefElement" platform="dita"/>
-  <topicref href="complexattributedefinitions.dita">
-   <topicref href="theconactionattribute.dita" keys="attributes-conaction" platform="dita"/>
-   <topicref href="theconrefendattribute.dita" keys="attributes-conrefend" platform="dita"/>
-   <topicref href="theconkeyrefattribute.dita" keys="attributes-conkeyref" platform="dita"/>
-   <topicref href="theconrefattribute.dita" keys="attributes-conref">
-    <topicref href="ditauseconreftarget.dita" keys="attributes-useconreftarget"/>
+  <topicref keyref="attributes-architectural"/>
+  <topicref keyref="attributes-commonMap"/>
+  <topicref keyref="attributes-calsTable" platform="dita"/>
+  <topicref keyref="attributes-dataElement"/>
+  <topicref keyref="attributes-date" platform="dita"/>
+  <topicref keyref="attributes-display"/>
+  <topicref keyref="attributes-linkRelationship"/>
+  <topicref keyref="attributes-includeElement"/>
+  <topicref keyref="attributes-common"/>
+  <topicref keyref="attributes-simpletableElement" platform="dita"/>
+  <topicref keyref="attributes-specialization" platform="dita"/>
+  <topicref keyref="attributes-topicrefElement" platform="dita"/>
+  <topicref keyref="attributes-complex-attributes-container">
+   <topicref keyref="attributes-conaction" platform="dita"/>
+   <topicref keyref="attributes-conrefend" platform="dita"/>
+   <topicref keyref="attributes-conkeyref" platform="dita"/>
+   <topicref keyref="attributes-conref">
+    <topicref keyref="attributes-useconreftarget"/>
    </topicref>
-   <topicref href="theformatattribute.dita" keys="attributes-format"/>
-   <topicref href="thehrefattribute.dita" keys="attributes-href"/>
-   <topicref href="thekeyrefattribute.dita" keys="attributes-keyref"/>
-   <topicref href="thekeysattribute.dita" keys="attributes-keys"/>
-   <topicref href="the-key-scope-attribute.dita" keys="attributes-keyscope" platform="dita"/>
-   <topicref href="theroleattribute.dita" keys="attributes-role" platform="dita"/>
-   <topicref href="thescopeattribute.dita" keys="attributes-scope"/>
-   <topicref href="thetypeattribute.dita" keys="attributes-type"/>
+   <topicref keyref="attributes-format"/>
+   <topicref keyref="attributes-href"/>
+   <topicref keyref="attributes-keyref"/>
+   <topicref keyref="attributes-keys"/>
+   <topicref keyref="attributes-keyscope" platform="dita"/>
+   <topicref keyref="attributes-role" platform="dita"/>
+   <topicref keyref="attributes-scope"/>
+   <topicref keyref="attributes-type"/>
   </topicref>
  </topicref>
- <?Pub Caret -1?>
 </map>
-<?Pub *0000003006?>

--- a/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map id="ditaref-commonatts" xml:lang="en-us">
+ <title>Keys for common attribute definitions used by each version of the guide</title>
+ <keydef href="attributes.dita" keys="attributes-container-topic"/>
+ <keydef href="universalAttributes.dita" keys="attributes-universal"/>
+ <keydef href="idAttributes.dita" keys="attributes-id"/>
+ <keydef href="metadataAttributes.dita" keys="attributes-metadata"/>
+ <keydef href="localizationAttributes.dita" keys="attributes-localization"/>
+ <keydef href="architecturalAttributes.dita" keys="attributes-architectural"/>
+ <keydef href="commonMapAttributes.dita" keys="attributes-commonMap"/>
+ <keydef href="calsTableAttributes.dita" keys="attributes-calsTable"/>
+ <keydef href="dataElementAttributes.dita" keys="attributes-dataElement"/>
+ <keydef href="dateAttributes.dita" keys="attributes-date"/>
+ <keydef href="displayAttributes.dita" keys="attributes-display"/>
+ <keydef href="linkRelationshipAttributes.dita" keys="attributes-linkRelationship"/>
+ <keydef href="inclusionAttributes.dita" keys="attributes-includeElement"/>
+ <keydef href="commonAttributes.dita" keys="attributes-common"/>
+ <keydef href="simpletableAttributes.dita" keys="attributes-simpletableElement"/>
+ <keydef href="specializationAttributes.dita" keys="attributes-specialization"/>
+ <keydef href="topicrefElementAttributes.dita" keys="attributes-topicrefElement"/>
+ <keydef href="complexattributedefinitions.dita" keys="attributes-complex-attributes-container"/>
+ <keydef href="theconactionattribute.dita" keys="attributes-conaction"/>
+ <keydef href="theconrefendattribute.dita" keys="attributes-conrefend"/>
+ <keydef href="theconkeyrefattribute.dita" keys="attributes-conkeyref"/>
+ <keydef href="theconrefattribute.dita" keys="attributes-conref"/>
+ <keydef href="ditauseconreftarget.dita" keys="attributes-useconreftarget"/>
+ <keydef href="theformatattribute.dita" keys="attributes-format"/>
+ <keydef href="thehrefattribute.dita" keys="attributes-href"/>
+ <keydef href="thekeyrefattribute.dita" keys="attributes-keyref"/>
+ <keydef href="thekeysattribute.dita" keys="attributes-keys"/>
+ <keydef href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
+ <keydef href="theroleattribute.dita" keys="attributes-role"/>
+ <keydef href="thescopeattribute.dita" keys="attributes-scope"/>
+ <keydef href="thetypeattribute.dita" keys="attributes-type"/>
+</map>

--- a/specification/langRef/base-elements.ditamap
+++ b/specification/langRef/base-elements.ditamap
@@ -30,7 +30,7 @@
  </topicref>
  <topicref href="other-elements.dita">
   <topicref href="containers/legacy-conversion-elements.dita">
-   <topicref href="base/required-cleanup.dita" keys="elements-required-cleanup"/>
+   <topicref keyref="elements-required-cleanup"/>
   </topicref>
   <mapref href="ditaref-ditaval.ditamap"/>
  </topicref>

--- a/specification/langRef/base/area.dita
+++ b/specification/langRef/base/area.dita
@@ -25,7 +25,7 @@ coordinates of that shape, and a link target for the area.</shortdesc>
  &lt;coords>54,1,117,60&lt;/coords>
  &lt;xref href="d1-s2.dita">&lt;/xref>
 &lt;/area></codeblock><p>A more complete example is located
-in the description for <xref href="imagemap.dita"></xref>.</p></example>
+in the description for <xref keyref="elements-imagemap"></xref>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -40,6 +40,6 @@
         </dlentry>
       </dl>
     </section>
-    <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example>
+    <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example>
   </refbody>
 </reference>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -78,6 +78,6 @@
         </dlentry>
       </dl>
     </section>
-    <example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example>
+    <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example>
   </refbody>
 </reference>

--- a/specification/langRef/base/keywords.dita
+++ b/specification/langRef/base/keywords.dita
@@ -17,7 +17,7 @@
  <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>While the <xref href="keyword.dita"><xmlelement>keyword</xmlelement></xref> element can be
+      <p>While the <xref keyref="elements-keyword"><xmlelement>keyword</xmlelement></xref> element can be
         used inline, the <xmlelement>keywords</xmlelement> element is not an inline element. The
           <xmlelement>keywords</xmlelement> element only appears in the
           <xmlelement>topicmeta</xmlelement> or <xmlelement>prolog</xmlelement>, and is used to

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -105,6 +105,6 @@
         </dlentry>
       </dl>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="object.dita"></xref>.</p></example>
+    <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-object"/>.</p></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/platform.dita
+++ b/specification/langRef/base/platform.dita
@@ -10,4 +10,4 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>
+    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prodname.dita
+++ b/specification/langRef/base/prodname.dita
@@ -7,4 +7,4 @@ the name of the product that is supported by the information in this topic.</sho
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>
+    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prognum.dita
+++ b/specification/langRef/base/prognum.dita
@@ -6,4 +6,4 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="prodinfo.dita"/>.</p></example></refbody></reference>
+    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -30,7 +30,7 @@
         />.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
-href="reltable.dita"></xref>.</p></example>
+keyref="elements-reltable"/>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/relheader.dita
+++ b/specification/langRef/base/relheader.dita
@@ -21,6 +21,6 @@
       <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
-href="reltable.dita"></xref>.</p></example>
+keyref="elements-reltable"/>.</p></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/relrow.dita
+++ b/specification/langRef/base/relrow.dita
@@ -23,7 +23,7 @@
          <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
-href="reltable.dita"></xref>.</p></example>
+keyref="elements-reltable"/>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -7,4 +7,4 @@
           keyref="attributes-universal"/>, along with
         <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
           keyref="attributes-calsTable"/>.</p>
-    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>
+    </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -45,7 +45,7 @@
       </sectiondiv>
     </section>
     <example id="example" otherprops="examples">
-      <p>See <xref href="subjectScheme.dita"/>.</p>
+      <p>See <xref keyref="elements-subjectScheme"/>.</p>
     </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/sli.dita
+++ b/specification/langRef/base/sli.dita
@@ -16,7 +16,7 @@
          <title>Attributes</title>
          <p conkeyref="reuse-attributes/only-universal"/>
       </section>
-<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="sl.dita"></xref>.</p></example>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-sl"></xref>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/subjectCell.dita
+++ b/specification/langRef/base/subjectCell.dita
@@ -31,7 +31,7 @@ across columns, other than the fact that they apply to the same content.</shortd
             <title>Example</title>
             <p>For a complete example in the context of the
                     <xmlelement>topicSubjectTable</xmlelement>, see <xref
-                    href="topicSubjectTable.dita#topicSubjectTable/example"/>.</p>
+                    keyref="elements-topicSubjectTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/subjectRel.dita
+++ b/specification/langRef/base/subjectRel.dita
@@ -28,7 +28,7 @@ the subjects instead of links between topic documents.</shortdesc>
             <title>Example</title>
             <p>For a complete example in the context of the
                 <xmlelement>subjectRelTable</xmlelement>, see <xref
-                    href="subjectRelTable.dita#subjectRelTable/example"/>.</p>
+                    keyref="elements-subjectRelTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/subjectRelHeader.dita
+++ b/specification/langRef/base/subjectRelHeader.dita
@@ -33,7 +33,7 @@ subjects in associations.</shortdesc>
             <title>Example</title>
             <p>For a complete example in the context of the
                 <xmlelement>subjectRelTable</xmlelement>, see <xref
-                    href="subjectRelTable.dita#subjectRelTable/example"/>.</p>
+                    keyref="elements-subjectRelTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/subjectRole.dita
+++ b/specification/langRef/base/subjectRole.dita
@@ -36,7 +36,7 @@
 <example id="example" otherprops="examples">
 <title>Example</title>
 <p>For a complete example in the context of the <xmlelement>subjectRelTable</xmlelement>, see <xref
-href="subjectRelTable.dita#subjectRelTable/example"/>.</p>
+  keyref="elements-subjectRelTable/example"/>.</p>
 </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -18,7 +18,7 @@
       <p>The DITA table is based on the OASIS Exchange Table Model, augmented with DITA attributes
         that enable it for accessibility, specialization, conref, and other DITA processing. In
         addition, the table includes a <xmlelement>desc</xmlelement> element, which enables table
-        description that is parallel with figure description. See <xref href="simpletable.dita"/>
+        description that is parallel with figure description. See <xref keyref="elements-simpletable"/>
         for a simplified table model that is closer to the HTML5 table model, and can be specialized
         to represent more regular relationships of data.</p>
       <p conkeyref="reuse-general/pgwide-explain"/>

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -11,4 +11,4 @@
           keyref="attributes-universal"/> and
           <xmlatt>valign</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -27,5 +27,5 @@
         </dlentry>
       </dl>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref
-        href="table.dita"/>.</p></example></refbody>
+        keyref="elements-table"/>.</p></example></refbody>
 </reference>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -12,4 +12,4 @@
           keyref="attributes-universal"/> and
           <xmlatt>valign</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p>See <xref href="table.dita"/>.</p></example></refbody></reference>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/topicCell.dita
+++ b/specification/langRef/base/topicCell.dita
@@ -33,7 +33,7 @@
             <title>Example</title>
             <p>For a complete example in the context of the
                     <xmlelement>topicSubjectTable</xmlelement>, see <xref
-                    href="topicSubjectTable.dita#topicSubjectTable/example"/>.</p>
+                    keyref="elements-topicSubjectTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/topicSubjectHeader.dita
+++ b/specification/langRef/base/topicSubjectHeader.dita
@@ -40,7 +40,7 @@
             <title>Example</title>
             <p>For a complete example in the context of the
                     <xmlelement>topicSubjectTable</xmlelement>, see <xref
-                    href="topicSubjectTable.dita#topicSubjectTable/example"/>.</p>
+                        keyref="elements-topicSubjectTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/topicSubjectRow.dita
+++ b/specification/langRef/base/topicSubjectRow.dita
@@ -29,7 +29,7 @@
             <title>Example</title>
             <p>For a complete example in the context of the
                     <xmlelement>topicSubjectTable</xmlelement>, see <xref
-                    href="topicSubjectTable.dita#topicSubjectTable/example"/>.</p>
+                        keyref="elements-topicSubjectTable/example"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/basic-map-elements.ditamap
+++ b/specification/langRef/basic-map-elements.ditamap
@@ -3,16 +3,16 @@
 <map>
  <title>Basic map elements</title>
  <topicref href="containers/basic-map-elements.dita" id="mapelems" >
-  <topicref href="base/map.dita" keys="elements-map" />
-  <topicref href="base/topicref.dita" keys="elements-topicref" />
-  <topicref href="base/topicmeta.dita" keys="elements-topicmeta" />
-  <topicref href="base/anchor.dita" keys="elements-anchor" />
-  <topicref href="base/navref.dita" keys="elements-navref" />
-  <topicref href="base/reltable.dita" keys="elements-reltable" />
-  <topicref href="base/relrow.dita" keys="elements-relrow" />
-  <topicref href="base/relcell.dita" keys="elements-relcell" />
-  <topicref href="base/relheader.dita" keys="elements-relheader" />
-  <topicref href="base/relcolspec.dita" keys="elements-relcolspec" />
-  <topicref href="base/ux-window.dita"  keys="elements-ux-window" />
+  <topicref keyref="elements-map" />
+  <topicref keyref="elements-topicref" />
+  <topicref keyref="elements-topicmeta" />
+  <topicref keyref="elements-anchor" />
+  <topicref keyref="elements-navref" />
+  <topicref keyref="elements-reltable" />
+  <topicref keyref="elements-relrow" />
+  <topicref keyref="elements-relcell" />
+  <topicref keyref="elements-relheader" />
+  <topicref keyref="elements-relcolspec" />
+  <topicref keyref="elements-ux-window" />
  </topicref>
 </map>

--- a/specification/langRef/basic-topic-elements.ditamap
+++ b/specification/langRef/basic-topic-elements.ditamap
@@ -3,16 +3,16 @@
 <map>
  <title>Basic topic elements</title>
  <topicref href="containers/basic-topic-elements.dita" >
-  <topicref href="base/abstract.dita" keys="elements-abstract" />
-  <topicref href="base/body.dita" keys="elements-body" />
-  <topicref href="base/bodydiv.dita" keys="elements-bodydiv" />
-  <topicref href="base/dita.dita" keys="elements-dita" />
-  <topicref href="base/navtitle.dita" keys="elements-navtitle" />
-  <topicref href="base/related-links.dita" keys="elements-related-links" />
-  <topicref href="base/searchtitle.dita" keys="elements-searchtitle" />
-  <topicref href="base/shortdesc.dita" keys="elements-shortdesc" />
-  <topicref href="base/title.dita" keys="elements-title" />
-  <topicref href="base/titlealts.dita" keys="elements-titlealts" />
-  <topicref href="base/topic.dita" keys="elements-topic" />
+  <topicref keyref="elements-abstract" />
+  <topicref keyref="elements-body" />
+  <topicref keyref="elements-bodydiv" />
+  <topicref keyref="elements-dita" />
+  <topicref keyref="elements-navtitle" />
+  <topicref keyref="elements-related-links" />
+  <topicref keyref="elements-searchtitle" />
+  <topicref keyref="elements-shortdesc" />
+  <topicref keyref="elements-title" />
+  <topicref keyref="elements-titlealts" />
+  <topicref keyref="elements-topic" />
  </topicref>
 </map>

--- a/specification/langRef/body-elements.ditamap
+++ b/specification/langRef/body-elements.ditamap
@@ -3,47 +3,47 @@
 <map>
  <title>Body elements</title>
  <topicref href="containers/body-elements.dita" >
-  <topicref href="base/alt.dita" keys="elements-alt" />
-  <topicref href="base/cite.dita" keys="elements-cite" />
-  <topicref href="base/dd.dita" keys="elements-dd" />
-  <topicref href="base/desc.dita" keys="elements-desc" />
-  <topicref href="base/ddhd.dita" keys="elements-ddhd" />
-  <topicref href="base/div.dita" keys="elements-div"  />
-  <topicref href="base/dl.dita" keys="elements-dl" />
-  <topicref href="base/dlentry.dita" keys="elements-dlentry" />
-  <topicref href="base/dlhead.dita" keys="elements-dlhead" />
-  <topicref href="base/dt.dita" keys="elements-dt" />
-  <topicref href="base/draft-comment.dita" keys="elements-draft-comment" />
-  <topicref href="base/dthd.dita" keys="elements-dthd" />
-  <topicref href="base/example.dita" keys="elements-example" />
-  <topicref href="base/fallback.dita" keys="elements-fallback"/>
-  <topicref href="base/fig.dita" keys="elements-fig" />
-  <topicref href="base/figgroup.dita" keys="elements-figgroup" />
-  <topicref href="base/fn.dita" keys="elements-fn" />
-  <topicref href="base/image.dita" keys="elements-image" />
-  <topicref href="base/include.dita" keys="elements-include"/>
-  <topicref href="base/keyword.dita" keys="elements-keyword" />
-  <topicref href="base/li.dita" keys="elements-li" />
-  <topicref href="base/lines.dita" keys="elements-lines" />
-  <topicref href="base/longdescref.dita" keys="elements-longdescref" />
-  <topicref href="base/longquoteref.dita" keys="elements-longquoteref" />
-  <topicref href="base/lq.dita" keys="elements-lq" />
-  <topicref href="base/note.dita" keys="elements-note" />
-  <topicref href="base/object.dita" keys="elements-object" />
-  <topicref href="base/ol.dita" keys="elements-ol" />
-  <topicref href="base/p.dita" keys="elements-p" />
-  <topicref href="base/param.dita" keys="elements-param" />
-  <topicref href="base/ph.dita" keys="elements-ph" />
-  <topicref href="base/pre.dita" keys="elements-pre" />
-  <topicref href="base/q.dita" keys="elements-q" />
-  <topicref href="base/section.dita" keys="elements-section" />
-  <topicref href="base/sectiondiv.dita" keys="elements-sectiondiv" />
-  <topicref href="base/sl.dita" keys="elements-sl" />
-  <topicref href="base/sli.dita" keys="elements-sli" />
-  <topicref href="base/term.dita" keys="elements-term" />
-  <topicref href="base/text.dita" keys="elements-text" />
-  <topicref href="base/tm.dita" keys="elements-tm" />
-  <topicref href="base/ul.dita" keys="elements-ul" />
-  <topicref href="base/xref.dita" keys="elements-xref" />
+  <topicref keyref="elements-alt" />
+  <topicref keyref="elements-cite" />
+  <topicref keyref="elements-dd" />
+  <topicref keyref="elements-desc" />
+  <topicref keyref="elements-ddhd" />
+  <topicref keyref="elements-div"  />
+  <topicref keyref="elements-dl" />
+  <topicref keyref="elements-dlentry" />
+  <topicref keyref="elements-dlhead" />
+  <topicref keyref="elements-dt" />
+  <topicref keyref="elements-draft-comment" />
+  <topicref keyref="elements-dthd" />
+  <topicref keyref="elements-example" />
+  <topicref keyref="elements-fallback"/>
+  <topicref keyref="elements-fig" />
+  <topicref keyref="elements-figgroup" />
+  <topicref keyref="elements-fn" />
+  <topicref keyref="elements-image" />
+  <topicref keyref="elements-include"/>
+  <topicref keyref="elements-keyword" />
+  <topicref keyref="elements-li" />
+  <topicref keyref="elements-lines" />
+  <topicref keyref="elements-longdescref" />
+  <topicref keyref="elements-longquoteref" />
+  <topicref keyref="elements-lq" />
+  <topicref keyref="elements-note" />
+  <topicref keyref="elements-object" />
+  <topicref keyref="elements-ol" />
+  <topicref keyref="elements-p" />
+  <topicref keyref="elements-param" />
+  <topicref keyref="elements-ph" />
+  <topicref keyref="elements-pre" />
+  <topicref keyref="elements-q" />
+  <topicref keyref="elements-section" />
+  <topicref keyref="elements-sectiondiv" />
+  <topicref keyref="elements-sl" />
+  <topicref keyref="elements-sli" />
+  <topicref keyref="elements-term" />
+  <topicref keyref="elements-text" />
+  <topicref keyref="elements-tm" />
+  <topicref keyref="elements-ul" />
+  <topicref keyref="elements-xref" />
  </topicref>
 </map>

--- a/specification/langRef/classification-domain-elements.ditamap
+++ b/specification/langRef/classification-domain-elements.ditamap
@@ -3,13 +3,13 @@
 <map>
  <title>Classification domain elements</title>
  <topicref href="containers/classify-d.dita">  
-  <topicref href="base/subjectCell.dita" keys="elements-subjectCell"/>
-  <topicref href="base/subjectref.dita" keys="elements-subjectref" />
-  <topicref href="base/topicapply.dita" keys="elements-topicapply" />
-  <topicref href="base/topicCell.dita" keys="elements-topicCell"/>
-  <topicref href="base/topicsubject.dita" keys="elements-topicsubject" />
-  <topicref href="base/topicSubjectHeader.dita" keys="elements-topicSubjectHeader"/>
-  <topicref href="base/topicSubjectRow.dita" keys="elements-topicSubjectRow"/>
-  <topicref href="base/topicSubjectTable.dita" keys="elements-topicSubjectTable"/>
+  <topicref keyref="elements-subjectCell"/>
+  <topicref keyref="elements-subjectref" />
+  <topicref keyref="elements-topicapply" />
+  <topicref keyref="elements-topicCell"/>
+  <topicref keyref="elements-topicsubject" />
+  <topicref keyref="elements-topicSubjectHeader"/>
+  <topicref keyref="elements-topicSubjectRow"/>
+  <topicref keyref="elements-topicSubjectTable"/>
  </topicref>
 </map>

--- a/specification/langRef/ditaref-ditaval.ditamap
+++ b/specification/langRef/ditaref-ditaval.ditamap
@@ -3,13 +3,13 @@
 <map xml:lang="en-us">
  <title>DITAVAL elements</title>
  <topicref href="containers/ditaval-elements.dita">
-  <topicref href="ditaval/ditaval-alt-text.dita" keys="alt-text"/>
-  <topicref href="ditaval/ditaval-endflag.dita" keys="end-flag"/>
-  <topicref href="ditaval/ditaval-prop.dita" keys="prop"/>
-  <topicref href="ditaval/ditaval-revprop.dita" keys="revprops"/>
-  <topicref href="ditaval/ditaval-startflag.dita" keys="startflag"/>
-  <topicref href="ditaval/ditaval-style-conflict.dita" keys="style-conflict"/>
-  <topicref href="ditaval/ditaval-val.dita" keys="val"/>
+  <topicref keyref="alt-text"/>
+  <topicref keyref="end-flag"/>
+  <topicref keyref="prop"/>
+  <topicref keyref="revprops"/>
+  <topicref keyref="startflag"/>
+  <topicref keyref="style-conflict"/>
+  <topicref keyref="val"/>
  </topicref>
 </map>
 

--- a/specification/langRef/ditaref-ditaval.ditamap
+++ b/specification/langRef/ditaref-ditaval.ditamap
@@ -3,13 +3,13 @@
 <map xml:lang="en-us">
  <title>DITAVAL elements</title>
  <topicref href="containers/ditaval-elements.dita">
-  <topicref keyref="alt-text"/>
-  <topicref keyref="end-flag"/>
-  <topicref keyref="prop"/>
-  <topicref keyref="revprops"/>
-  <topicref keyref="startflag"/>
-  <topicref keyref="style-conflict"/>
-  <topicref keyref="val"/>
+  <topicref keyref="elements-ditaval-alt-text"/>
+  <topicref keyref="elements-ditaval-end-flag"/>
+  <topicref keyref="elements-ditaval-prop"/>
+  <topicref keyref="elements-ditaval-revprop"/>
+  <topicref keyref="elements-ditaval-startflag"/>
+  <topicref keyref="elements-ditaval-style-conflict"/>
+  <topicref keyref="elements-ditaval-val"/>
  </topicref>
 </map>
 

--- a/specification/langRef/ditaval/ditaval-alt-text.dita
+++ b/specification/langRef/ditaval/ditaval-alt-text.dita
@@ -21,7 +21,7 @@
       <title>Attributes</title>
       <p conkeyref="reuse-attributes/no-atts"/>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="val"/>.</p></example>
+<example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-ditaval-val"/>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/ditaval/ditaval-endflag.dita
+++ b/specification/langRef/ditaval/ditaval-endflag.dita
@@ -29,6 +29,6 @@
       </dl>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-      <p>See <xref keyref="val"/>.</p></example>
+      <p>See <xref keyref="elements-ditaval-val"/>.</p></example>
 </refbody>
 </reference>

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -117,7 +117,7 @@ the attribute, to take an action on. The identified attribute is a conditional-p
       </dl>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See the example
-in the <xref href="ditaval-val.dita">&lt;val></xref> description.</p></example>
+in the <xref keyref="elements-ditaval-val">&lt;val></xref> description.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -109,7 +109,7 @@
                 </dl></p></section>
         <example id="example" otherprops="examples">
             <title>Example</title>
-            <p>See <xref keyref="val"/>.</p>
+            <p>See <xref keyref="elements-ditaval-val"/>.</p>
         </example>
 </refbody>
 </reference>

--- a/specification/langRef/ditaval/ditaval-startflag.dita
+++ b/specification/langRef/ditaval/ditaval-startflag.dita
@@ -30,6 +30,6 @@
       </dl>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-      <p>See <xref keyref="val"/>.</p></example>
+      <p>See <xref keyref="elements-ditaval-val"/>.</p></example>
 </refbody>
 </reference>

--- a/specification/langRef/ditaval/ditaval-style-conflict.dita
+++ b/specification/langRef/ditaval/ditaval-style-conflict.dita
@@ -74,7 +74,7 @@
         </dl></p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-      <p>See <xref keyref="val"/>.</p></example>
+      <p>See <xref keyref="elements-ditaval-val"/>.</p></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/ditavalref-elements.ditamap
+++ b/specification/langRef/ditavalref-elements.ditamap
@@ -3,11 +3,11 @@
 <map>
  <title>DITAVAL reference domain</title>
  <topicref href="containers/ditaval-d.dita" >
-  <topicref href="base/ditavalref.dita" keys="elements-ditavalref"/>
-  <topicref href="base/ditavalmeta.dita" keys="elements-ditavalmeta"/>
-  <topicref href="base/dvrResourcePrefix.dita" keys="elements-dvrResourcePrefix" />
-  <topicref href="base/dvrResourceSuffix.dita" keys="elements-dvrResourceSuffix" />
-  <topicref href="base/dvrKeyscopePrefix.dita" keys="elements-dvrKeyscopePrefix" />
-  <topicref href="base/dvrKeyscopeSuffix.dita" keys="elements-dvrKeyscopeSuffix" />
+  <topicref keyref="elements-ditavalref"/>
+  <topicref keyref="elements-ditavalmeta"/>
+  <topicref keyref="elements-dvrResourcePrefix" />
+  <topicref keyref="elements-dvrResourceSuffix" />
+  <topicref keyref="elements-dvrKeyscopePrefix" />
+  <topicref keyref="elements-dvrKeyscopeSuffix" />
  </topicref>
 </map>

--- a/specification/langRef/hazard-statement-elements.ditamap
+++ b/specification/langRef/hazard-statement-elements.ditamap
@@ -3,11 +3,11 @@
 <map>
  <title>Hazard statement domain elements</title>
  <topicref href="containers/hazard-d.dita">
-  <topicref href="base/consequence.dita" keys="elements-consequence" />
-  <topicref href="base/hazardstatement.dita" keys="elements-hazardstatement" />
-  <topicref href="base/hazardsymbol.dita" keys="elements-hazardsymbol" />
-  <topicref href="base/howtoavoid.dita" keys="elements-howtoavoid" />
-  <topicref href="base/messagepanel.dita" keys="elements-messagepanel" />
-  <topicref href="base/typeofhazard.dita" keys="elements-typeofhazard" />
+  <topicref keyref="elements-consequence" />
+  <topicref keyref="elements-hazardstatement" />
+  <topicref keyref="elements-hazardsymbol" />
+  <topicref keyref="elements-howtoavoid" />
+  <topicref keyref="elements-messagepanel" />
+  <topicref keyref="elements-typeofhazard" />
  </topicref>
 </map>

--- a/specification/langRef/highlighting-elements.ditamap
+++ b/specification/langRef/highlighting-elements.ditamap
@@ -2,14 +2,14 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Highlighting domain elements</title>
- <topicref href="containers/hi-d.dita" >
-  <topicref href="base/b.dita" keys="elements-b" />
-  <topicref href="base/i.dita" keys="elements-i" />
-  <topicref href="base/line-through.dita"  keys="elements-line-through"/>
-  <topicref href="base/overline.dita"  keys="elements-overline"/>
-  <topicref href="base/sub.dita" keys="elements-sub" />
-  <topicref href="base/sup.dita" keys="elements-sup" />
-  <topicref href="base/tt.dita" keys="elements-tt" />
-  <topicref href="base/u.dita" keys="elements-u" />
+ <topicref href="containers/hi-d.dita">
+  <topicref keyref="elements-b"/>
+  <topicref keyref="elements-i"/>
+  <topicref keyref="elements-line-through"/>
+  <topicref keyref="elements-overline"/>
+  <topicref keyref="elements-sub"/>
+  <topicref keyref="elements-sup"/>
+  <topicref keyref="elements-tt"/>
+  <topicref keyref="elements-u"/>
  </topicref>
 </map>

--- a/specification/langRef/indexing-elements.ditamap
+++ b/specification/langRef/indexing-elements.ditamap
@@ -3,8 +3,8 @@
 <map>
  <title>Indexing elements</title>
  <topicref href="containers/indexing-d.dita" >
-  <topicref href="base/index-see.dita" keys="elements-index-see" />
-  <topicref href="base/index-see-also.dita" keys="elements-index-see-also" />
-  <topicref href="base/indexterm.dita" keys="elements-indexterm"/>
+  <topicref keyref="elements-index-see" />
+  <topicref keyref="elements-index-see-also" />
+  <topicref keyref="elements-indexterm"/>
  </topicref>
 </map>

--- a/specification/langRef/key-definitions-base-elements.ditamap
+++ b/specification/langRef/key-definitions-base-elements.ditamap
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map xml:lang="en-us">
+ <title>Keys for base elements</title>
+ <mapref href="key-definitions-basic-topic-elements.ditamap"/>
+ <mapref href="key-definitions-body-elements.ditamap"/>  
+ <mapref href="key-definitions-indexing-elements.ditamap"/>
+ <mapref href="key-definitions-related-links-elements.ditamap"/>
+ <mapref href="key-definitions-table-elements.ditamap"/>
+ 
+ <mapref href="key-definitions-basic-map-elements.ditamap"/>
+ <mapref href="key-definitions-map-group-elements.ditamap"/>
+ <mapref href="key-definitions-prolog-elements.ditamap"/>
+ <mapref href="key-definitions-specialization-elements.ditamap"/>
+ 
+ <mapref href="key-definitions-ditavalref-elements.ditamap"/>  
+ <mapref href="key-definitions-hazard-statement-elements.ditamap"/>
+ <mapref href="key-definitions-highlighting-elements.ditamap"/>
+ <mapref href="key-definitions-multimedia-domain.ditamap"/>
+ <mapref href="key-definitions-utilities-elements.ditamap"/>
+ <mapref href="key-definitions-subjectScheme-elements.ditamap"/>
+ <mapref href="key-definitions-classification-domain-elements.ditamap"/>
+
+ <keydef href="base/required-cleanup.dita" keys="elements-required-cleanup"/>
+ 
+ <mapref href="key-definitions-ditaref-ditaval.ditamap"/>
+</map>

--- a/specification/langRef/key-definitions-basic-map-elements.ditamap
+++ b/specification/langRef/key-definitions-basic-map-elements.ditamap
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for basic map elements</title>
+ <keydef href="base/map.dita" keys="elements-map" />
+ <keydef href="base/topicref.dita" keys="elements-topicref" />
+ <keydef href="base/topicmeta.dita" keys="elements-topicmeta" />
+ <keydef href="base/anchor.dita" keys="elements-anchor" />
+ <keydef href="base/navref.dita" keys="elements-navref" />
+ <keydef href="base/reltable.dita" keys="elements-reltable" />
+ <keydef href="base/relrow.dita" keys="elements-relrow" />
+ <keydef href="base/relcell.dita" keys="elements-relcell" />
+ <keydef href="base/relheader.dita" keys="elements-relheader" />
+ <keydef href="base/relcolspec.dita" keys="elements-relcolspec" />
+ <keydef href="base/ux-window.dita"  keys="elements-ux-window" />
+</map>

--- a/specification/langRef/key-definitions-basic-topic-elements.ditamap
+++ b/specification/langRef/key-definitions-basic-topic-elements.ditamap
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for basic topic elements</title>
+ <keydef href="base/abstract.dita" keys="elements-abstract" />
+ <keydef href="base/body.dita" keys="elements-body" />
+ <keydef href="base/bodydiv.dita" keys="elements-bodydiv" />
+ <keydef href="base/dita.dita" keys="elements-dita" />
+ <keydef href="base/navtitle.dita" keys="elements-navtitle" />
+ <keydef href="base/related-links.dita" keys="elements-related-links" />
+ <keydef href="base/searchtitle.dita" keys="elements-searchtitle" />
+ <keydef href="base/shortdesc.dita" keys="elements-shortdesc" />
+ <keydef href="base/title.dita" keys="elements-title" />
+ <keydef href="base/titlealts.dita" keys="elements-titlealts" />
+ <keydef href="base/topic.dita" keys="elements-topic" />
+</map>

--- a/specification/langRef/key-definitions-body-elements.ditamap
+++ b/specification/langRef/key-definitions-body-elements.ditamap
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for body elements</title>
+ <keydef href="base/alt.dita" keys="elements-alt" />
+ <keydef href="base/cite.dita" keys="elements-cite" />
+ <keydef href="base/dd.dita" keys="elements-dd" />
+ <keydef href="base/desc.dita" keys="elements-desc" />
+ <keydef href="base/ddhd.dita" keys="elements-ddhd" />
+ <keydef href="base/div.dita" keys="elements-div"  />
+ <keydef href="base/dl.dita" keys="elements-dl" />
+ <keydef href="base/dlentry.dita" keys="elements-dlentry" />
+ <keydef href="base/dlhead.dita" keys="elements-dlhead" />
+ <keydef href="base/dt.dita" keys="elements-dt" />
+ <keydef href="base/draft-comment.dita" keys="elements-draft-comment" />
+ <keydef href="base/dthd.dita" keys="elements-dthd" />
+ <keydef href="base/example.dita" keys="elements-example" />
+ <keydef href="base/fallback.dita" keys="elements-fallback"/>
+ <keydef href="base/fig.dita" keys="elements-fig" />
+ <keydef href="base/figgroup.dita" keys="elements-figgroup" />
+ <keydef href="base/fn.dita" keys="elements-fn" />
+ <keydef href="base/image.dita" keys="elements-image" />
+ <keydef href="base/include.dita" keys="elements-include"/>
+ <keydef href="base/keyword.dita" keys="elements-keyword" />
+ <keydef href="base/li.dita" keys="elements-li" />
+ <keydef href="base/lines.dita" keys="elements-lines" />
+ <keydef href="base/longdescref.dita" keys="elements-longdescref" />
+ <keydef href="base/longquoteref.dita" keys="elements-longquoteref" />
+ <keydef href="base/lq.dita" keys="elements-lq" />
+ <keydef href="base/note.dita" keys="elements-note" />
+ <keydef href="base/object.dita" keys="elements-object" />
+ <keydef href="base/ol.dita" keys="elements-ol" />
+ <keydef href="base/p.dita" keys="elements-p" />
+ <keydef href="base/param.dita" keys="elements-param" />
+ <keydef href="base/ph.dita" keys="elements-ph" />
+ <keydef href="base/pre.dita" keys="elements-pre" />
+ <keydef href="base/q.dita" keys="elements-q" />
+ <keydef href="base/section.dita" keys="elements-section" />
+ <keydef href="base/sectiondiv.dita" keys="elements-sectiondiv" />
+ <keydef href="base/sl.dita" keys="elements-sl" />
+ <keydef href="base/sli.dita" keys="elements-sli" />
+ <keydef href="base/term.dita" keys="elements-term" />
+ <keydef href="base/text.dita" keys="elements-text" />
+ <keydef href="base/tm.dita" keys="elements-tm" />
+ <keydef href="base/ul.dita" keys="elements-ul" />
+ <keydef href="base/xref.dita" keys="elements-xref" />
+</map>

--- a/specification/langRef/key-definitions-classification-domain-elements.ditamap
+++ b/specification/langRef/key-definitions-classification-domain-elements.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for classification domain elements</title>
+ <keydef href="base/subjectCell.dita" keys="elements-subjectCell"/>
+ <keydef href="base/subjectref.dita" keys="elements-subjectref" />
+ <keydef href="base/topicapply.dita" keys="elements-topicapply" />
+ <keydef href="base/topicCell.dita" keys="elements-topicCell"/>
+ <keydef href="base/topicsubject.dita" keys="elements-topicsubject" />
+ <keydef href="base/topicSubjectHeader.dita" keys="elements-topicSubjectHeader"/>
+ <keydef href="base/topicSubjectRow.dita" keys="elements-topicSubjectRow"/>
+ <keydef href="base/topicSubjectTable.dita" keys="elements-topicSubjectTable"/>
+</map>

--- a/specification/langRef/key-definitions-ditaref-ditaval.ditamap
+++ b/specification/langRef/key-definitions-ditaref-ditaval.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map xml:lang="en-us">
+ <title>Keys for DITAVAL elements</title>
+ <keydef href="ditaval/ditaval-alt-text.dita" keys="alt-text"/>
+ <keydef href="ditaval/ditaval-endflag.dita" keys="end-flag"/>
+ <keydef href="ditaval/ditaval-prop.dita" keys="prop"/>
+ <keydef href="ditaval/ditaval-revprop.dita" keys="revprops"/>
+ <keydef href="ditaval/ditaval-startflag.dita" keys="startflag"/>
+ <keydef href="ditaval/ditaval-style-conflict.dita" keys="style-conflict"/>
+ <keydef href="ditaval/ditaval-val.dita" keys="val"/>
+</map>
+

--- a/specification/langRef/key-definitions-ditaref-ditaval.ditamap
+++ b/specification/langRef/key-definitions-ditaref-ditaval.ditamap
@@ -2,12 +2,12 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map xml:lang="en-us">
  <title>Keys for DITAVAL elements</title>
- <keydef href="ditaval/ditaval-alt-text.dita" keys="alt-text"/>
- <keydef href="ditaval/ditaval-endflag.dita" keys="end-flag"/>
- <keydef href="ditaval/ditaval-prop.dita" keys="prop"/>
- <keydef href="ditaval/ditaval-revprop.dita" keys="revprops"/>
- <keydef href="ditaval/ditaval-startflag.dita" keys="startflag"/>
- <keydef href="ditaval/ditaval-style-conflict.dita" keys="style-conflict"/>
- <keydef href="ditaval/ditaval-val.dita" keys="val"/>
+ <keydef href="ditaval/ditaval-alt-text.dita" keys="elements-ditaval-alt-text"/>
+ <keydef href="ditaval/ditaval-endflag.dita" keys="elements-ditaval-end-flag"/>
+ <keydef href="ditaval/ditaval-prop.dita" keys="elements-ditaval-prop"/>
+ <keydef href="ditaval/ditaval-revprop.dita" keys="elements-ditaval-revprop"/>
+ <keydef href="ditaval/ditaval-startflag.dita" keys="elements-ditaval-startflag"/>
+ <keydef href="ditaval/ditaval-style-conflict.dita" keys="elements-ditaval-style-conflict"/>
+ <keydef href="ditaval/ditaval-val.dita" keys="elements-ditaval-val"/>
 </map>
 

--- a/specification/langRef/key-definitions-ditavalref-elements.ditamap
+++ b/specification/langRef/key-definitions-ditavalref-elements.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for DITAVAL reference domain</title>
+ <keydef href="base/ditavalref.dita" keys="elements-ditavalref"/>
+ <keydef href="base/ditavalmeta.dita" keys="elements-ditavalmeta"/>
+ <keydef href="base/dvrResourcePrefix.dita" keys="elements-dvrResourcePrefix" />
+ <keydef href="base/dvrResourceSuffix.dita" keys="elements-dvrResourceSuffix" />
+ <keydef href="base/dvrKeyscopePrefix.dita" keys="elements-dvrKeyscopePrefix" />
+ <keydef href="base/dvrKeyscopeSuffix.dita" keys="elements-dvrKeyscopeSuffix" />
+</map>

--- a/specification/langRef/key-definitions-hazard-statement-elements.ditamap
+++ b/specification/langRef/key-definitions-hazard-statement-elements.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for hazard statement domain elements</title>
+ <keydef href="base/consequence.dita" keys="elements-consequence" />
+ <keydef href="base/hazardstatement.dita" keys="elements-hazardstatement" />
+ <keydef href="base/hazardsymbol.dita" keys="elements-hazardsymbol" />
+ <keydef href="base/howtoavoid.dita" keys="elements-howtoavoid" />
+ <keydef href="base/messagepanel.dita" keys="elements-messagepanel" />
+ <keydef href="base/typeofhazard.dita" keys="elements-typeofhazard" />
+</map>

--- a/specification/langRef/key-definitions-highlighting-elements.ditamap
+++ b/specification/langRef/key-definitions-highlighting-elements.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for highlighting domain elements</title>
+ <keydef href="base/b.dita" keys="elements-b" />
+ <keydef href="base/i.dita" keys="elements-i" />
+ <keydef href="base/line-through.dita"  keys="elements-line-through"/>
+ <keydef href="base/overline.dita"  keys="elements-overline"/>
+ <keydef href="base/sub.dita" keys="elements-sub" />
+ <keydef href="base/sup.dita" keys="elements-sup" />
+ <keydef href="base/tt.dita" keys="elements-tt" />
+ <keydef href="base/u.dita" keys="elements-u" />
+</map>

--- a/specification/langRef/key-definitions-indexing-elements.ditamap
+++ b/specification/langRef/key-definitions-indexing-elements.ditamap
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for indexing elements</title>
+ <keydef href="base/index-see.dita" keys="elements-index-see" />
+ <keydef href="base/index-see-also.dita" keys="elements-index-see-also" />
+ <keydef href="base/indexterm.dita" keys="elements-indexterm"/>
+</map>

--- a/specification/langRef/key-definitions-map-group-elements.ditamap
+++ b/specification/langRef/key-definitions-map-group-elements.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for map group elements</title>
+ <keydef href="base/anchorref.dita" keys="elements-anchorref" />
+ <keydef href="base/keydef.dita" keys="elements-keydef" />
+ <keydef href="base/mapref.dita" keys="elements-mapref" />
+ <keydef href="base/mapresources.dita" keys="element-mapresources"/>
+ <keydef href="base/topicgroup.dita" keys="elements-topicgroup" />
+ <keydef href="base/topichead.dita" keys="elements-topichead" />
+</map>

--- a/specification/langRef/key-definitions-multimedia-domain.ditamap
+++ b/specification/langRef/key-definitions-multimedia-domain.ditamap
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for multimedia domain</title>
+ <keydef href="base/audio.dita" keys="elements-audio"/>
+ <keydef href="base/media-autoplay.dita" keys="elements-media-autoplay"/>
+ <keydef href="base/media-controls.dita" keys="elements-media-controls"/>
+ <keydef href="base/media-loop.dita" keys="elements-media-loop"/>
+ <keydef href="base/media-muted.dita" keys="elements-media-muted"/>
+ <keydef href="base/media-source.dita" keys="elements-media-source"/>
+ <keydef href="base/media-track.dita" keys="elements-media-track"/>
+ <keydef href="base/video.dita" keys="elements-video"/>
+ <keydef href="base/video-poster.dita" keys="elements-video-poster"/>
+</map>

--- a/specification/langRef/key-definitions-prolog-elements.ditamap
+++ b/specification/langRef/key-definitions-prolog-elements.ditamap
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for prolog elements</title>
+ <keydef href="base/audience.dita" keys="elements-audience" />
+ <keydef href="base/author.dita" keys="elements-author" />
+ <keydef href="base/brand.dita" keys="elements-brand" />
+ <keydef href="base/category.dita" keys="elements-category" />
+ <keydef href="base/component.dita" keys="elements-component" />
+ <keydef href="base/copyrholder.dita" keys="elements-copyrholder" />
+ <keydef href="base/copyright.dita" keys="elements-copyright" />
+ <keydef href="base/copyryear.dita" keys="elements-copyryear" />
+ <keydef href="base/created.dita" keys="elements-created" />
+ <keydef href="base/critdates.dita" keys="elements-critdates" />
+ <keydef href="base/featnum.dita" keys="elements-featnum" />
+ <keydef href="base/keywords.dita" keys="elements-keywords" />
+ <keydef href="base/metadata.dita" keys="elements-metadata" />
+ <keydef href="base/othermeta.dita" keys="elements-othermeta" />
+ <keydef href="base/permissions.dita" keys="elements-permissions" />
+ <keydef href="base/platform.dita" keys="elements-platform" />
+ <keydef href="base/prodinfo.dita" keys="elements-prodinfo" />
+ <keydef href="base/prodname.dita" keys="elements-prodname" />
+ <keydef href="base/prognum.dita" keys="elements-prognum" />
+ <keydef href="base/prolog.dita" keys="elements-prolog" />
+ <keydef href="base/publisher.dita" keys="elements-publisher" />
+ <keydef href="base/resourceid.dita" keys="elements-resourceid" />
+ <keydef href="base/revised.dita" keys="elements-revised" />
+ <keydef href="base/series.dita" keys="elements-series" />
+ <keydef href="base/source.dita" keys="elements-source" />
+ <keydef href="base/vrmlist.dita" keys="elements-vrmlist" />
+ <keydef href="base/vrm.dita" keys="elements-vrm" />
+</map>

--- a/specification/langRef/key-definitions-related-links-elements.ditamap
+++ b/specification/langRef/key-definitions-related-links-elements.ditamap
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for related links elements</title>
+ <keydef href="base/link.dita" keys="elements-link" />
+ <keydef href="base/linkinfo.dita" keys="elements-linkinfo"/>
+ <keydef href="base/linklist.dita" keys="elements-linklist" />
+ <keydef href="base/linkpool.dita" keys="elements-linkpool" />
+ <keydef href="base/linktext.dita" keys="elements-linktext" />
+</map>

--- a/specification/langRef/key-definitions-specialization-elements.ditamap
+++ b/specification/langRef/key-definitions-specialization-elements.ditamap
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Specialization elements</title>
+ <keydef href="base/data.dita" keys="elements-data"/>
+ <keydef href="base/data-about.dita" keys="elements-data-about"/>
+ <keydef href="base/foreign.dita" keys="elements-foreign"/>
+ <keydef href="base/itemgroup.dita" keys="elements-itemgroup"/>
+ <keydef href="base/no-topic-nesting.dita" keys="elements-no-topic-nesting"/>
+ <keydef href="base/state.dita" keys="elements-state"/>
+ <keydef href="base/unknown.dita" keys="elements-unknown"/>
+</map>

--- a/specification/langRef/key-definitions-subjectScheme-elements.ditamap
+++ b/specification/langRef/key-definitions-subjectScheme-elements.ditamap
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for subjectScheme elements</title>
+ <keydef href="base/attributedef.dita" keys="elements-attributedef" />  
+ <keydef href="base/defaultSubject.dita" keys="elements-defaultSubject" />
+ <keydef href="base/elementdef.dita" keys="elements-elementdef" />
+ <keydef href="base/enumerationdef.dita" keys="elements-enumerationdef" />
+ <keydef href="base/hasInstance.dita" keys="elements-hasInstance" />
+ <keydef href="base/hasKind.dita" keys="elements-hasKind" />
+ <keydef href="base/hasNarrower.dita" keys="elements-hasNarrower" />
+ <keydef href="base/hasPart.dita" keys="elements-hasPart" />
+ <keydef href="base/hasRelated.dita" keys="elements-hasRelated" />
+ <keydef href="base/relatedSubjects.dita" keys="elements-relatedSubjects" />
+ <keydef href="base/schemeref.dita" keys="elements-schemeref" />
+ <keydef href="base/subjectdef.dita" keys="elements-subjectdef" />
+ <keydef href="base/subjectHead.dita" keys="elements-subjectHead" />
+ <keydef href="base/subjectHeadMeta.dita" keys="elements-subjectHeadMeta" />
+ <keydef href="base/subjectRel.dita" keys="elements-subjectRel" />
+ <keydef href="base/subjectRelTable.dita" keys="elements-subjectRelTable" />
+ <keydef href="base/subjectRelHeader.dita" keys="elements-subjectRelHeader" />
+ <keydef href="base/subjectRole.dita" keys="elements-subjectRole" />
+ <keydef href="base/subjectScheme.dita" keys="elements-subjectScheme" />
+</map>

--- a/specification/langRef/key-definitions-table-elements.ditamap
+++ b/specification/langRef/key-definitions-table-elements.ditamap
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for table elements</title>
+ <keydef href="base/colspec.dita" keys="elements-colspec" />
+ <keydef href="base/entry.dita" keys="elements-entry" />
+ <keydef href="base/row.dita" keys="elements-row" />
+ <keydef href="base/simpletable.dita" keys="elements-simpletable" />
+ <keydef href="base/stentry.dita" keys="elements-stentry" />
+ <keydef href="base/sthead.dita" keys="elements-sthead" />
+ <keydef href="base/strow.dita" keys="elements-strow" />
+ <keydef href="base/table.dita" keys="elements-table" />
+ <keydef href="base/tbody.dita" keys="elements-tbody" />
+ <keydef href="base/tgroup.dita" keys="elements-tgroup" />
+ <keydef href="base/thead.dita" keys="elements-thead" />
+</map>

--- a/specification/langRef/key-definitions-utilities-elements.ditamap
+++ b/specification/langRef/key-definitions-utilities-elements.ditamap
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>Keys for utilities domain elements</title>
+ <keydef href="base/area.dita" keys="elements-area" />
+ <keydef href="base/coords.dita" keys="elements-coords" />
+ <keydef href="base/imagemap.dita" keys="elements-imagemap" />
+ <keydef href="base/shape.dita" keys="elements-shape" />
+ <keydef href="base/sort-as.dita"  keys="elements-sort-as" />
+</map>

--- a/specification/langRef/map-group-elements.ditamap
+++ b/specification/langRef/map-group-elements.ditamap
@@ -3,11 +3,11 @@
 <map>
  <title>Map group elements</title>
  <topicref href="containers/mapgroup-d.dita" >
-  <topicref href="base/anchorref.dita" keys="elements-anchorref" />
-  <topicref href="base/keydef.dita" keys="elements-keydef" />
-  <topicref href="base/mapref.dita" keys="elements-mapref" />
-  <topicref href="base/mapresources.dita" keys="element-mapresources"/>
-  <topicref href="base/topicgroup.dita" keys="elements-topicgroup" />
-  <topicref href="base/topichead.dita" keys="elements-topichead" />
+  <topicref keyref="elements-anchorref" />
+  <topicref keyref="elements-keydef" />
+  <topicref keyref="elements-mapref" />
+  <topicref keyref="element-mapresources"/>
+  <topicref keyref="elements-topicgroup" />
+  <topicref keyref="elements-topichead" />
  </topicref>
 </map>

--- a/specification/langRef/multimedia-domain.ditamap
+++ b/specification/langRef/multimedia-domain.ditamap
@@ -2,16 +2,15 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map id="MultimediaDomainMap">
  <title>Multimedia domain</title>
- <!--<mapref href="../common/key-definitions-library-topics.ditamap" format="ditamap" processing-role="resource-only"/>-->
  <topicref href="containers/multimedia-domain.dita">
-  <topicref href="base/audio.dita" keys="elements-audio"/>
-  <topicref href="base/media-autoplay.dita" keys="elements-media-autoplay"/>
-  <topicref href="base/media-controls.dita" keys="elements-media-controls"/>
-  <topicref href="base/media-loop.dita" keys="elements-media-loop"/>
-  <topicref href="base/media-muted.dita" keys="elements-media-muted"/>
-  <topicref href="base/media-source.dita" keys="elements-media-source"/>
-  <topicref href="base/media-track.dita" keys="elements-media-track"/>
-  <topicref href="base/video.dita" keys="elements-video"/>
-  <topicref href="base/video-poster.dita" keys="elements-video-poster"/>
+  <topicref keyref="elements-audio"/>
+  <topicref keyref="elements-media-autoplay"/>
+  <topicref keyref="elements-media-controls"/>
+  <topicref keyref="elements-media-loop"/>
+  <topicref keyref="elements-media-muted"/>
+  <topicref keyref="elements-media-source"/>
+  <topicref keyref="elements-media-track"/>
+  <topicref keyref="elements-video"/>
+  <topicref keyref="elements-video-poster"/>
  </topicref>
 </map>

--- a/specification/langRef/prolog-elements.ditamap
+++ b/specification/langRef/prolog-elements.ditamap
@@ -3,32 +3,32 @@
 <map>
  <title>Prolog elements</title>
  <topicref href="containers/prolog-elements.dita" >
-  <topicref href="base/audience.dita" keys="elements-audience" />
-  <topicref href="base/author.dita" keys="elements-author" />
-  <topicref href="base/brand.dita" keys="elements-brand" />
-  <topicref href="base/category.dita" keys="elements-category" />
-  <topicref href="base/component.dita" keys="elements-component" />
-  <topicref href="base/copyrholder.dita" keys="elements-copyrholder" />
-  <topicref href="base/copyright.dita" keys="elements-copyright" />
-  <topicref href="base/copyryear.dita" keys="elements-copyryear" />
-  <topicref href="base/created.dita" keys="elements-created" />
-  <topicref href="base/critdates.dita" keys="elements-critdates" />
-  <topicref href="base/featnum.dita" keys="elements-featnum" />
-  <topicref href="base/keywords.dita" keys="elements-keywords" />
-  <topicref href="base/metadata.dita" keys="elements-metadata" />
-  <topicref href="base/othermeta.dita" keys="elements-othermeta" />
-  <topicref href="base/permissions.dita" keys="elements-permissions" />
-  <topicref href="base/platform.dita" keys="elements-platform" />
-  <topicref href="base/prodinfo.dita" keys="elements-prodinfo" />
-  <topicref href="base/prodname.dita" keys="elements-prodname" />
-  <topicref href="base/prognum.dita" keys="elements-prognum" />
-  <topicref href="base/prolog.dita" keys="elements-prolog" />
-  <topicref href="base/publisher.dita" keys="elements-publisher" />
-  <topicref href="base/resourceid.dita" keys="elements-resourceid" />
-  <topicref href="base/revised.dita" keys="elements-revised" />
-  <topicref href="base/series.dita" keys="elements-series" />
-  <topicref href="base/source.dita" keys="elements-source" />
-  <topicref href="base/vrmlist.dita" keys="elements-vrmlist" />
-  <topicref href="base/vrm.dita" keys="elements-vrm" />
+  <topicref keyref="elements-audience" />
+  <topicref keyref="elements-author" />
+  <topicref keyref="elements-brand" />
+  <topicref keyref="elements-category" />
+  <topicref keyref="elements-component" />
+  <topicref keyref="elements-copyrholder" />
+  <topicref keyref="elements-copyright" />
+  <topicref keyref="elements-copyryear" />
+  <topicref keyref="elements-created" />
+  <topicref keyref="elements-critdates" />
+  <topicref keyref="elements-featnum" />
+  <topicref keyref="elements-keywords" />
+  <topicref keyref="elements-metadata" />
+  <topicref keyref="elements-othermeta" />
+  <topicref keyref="elements-permissions" />
+  <topicref keyref="elements-platform" />
+  <topicref keyref="elements-prodinfo" />
+  <topicref keyref="elements-prodname" />
+  <topicref keyref="elements-prognum" />
+  <topicref keyref="elements-prolog" />
+  <topicref keyref="elements-publisher" />
+  <topicref keyref="elements-resourceid" />
+  <topicref keyref="elements-revised" />
+  <topicref keyref="elements-series" />
+  <topicref keyref="elements-source" />
+  <topicref keyref="elements-vrmlist" />
+  <topicref keyref="elements-vrm" />
  </topicref>
 </map>

--- a/specification/langRef/related-links-elements.ditamap
+++ b/specification/langRef/related-links-elements.ditamap
@@ -3,10 +3,10 @@
 <map>
  <title>Related links elements</title>
  <topicref href="containers/related-links-elements.dita" >
-  <topicref href="base/link.dita" keys="elements-link" />
-  <topicref href="base/linkinfo.dita" keys="elements-linkinfo"/>
-  <topicref href="base/linklist.dita" keys="elements-linklist" />
-  <topicref href="base/linkpool.dita" keys="elements-linkpool" />
-  <topicref href="base/linktext.dita" keys="elements-linktext" />
+  <topicref keyref="elements-link" />
+  <topicref keyref="elements-linkinfo"/>
+  <topicref keyref="elements-linklist" />
+  <topicref keyref="elements-linkpool" />
+  <topicref keyref="elements-linktext" />
  </topicref>
 </map>

--- a/specification/langRef/specialization-elements.ditamap
+++ b/specification/langRef/specialization-elements.ditamap
@@ -3,12 +3,12 @@
 <map>
  <title>Specialization elements</title>
  <topicref href="containers/specialization-elements.dita">
-  <topicref href="base/data.dita" keys="elements-data"/>
-  <topicref href="base/data-about.dita" keys="elements-data-about"/>
-  <topicref href="base/foreign.dita" keys="elements-foreign"/>
-  <topicref href="base/itemgroup.dita" keys="elements-itemgroup"/>
-  <topicref href="base/no-topic-nesting.dita" keys="elements-no-topic-nesting"/>
-  <topicref href="base/state.dita" keys="elements-state"/>
-  <topicref href="base/unknown.dita" keys="elements-unknown"/>
+  <topicref keyref="elements-data"/>
+  <topicref keyref="elements-data-about"/>
+  <topicref keyref="elements-foreign"/>
+  <topicref keyref="elements-itemgroup"/>
+  <topicref keyref="elements-no-topic-nesting"/>
+  <topicref keyref="elements-state"/>
+  <topicref keyref="elements-unknown"/>
  </topicref>
 </map>

--- a/specification/langRef/subjectScheme-elements.ditamap
+++ b/specification/langRef/subjectScheme-elements.ditamap
@@ -3,24 +3,24 @@
 <map>
  <title>SubjectScheme elements</title>
  <topicref href="containers/subjectScheme.dita">  
-  <topicref href="base/attributedef.dita" keys="elements-attributedef" />  
-  <topicref href="base/defaultSubject.dita" keys="elements-defaultSubject" />
-  <topicref href="base/elementdef.dita" keys="elements-elementdef" />
-  <topicref href="base/enumerationdef.dita" keys="elements-enumerationdef" />
-  <topicref href="base/hasInstance.dita" keys="elements-hasInstance" />
-  <topicref href="base/hasKind.dita" keys="elements-hasKind" />
-  <topicref href="base/hasNarrower.dita" keys="elements-hasNarrower" />
-  <topicref href="base/hasPart.dita" keys="elements-hasPart" />
-  <topicref href="base/hasRelated.dita" keys="elements-hasRelated" />
-  <topicref href="base/relatedSubjects.dita" keys="elements-relatedSubjects" />
-  <topicref href="base/schemeref.dita" keys="elements-schemeref" />
-  <topicref href="base/subjectdef.dita" keys="elements-subjectdef" />
-  <topicref href="base/subjectHead.dita" keys="elements-subjectHead" />
-  <topicref href="base/subjectHeadMeta.dita" keys="elements-subjectHeadMeta" />
-  <topicref href="base/subjectRel.dita" keys="elements-subjectRel" />
-  <topicref href="base/subjectRelTable.dita" keys="elements-subjectRelTable" />
-  <topicref href="base/subjectRelHeader.dita" keys="elements-subjectRelHeader" />
-  <topicref href="base/subjectRole.dita" keys="elements-subjectRole" />
-  <topicref href="base/subjectScheme.dita" keys="elements-subjectScheme" />
+  <topicref keyref="elements-attributedef" />  
+  <topicref keyref="elements-defaultSubject" />
+  <topicref keyref="elements-elementdef" />
+  <topicref keyref="elements-enumerationdef" />
+  <topicref keyref="elements-hasInstance" />
+  <topicref keyref="elements-hasKind" />
+  <topicref keyref="elements-hasNarrower" />
+  <topicref keyref="elements-hasPart" />
+  <topicref keyref="elements-hasRelated" />
+  <topicref keyref="elements-relatedSubjects" />
+  <topicref keyref="elements-schemeref" />
+  <topicref keyref="elements-subjectdef" />
+  <topicref keyref="elements-subjectHead" />
+  <topicref keyref="elements-subjectHeadMeta" />
+  <topicref keyref="elements-subjectRel" />
+  <topicref keyref="elements-subjectRelTable" />
+  <topicref keyref="elements-subjectRelHeader" />
+  <topicref keyref="elements-subjectRole" />
+  <topicref keyref="elements-subjectScheme" />
  </topicref>
 </map>

--- a/specification/langRef/table-elements.ditamap
+++ b/specification/langRef/table-elements.ditamap
@@ -3,16 +3,16 @@
 <map>
  <title>Table elements</title>
  <topicref href="containers/table-elements.dita" >
-  <topicref href="base/colspec.dita" keys="elements-colspec" />
-  <topicref href="base/entry.dita" keys="elements-entry" />
-  <topicref href="base/row.dita" keys="elements-row" />
-  <topicref href="base/simpletable.dita" keys="elements-simpletable" />
-  <topicref href="base/stentry.dita" keys="elements-stentry" />
-  <topicref href="base/sthead.dita" keys="elements-sthead" />
-  <topicref href="base/strow.dita" keys="elements-strow" />
-  <topicref href="base/table.dita" keys="elements-table" />
-  <topicref href="base/tbody.dita" keys="elements-tbody" />
-  <topicref href="base/tgroup.dita" keys="elements-tgroup" />
-  <topicref href="base/thead.dita" keys="elements-thead" />
+  <topicref keyref="elements-colspec" />
+  <topicref keyref="elements-entry" />
+  <topicref keyref="elements-row" />
+  <topicref keyref="elements-simpletable" />
+  <topicref keyref="elements-stentry" />
+  <topicref keyref="elements-sthead" />
+  <topicref keyref="elements-strow" />
+  <topicref keyref="elements-table" />
+  <topicref keyref="elements-tbody" />
+  <topicref keyref="elements-tgroup" />
+  <topicref keyref="elements-thead" />
  </topicref>
 </map>

--- a/specification/langRef/utilities-elements.ditamap
+++ b/specification/langRef/utilities-elements.ditamap
@@ -3,10 +3,10 @@
 <map>
  <title>Utilities domain elements</title>
  <topicref href="containers/ut-d.dita" >
-  <topicref href="base/area.dita" keys="elements-area" />
-  <topicref href="base/coords.dita" keys="elements-coords" />
-  <topicref href="base/imagemap.dita" keys="elements-imagemap" />
-  <topicref href="base/shape.dita" keys="elements-shape" />
-  <topicref href="base/sort-as.dita"  keys="elements-sort-as" />
+  <topicref keyref="elements-area" />
+  <topicref keyref="elements-coords" />
+  <topicref keyref="elements-imagemap" />
+  <topicref keyref="elements-shape" />
+  <topicref keyref="elements-sort-as" />
  </topicref>
 </map>


### PR DESCRIPTION
Prototyping a change in how keys are defined and referenced in the base specification.

Currently keys for each element's language-reference topic are defined inside the TOC. This update makes the following changes:

* Creates a key definition map to match each TOC map for elements
* In the TOC itself, switch from using `href="base/example.dita" keys="elements-example"` to just referencing the key: `keyref="elements-example"`
* Tangential change: define much better keys for DITAVAL elements, which were likely to clash with other keys
* Within all topics in the language reference, where they currently cross reference elements with `href` (usually for example content), switch to use `keyref`