### PR TITLE
Remove uses of glossary.dtd, edit DTD Public ID topic

### DIFF
--- a/specification/glossary/base-sort-phrase.dita
+++ b/specification/glossary/base-sort-phrase.dita
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary//EN" "glossary.dtd">
+<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary Entry//EN" "glossentry.dtd">
 <glossentry id="base-sort-phrase">
     <glossterm>base sort phrase</glossterm>
     <glossdef>The text by which an element is sorted in the absence of a <xmlelement>sort-as </xmlelement> element. This

--- a/specification/glossary/sort-phrase.dita
+++ b/specification/glossary/sort-phrase.dita
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary//EN" "glossary.dtd">
+<!DOCTYPE glossentry PUBLIC "-//OASIS//DTD DITA Glossary Entry//EN" "glossentry.dtd">
 <glossentry id="sort-phrase">
     <glossterm>sort phrase</glossterm>
     <glossdef>A string specified by the <xmlelement>sort-as</xmlelement> element that determines how

--- a/specification/non-normative/dtd-public-identifiers.dita
+++ b/specification/non-normative/dtd-public-identifiers.dita
@@ -12,70 +12,17 @@
         format:</p>
       <codeblock>"-//OASIS//DTD DITA <varname>version</varname> <varname>information-type</varname>//EN"</codeblock>
       <p> where:<ul>
-          <li><varname>version</varname> either is the DITA version number (for example, 1.0, 1.1,
-            1.2, or 1.3) or is omitted entirely.</li>
-          <li><varname>information-type</varname> is the name of the topic or map type in camel
-            case, for example, Concept or BookMap.</li>
+          <li><varname>version</varname> either is the DITA specific version number (for example,
+            2.0, 1.3, or 1.2), 2.x (representing the latest version of DITA 2.x), or 1.x
+            (representing 1.3, which is the final version of 1.x). Ommitting the version number
+            entirely is also equivalent to the final release of DITA 1.x.</li>
+          <li><varname>information-type</varname> is the name of the topic or map type, for example,
+            Concept or BookMap.</li>
         </ul>
       </p>
       <p>Note that "OASIS" is the owner identifier; this indicates that the artifacts are owned by
         OASIS. The keyword "DITA" is a convention that indicates that the artifact is
         DITA-related.</p>
     </section>
