### PR TITLE
Add resource only variable file for covers

### DIFF
--- a/specification/dita-2.0-key-definitions-cover-pages.ditamap
+++ b/specification/dita-2.0-key-definitions-cover-pages.ditamap
@@ -6,6 +6,8 @@
     <topicmeta>
       <navtitle>Cover page variables</navtitle>
     </topicmeta>
+    <!-- Make common variable content available -->
+    <topicref href="common/conref-cover-pages.dita" processing-role="resource-only"/>
     <keydef keys="stage">
       <!--Used in the master maps as a title-->
       <!-- Also used in the "Citation format" section.-->


### PR DESCRIPTION
Signed-off-by: Robert D. Anderson <robert.dan.anderson@oracle.com>

For best practices / better processing results, the conref library used for cover pages should be referenced from the map as a resource only topic. This fixes an issue with recent DITA-OT versions that skipped some processing for the topic (because it wasn't in the map).