### PR TITLE
Fix bug in stentry att definition

### DIFF
--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -2711,33 +2711,35 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
             <attribute name="specentry"/>
           </optional>
           <optional>
-            <attribute name="colspan"/>
-            <data type="NMTOKEN"/>
+            <attribute name="colspan">
+              <data type="NMTOKEN"/>
+            </attribute>
           </optional>
           <optional>
-            <attribute name="rowspan"/>
-            <data type="NMTOKEN"/>
+            <attribute name="rowspan">
+              <data type="NMTOKEN"/>
+            </attribute>
           </optional>
           <optional>
-            <attribute name="scope"/>
-            <choice>
-              <value>row</value>
-              <value>col</value>              
-              <value>rowgroup</value>              
-              <value>colgroup</value>              
-              <value>-dita-use-conref-target</value>
-            </choice>
+            <attribute name="scope">
+              <choice>
+                <value>row</value>
+                <value>col</value>              
+                <value>rowgroup</value>              
+                <value>colgroup</value>              
+                <value>-dita-use-conref-target</value>
+              </choice>
+            </attribute>
           </optional>
           <optional>
-            <attribute name="headers"/>
-            <data type="NMTOKENS"/>
+            <attribute name="headers">
+              <data type="NMTOKENS"/>
+            </attribute>
           </optional>
           <ref name="univ-atts"/>
         </define>
         <define name="stentry.element">
-          <element name="stentry" dita:longName="Simple Table Cell (entry)">
-            <a:documentation>The simpletable entry (&lt;stentry>) element represents a single table cell, like &lt;entry> in &lt;table>. You can place any number of stentry cells in either an
-              &lt;sthead> element (for headings) or &lt;strow> element (for rows of data). Category: Table elements</a:documentation>
+          <element name="stentry">
             <ref name="stentry.attlist"/>
             <ref name="stentry.content"/>
           </element>


### PR DESCRIPTION
RNG is currently broken because a few attributes are declared improperly.