### PR TITLE
Update DITA-OT to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk:
 - openjdk8
 env:
   global:
-  - DITA_OT_VERSION=3.2.1
+  - DITA_OT_VERSION=3.5.4
 install: .travis/install.sh
 script: .travis/run.sh

--- a/.travis/ditaotplugin.xml
+++ b/.travis/ditaotplugin.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-This file is part of the DITA Open Toolkit project.
-See the accompanying LICENSE file for applicable license.
--->
-<plugin id="org.oasis-open.dita.v2_0">
-  <feature extension="dita.specialization.catalog.relative" file="catalog.xml"/>
-</plugin>

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,14 +4,15 @@ set -e
 
 # Install DITA-OT
 curl -sfL https://github.com/dita-ot/dita-ot/releases/download/$DITA_OT_VERSION/dita-ot-$DITA_OT_VERSION.zip -o dita-ot-$DITA_OT_VERSION.zip
-unzip dita-ot-$DITA_OT_VERSION.zip
+unzip -q dita-ot-$DITA_OT_VERSION.zip
 export DITA_HOME=$PWD/dita-ot-$DITA_OT_VERSION
 
-# Create and install plugin for 2.0 with latest doctypes
-mkdir $DITA_HOME/plugins/org.oasis-open.dita.v2_0/
-cp -a ./doctypes/. $DITA_HOME/plugins/org.oasis-open.dita.v2_0/
-cp .travis/ditaotplugin.xml $DITA_HOME/plugins/org.oasis-open.dita.v2_0/plugin.xml
-$DITA_HOME/bin/dita -install
+# Copy latest base doctype updates over the beta version in DITA-OT;
+# replace whatever (possibly older) version is currently shipped.
+rm -rv $DITA_HOME/plugins/org.oasis-open.dita.v2_0/dtd/
+rm -rv $DITA_HOME/plugins/org.oasis-open.dita.v2_0/rng/
+cp -av ./doctypes/. $DITA_HOME/plugins/org.oasis-open.dita.v2_0/
+$DITA_HOME/bin/dita install
 
 # Install RNG support
 #curl -sfL https://github.com/oxygenxml/dita-relaxng-defaults/archive/master.zip -o dita-ng.zip


### PR DESCRIPTION
* Updates travis build from DITA-OT 3.2.1 to 3.5.4, the latest
* Because DITA-OT 3.5.4 already ships beta 2.0 support, we can remove some of the extra setup to make that work; instead, we delete the DTD and RNG directories from 3.5.4 and replace them with the latest from this repo
* Tested with a commit in this repo that broke the DTD (result: travis failed as expected, then backed the commit out)