### PR TITLE
Rework shortdesc for table elements

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -682,15 +682,15 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                         <dl>
                                                 <dlentry id="map-attribute-id">
                                                   <dt><xmlatt>id</xmlatt></dt>
-                                                  <dd>Allows an ID to be specified for the map. Note
-                                                  that maps do not require IDs (unlike topics), and
-                                                  the map ID is not included in references to
-                                                  elements within a map. <ph
-                                                  conref="#conref-attribute/define-ID"/></dd>
+                                                  <dd>Specifies an ID for the map. Note that maps do
+                                                  not require IDs (unlike topics), and the map ID is
+                                                  not included in references to elements within a
+                                                  map. <ph conref="#conref-attribute/define-ID"
+                                                  /></dd>
                                                 </dlentry>
                                                 <dlentry id="map-attribute-anchorref">
                                                   <dt><xmlatt>anchorref</xmlatt></dt>
-                                                  <dd>Identifies a location within another map
+                                                  <dd>Specifies a location within another map
                                                   document where this map will be anchored.
                                                   Resolution of the map is deferred until the final
                                                   step in the delivery of any rendered content. For
@@ -719,17 +719,17 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                         <dl>
                                 <dlentry id="headers-att">
                                         <dt><xmlatt>headers</xmlatt></dt>
-                                        <dd>Identifies one or more entry element headers that apply
-                                                to its entry. The <xmlatt>headers</xmlatt> attribute
-                                                contains an unordered set of unique space-separated
-                                                tokens, each of which is an ID reference of an entry
-                                                from the same table. </dd>
+                                        <dd>Specifies one or more <xmlelement>entry</xmlelement>
+                                                headers that apply to the current entry. The
+                                                  <xmlatt>headers</xmlatt> attribute contains an
+                                                unordered set of unique space-separated tokens, each
+                                                of which is an ID reference of an entry from the
+                                                same table. </dd>
                                 </dlentry>
                                 <dlentry id="tablescope">
                                         <dt><xmlatt>scope</xmlatt></dt>
-                                        <dd>The presence of the <xmlatt>scope</xmlatt> attribute
-                                                indicates that the current entry is a header for the
-                                                specified scope. Allowable values are:<dl>
+                                        <dd>Specifies that the current entry is a header for other
+                                                table entries. Allowable values are:<dl>
                                                   <dlentry>
                                                   <dt><keyword>row</keyword></dt>
                                                   <dd>The current entry is a header for all cells in

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -2,9 +2,9 @@
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="colspec" xml:lang="en-us">
   <title><xmlelement>colspec</xmlelement></title>
-  <shortdesc>The <xmlelement>colspec</xmlelement> element contains a column specification for a
-    table, including assigning a column name and number, cell content alignment, and column
-    width.</shortdesc>
+  <shortdesc>A column specifications provides information about a single column in a table from on
+    the OASIS Exchange Table Model, such as a column name and number, cell content alignment, or a
+    column width.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -29,10 +29,9 @@
         </dlentry>
         <dlentry>
           <dt><xmlatt>colname</xmlatt></dt>
-          <!--RDA: cleaned up for 1.3, in 1.2 @colname used the same definition as for entry: "Specifies the table column name in which an entry is found-->
           <dd><ph>Specifies a name for the column defined by this element. The
-                <xmlelement>entry</xmlelement> element <ph>can</ph> use <xmlatt>colname</xmlatt> to
-              refer to the name of this column.</ph></dd>
+                <xmlelement>entry</xmlelement> element can use <xmlatt>colname</xmlatt> to refer to
+              the name of this column.</ph></dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>colwidth</xmlatt></dt>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -2,8 +2,8 @@
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="entry" xml:lang="en-us">
   <title><xmlelement>entry</xmlelement></title>
-  <shortdesc>The <xmlelement>entry</xmlelement> element defines a single cell in a
-    table.</shortdesc>
+  <shortdesc>A table entry represents a single cell in a table based on the OASIS Exchange Table
+    Model.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -25,8 +25,7 @@
       <dl>
         <dlentry>
           <dt><xmlatt>rotate</xmlatt></dt>
-          <dd>Indicates whether the contents of the entry <ph>is</ph> rotated. While the attribute
-            is declared with the XML data type CDATA, the only predefined values are:<dl>
+          <dd>Specifies whether the contents of the entry is rotated. Supported values are:<dl>
               <dlentry>
                 <dt>1</dt>
                 <dd>The contents of the cell are rotated 90 degrees counterclockwise.</dd>
@@ -39,8 +38,8 @@
                 <dt/>
                 <dd/>
               </dlentry>