-    <!--<section><title>Topic and topic-based specializations</title><p conkeyref="reuse-general/module-version-xpl"/><dl><dlentry product="base"><dt>Base topic</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Topic//EN" "basetopic.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Base Topic//EN" "basetopic.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Base Topic//EN" "basetopic.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Concept</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Concept//EN" "concept.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Concept//EN" "concept.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>DITAbase</dt><dd><draft-comment author="robander" time="16 February 2015">In Archspec we refer to "DITAbase", "DITABase", and "ditabase". Content models use "Ditabase". Langref has a few uses of "ditabase". Non-normative uses "ditabase" (including "Composite (ditabase)".</draft-comment><lines>PUBLIC "-//OASIS//DTD DITA Composite//EN" "ditabase.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Composite//EN" "ditabase.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Composite//EN" "ditabase.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Glossary</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Glossary//EN" "glossary.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Glossary//EN" "glossary.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Glossary//EN" "glossary.dtd"</lines></dd><dd><note>The <filepath>glossary.dtd</filepath> file is provided only for backward compatibility with DITA 1.1. Use the <filepath>glossentry.dtd</filepath> file in new documents.</note></dd></dlentry><dlentry product="technicalContent"><dt>Glossary entry</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Glossary Entry//EN" "glossentry.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Glossary Entry//EN" "glossentry.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Glossary Entry//EN" "glossentry.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning assessment</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Assessment//EN" "learningAssessment.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Assessment//EN" "learningAssessment.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Assessment//EN" "learningAssessment.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning content</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Content//EN" "learningContent.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Content//EN" "learningContent.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Content//EN" "learningContent.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning overview</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Overview//EN" "learningOverview.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Overview//EN" "learningOverview.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Overview//EN" "learningOverview.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning plan</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Plan//EN" "learningPlan.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Plan//EN" "learningPlan.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Plan//EN" "learningPlan.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning summary</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Summary//EN" "learningSummary.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Summary//EN" "learningSummary.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Summary//EN" "learningSummary.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Machinery task</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Machinery Task//EN" "machineryTask.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Machinery Task//EN" "machineryTask.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Machinery Task//EN" "machineryTask.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Reference</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Reference//EN" "reference.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Reference//EN" "reference.dtd"</lines></dd></dlentry><dlentry product="technicalContent" rev="DITA1.3 proposal-13097"><dt>Troubleshooting</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Troubleshooting//EN"
-PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Troubleshooting//EN"
-PUBLIC "-//OASIS//ELEMENTS DITA 1.x Troubleshooting//EN"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Task (general)</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA General Task//EN" "generalTask.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x General Task//EN" "generalTask.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 General Task//EN" "generalTask.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Task (strict)</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Task//EN" "task.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Task//EN" "task.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Topic</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Topic//EN" "topic.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Topic//EN" "topic.dtd"</lines></dd></dlentry></dl></section>-->
-    <!--<section><title>Map and map-based specializations</title><p conkeyref="reuse-general/module-version-xpl"/><dl><dlentry product="base"><dt>Base map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Base Map//EN" "basemap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.1 Base Map//EN" "basemap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.0 Base Map//EN" "basemap.dtd"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Bookmap</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA BookMap//EN" "bookmap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN" "bookmap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.1 BookMap//EN" "bookmap.dtd" </lines></dd></dlentry><dlentry product="base"><dt>Classification</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Classification Map//EN" "classifyMap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Classification Map//EN" "classifyMap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 Classification Map//EN" "classifyMap.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning bookmap</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning BookMap//EN" "learningBookmap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning BookMap//EN" "learningBookmap.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning BookMap//EN" "learningBookmap.dtd"</lines></dd></dlentry><dlentry product="learningTraining"><dt>Learning map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Map//EN" "learningMap.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Map//EN" "learningMap.dtd"
-PUBLIC "-//OASIS//DTD DITA Learning Map//EN" "learningMap.dtd"</lines></dd></dlentry><dlentry product="learningTraining" rev="DITA1.3 proposal-13089"><dt>Learning group map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Group Map//EN"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Group Map//EN"
-PUBLIC "-//OASIS//DTD DITA Learning Group Map//EN"</lines></dd></dlentry><dlentry product="learningTraining" rev="DITA1.3 proposal-13089"><dt>Learning object map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Learning Object Map//EN"
-PUBLIC "-//OASIS//DTD DITA 1.x Learning Object Map//EN"
-PUBLIC "-//OASIS//DTD DITA Learning Object Map//EN"</lines></dd></dlentry><dlentry product="technicalContent"><dt>Map</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.1 Map//EN" "map.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.0 Map//EN" "map.dtd"</lines></dd></dlentry><dlentry product="base"><dt>Subject scheme</dt><dd><lines>PUBLIC "-//OASIS//DTD DITA 1.3 Subject Scheme Map//EN" "subjectScheme.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x Subject Scheme Map//EN" "subjectScheme.dtd"
-PUBLIC "-//OASIS//DTD DITA Subject Scheme Map//EN" "subjectScheme.dtd"</lines></dd></dlentry></dl></section>-->
-    <!--<section><title>DITAVAL for conditional processing</title><p conkeyref="reuse-general/module-version-xpl"/><lines>PUBLIC "-//OASIS//DTD DITA DITAVAL//EN" "ditaval.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.x DITAVAL//EN" "ditaval.dtd"
-PUBLIC "-//OASIS//DTD DITA 1.3 DITAVAL//EN" "ditaval.dtd"</lines></section>-->
   </refbody>
 </reference>


### PR DESCRIPTION
`glossary.dtd` is obsolete and is being removed; replace it with references to `glossentry.dtd`

The file `glossary.dtd` was mentioned in a comment about DTD public identifiers; I've removed that comment, which was also obsolete. While in that topic I edited the description of public identifiers to match what is in use for 2.0.