-            </dl><p>If this attribute is not specified, no rotation <ph>occurs</ph>. In situations
-              where a stylesheet or other formatting mechanism specifies table cell orientation, the
+            </dl><p>If this attribute is not specified, no rotation occurs. In situations where a
+              stylesheet or other formatting mechanism specifies table cell orientation, the
                 <xmlatt>rotate</xmlatt> attribute can be ignored.</p></dd>
         </dlentry>
         <dlentry>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE reference
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
-<reference id="row" xml:lang="en-us"><title><xmlelement>row</xmlelement></title><shortdesc>The <xmlelement>row</xmlelement> element contains a single row in a table.</shortdesc><prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>row</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
+<reference id="row" xml:lang="en-us"><title><xmlelement>row</xmlelement></title><shortdesc>A table row is a single row in a table based on the OASIS Exchange Table
+    Model.</shortdesc><prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>row</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -3,10 +3,9 @@
  "reference.dtd">
 <reference id="table" xml:lang="en-us">
 <title><xmlelement>table</xmlelement></title>
-<shortdesc>The <xmlelement>table</xmlelement> element organizes arbitrarily complex relationships of
-    tabular information. This standard table markup allows column or row spanning and table captions
-    or descriptions. An optional title allowed inside the <xmlelement>table</xmlelement> element
-    provides a caption to describe the table.</shortdesc>
+<shortdesc>A table based on the OASIS Exchange Table Model organizes arbitrarily complex
+    relationships of tabular information. This standard table markup allows column or row spanning
+    and table captions or descriptions.</shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>table elements<indexterm><xmlelement>table</xmlelement></indexterm></indexterm>
@@ -16,11 +15,14 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>The DITA table is based on the OASIS Exchange Table Model, augmented with DITA attributes
-        that enable it for accessibility, specialization, conref, and other DITA processing. In
-        addition, the table includes a <xmlelement>desc</xmlelement> element, which enables table
-        description that is parallel with figure description. See <xref keyref="elements-simpletable"/>
-        for a simplified table model that is closer to the HTML5 table model, and can be specialized
-        to represent more regular relationships of data.</p>
+        that enable it for accessibility, specialization, conref, and other DITA processing. An
+        optional <xmlelement>title</xmlelement> inside the <xmlelement>table</xmlelement> element
+        provides a caption to describe the table. In addition, the optional
+          <xmlelement>desc</xmlelement> element enables table description that is parallel with
+        figure description.</p>
+      <p>See <xref keyref="elements-simpletable"/> for a simplified table model that is closer to
+        the HTML5 table model, and can be specialized to represent more regular relationships of
+        data.</p>
       <p conkeyref="reuse-general/pgwide-explain"/>
       <note>The <xmlatt>scale</xmlatt> attribute represents a stylistic markup property that is
         currently maintained in tables for legacy purposes. External stylesheets should enable less
@@ -33,11 +35,15 @@
           keyref="attributes-display"/>, and the attributes defined below. This
         element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
           <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-calsTable"/>.</p>
+      <draft-comment author="Robert">Looking for consistency on orient, pgwide, and entry/@rotate.
+        Should they mention "not enforced by dtd / rng"? Should they say "Supported values" (seems
+        to imply "processors MUST support at least these") or "Allowed values" (implies no other
+        values are legal)?</draft-comment>
       <dl>
         <dlentry id="orient">
           <dt><xmlatt>orient</xmlatt></dt>
-          <dd>Specifies the orientation of the table in page-based outputs. <ph>This attribute is
-              primarily useful for print-oriented display.</ph> Allowable values are:<dl>
+          <dd>Specifies the orientation of the table in page-based outputs. This attribute is
+            primarily useful for print-oriented display. Allowable values are:<dl>
               <dlentry>
                 <dt>port</dt>
                 <dd>The same orientation as the text flow.</dd>
@@ -56,8 +62,8 @@
         </dlentry>
         <dlentry>
           <dt><xmlatt>pgwide</xmlatt></dt>
-          <dd>Determines the horizontal placement of the element. Supported values are 1 and 0,
-            although these are not mandated by the DTD, Schema, or RNG.<p>For print-oriented
+          <dd>Specifies the horizontal placement of the element. Supported values are 1 and 0,
+            although these are not mandated by the DTD or RNG grammar files.<p>For print-oriented
               display, the value &quot;1&quot; places the element on the left page margin;
               &quot;0&quot; aligns the element with the left margin of the current text line and
               takes indention into account. </p></dd>
@@ -67,10 +73,12 @@
 <example id="example" otherprops="examples"><title>Example</title>
       <fig>
         <title>DITA source</title>
+        <p>The following code sample shows a table that is used to provide reference information
+          about animals and gestation:</p>
         <codeblock xml:space="preserve">&lt;table&gt;
 &lt;tgroup cols="2"&gt;
-&lt;colspec colname="COLSPEC0" colwidth="121*"/&gt;
-&lt;colspec colname="COLSPEC1" colwidth="76*"/&gt;
+&lt;colspec colwidth="121*"/&gt;
+&lt;colspec colwidth="76*"/&gt;
 &lt;thead&gt;
 &lt;row&gt;
 &lt;entry colname="COLSPEC0" valign="top"&gt;Animal&lt;/entry&gt;
@@ -101,12 +109,12 @@
       <p>The formatted output might be displayed as follows:</p>
       <table>
         <tgroup cols="2">
-          <colspec colname="COLSPEC0" colwidth="121*"/>
-          <colspec colname="COLSPEC1" colwidth="76*"/>
+          <colspec colwidth="121*"/>
+          <colspec colwidth="76*"/>
           <thead>
             <row>
-              <entry colname="COLSPEC0" valign="top">Animal</entry>
-              <entry colname="COLSPEC1" valign="top">Gestation</entry>
+              <entry valign="top">Animal</entry>
+              <entry valign="top">Gestation</entry>
             </row>
           </thead>
           <tbody>
@@ -134,6 +142,9 @@
         the table body and the matching header cell above that column.</p></example>
     <example id="implied-accessibility" otherprops="examples">
       <title>Example: Complex table with implied accessibility markup</title>
+      <draft-comment author="Robert">Discussed with Kris October 5 2020: would be good to have a
+        section on accessibility in the architectural spec; if that is created, some of these
+        examples might be better placed there.</draft-comment>
       <p>In the following example, the table uses <xmlelement>thead</xmlelement> to identify header
         rows and <xmlatt>rowheader</xmlatt> to identify a header column. This header relationship
         can be used to automatically create renderings of the table in other formats, such as HTML,
@@ -235,9 +246,9 @@ expected points in column c2 and actual points in column c3.&lt;/desc>
   <example  id="accessibility-manual" otherprops="examples">
       <title>Complex table with some manually specified accessibility markup</title>
       <p>In some complex tables, the <xmlelement>thead</xmlelement> element and
-          <xmlatt>rowheader</xmlatt> attribute <ph >might</ph> not be enough to
-        support all accessibility needs. Assume that the table above is flipped so that the names
-        are listed across the top row, instead of in the first column, as follows:</p>
+          <xmlatt>rowheader</xmlatt> attribute might not be enough to support all accessibility
+        needs. Assume that the table above is flipped so that the names are listed across the top
+        row, instead of in the first column, as follows:</p>
       <table frame="all" id="table_nzp_zzl_4n">
         <title>Sample with two header columns</title>
         <tgroup cols="5">

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -2,7 +2,8 @@
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="tbody" xml:lang="en-us">
 <title><xmlelement>tbody</xmlelement></title>
-<shortdesc>The <xmlelement>tbody</xmlelement> element contains the rows in a table.</shortdesc>
+<shortdesc>A table body is a group of rows in a table based on the OASIS Exchange Table
+        Model.</shortdesc>
 <prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>tbody</xmlelement></indexterm></indexterm></keywords></metadata></prolog>
 <refbody>
     <section id="attributes">

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -5,8 +5,8 @@
   id="tgroup"
   xml:lang="en-us">
   <title><xmlelement>tgroup</xmlelement></title>
-  <shortdesc>The <xmlelement>tgroup</xmlelement> element in a table contains the header and body
-    rows of a table.</shortdesc>
+  <shortdesc>A table group is a grouping of a table header and table body, based on the OASIS
+    Exchange Table Model.</shortdesc>
   <prolog>
     <metadata>
       <keywords><indexterm>table elements<indexterm><xmlelement>tgroup</xmlelement></indexterm></indexterm></keywords>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -2,8 +2,8 @@
   PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="thead" xml:lang="en-us">
 <title><xmlelement>thead</xmlelement></title>
-<shortdesc>The <xmlelement>thead</xmlelement> element is a table header that precedes the table body
-            (<xmlelement>tbody</xmlelement>) element in a complex table.</shortdesc>
+<shortdesc>A table header contains one or more header rows in a table based on the OASIS Exchange
+    Table Model.</shortdesc>
 <prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>thead</xmlelement></indexterm></indexterm></keywords></metadata></prolog>
 <refbody>
     <section id="attributes">


### PR DESCRIPTION
First draft of new short descriptions for table elements. Also includes minor wording edits in the usage section and table example.