### PR TITLE
Remove obsolete comments

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -28,12 +28,7 @@
                                         another element in the map (for cascade rules, see <xref
                                                 href="../archSpec/base/cascading-in-a-ditamap.dita#cascading-in-a-ditamap"
                                         />).</ph></p><p><ph id="define-ID">This attribute is defined
-                                        with the XML Data Type ID.</ph></p><p><ph id="define-CDATA"
-                                        >This attribute is defined with the XML Data Type
-                                        CDATA.</ph></p><p><ph id="define-NMTOKEN">This attribute is
-                                        defined with the XML Data Type NMTOKEN.</ph></p><p><ph
-                                        id="define-NMTOKENS">This attribute is defined with the XML
-                                        Data Type NMTOKENS.</ph></p><p><ph id="nonstandard-type"
+                                        with the XML Data Type ID.</ph></p><p><ph id="nonstandard-type"
                                         >Note that this differs from the <xmlatt>type</xmlatt>
                                         attribute on many other DITA elements.</ph></p><p><ph
                                         id="non-dita-href">References to content other than DITA

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -51,7 +51,7 @@
         <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>anchoref</xmlelement> element is specialized from
-                    <xmlelement>map</xmlelement>. It is defined in the mapgroup module.</p>
+                    <xmlelement>topicref</xmlelement>. It is defined in the mapgroup module.</p>
         </section>
         <section id="attributes">
             <title>Attributes</title>
@@ -72,9 +72,9 @@
                         <dd>A pointer to an <xmlelement>anchor</xmlelement> element in this or
                             another DITA map. When rendered, the contents of the current element
                             will be copied to the location of the <xmlelement>anchor</xmlelement>.
-                                <ph>See <xref keyref="attributes-href"/> for
-                                supported syntax when referencing a map element.</ph>
-                            <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                                <ph>See <xref keyref="attributes-href"/> for supported syntax when
+                                referencing a map element.</ph>
+                        </dd>
                     </dlentry>
                     <dlentry>
                         <dt><xmlatt>type</xmlatt></dt>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -52,16 +52,14 @@
                             <xmlatt>archive</xmlatt> attribute. When specified, and at least one key
                         name is resolvable, the key-provided archive list is used. If
                             <xmlatt>archive</xmlatt> is specified, it is used as a fallback when no
-                        key names can be resolved to a URI.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                        key names can be resolved to a URI. </dd>
                 </dlentry>
                 <dlentry id="classid">
                     <dt><xmlatt>classid</xmlatt></dt>
                     <dd>Contains a URI that specifies the location of an object&apos;s
                         implementation. It can be used together with the <xmlatt>data</xmlatt>
                         attribute which is specified relative to the value of the
-                            <xmlatt>codebase</xmlatt> attribute.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                            <xmlatt>codebase</xmlatt> attribute. </dd>
                 </dlentry>
                 <dlentry id="classidkeyref">
                     <dt><xmlatt>classidkeyref</xmlatt></dt>
@@ -69,16 +67,14 @@
                         implementation, as for <xmlatt>classid</xmlatt>. When specified, and the key
                         is resolvable, the key-provided class ID URI is used. If
                             <xmlatt>classid</xmlatt> is specified, it is used as a fallback when the
-                        key cannot be resolved to a URI.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                        key cannot be resolved to a URI. </dd>
                 </dlentry>
                 <dlentry id="codebase">
                     <dt><xmlatt>codebase</xmlatt></dt>
                     <dd>Specifies the base URI used for resolving the relative URI values given for
                             <xmlatt>classid</xmlatt>, <xmlatt>data</xmlatt>, and
                             <xmlatt>archive</xmlatt> attributes. If <xmlatt>codebase</xmlatt> is not
-                        set, the default is the base URI of the current element.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                        set, the default is the base URI of the current element.</dd>
                 </dlentry>
                 <dlentry id="codebasekeyref">
                     <dt><xmlatt>codebasekeyref</xmlatt></dt>
@@ -88,16 +84,14 @@
                         specified, it is used as a fallback if the key cannot be resolved to a URI.
                         If no URI results from processing <xmlatt>codebasekeyref</xmlatt> and
                             <xmlatt>codebase</xmlatt> is not specified, the default is the base URL
-                        of the current element.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                        of the current element.</dd>
                 </dlentry>
                 <dlentry id="data">
                     <dt><xmlatt>data</xmlatt></dt>
                     <dd>Contains a reference to the location of an object&apos;s data. If this
                         attribute is a relative URL, it is specified relative to the value of the
                             <xmlatt>codebase</xmlatt> attribute. If this attribute is set, the
-                            <xmlatt>type</xmlatt> attribute should also be set.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                            <xmlatt>type</xmlatt> attribute should also be set.</dd>
                 </dlentry>
                 <dlentry id="datakeyref">
                     <!-- KJE: Modified to be parallel to the desciption of  @datakeyref in the audio and video topics-->
@@ -130,8 +124,7 @@
                 </dlentry>
                 <dlentry id="standby">
                     <dt><xmlatt>standby</xmlatt></dt>
-                    <dd>Contains a message to be displayed while an object is loading.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                    <dd>Contains a message to be displayed while an object is loading.</dd>
                 </dlentry>
                 <dlentry conkeyref="reuse-attributes/image-height">
                     <dt/>
@@ -146,18 +139,15 @@
                     <dd>Indicates that a client-side image map is to be used. An image map specifies
                         active geometric regions of an included object and assigns a link to each
                         region. When a link is selected, a document <ph>might</ph> be retrieved or a
-                        program <ph>might</ph> run on the server.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                        program <ph>might</ph> run on the server.</dd>
                 </dlentry>
                 <dlentry id="name">
                     <dt><xmlatt>name</xmlatt></dt>
-                    <dd>Defines a unique name for the object.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+                    <dd>Defines a unique name for the object.</dd>
                 </dlentry>
                 <dlentry id="tabindex">
                     <dt><xmlatt>tabindex</xmlatt></dt>
-                    <dd>Position the object in tabbing order.
-                        <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-NMTOKEN"/>--></dd>
+                    <dd>Position the object in tabbing order.</dd>
                 </dlentry>
             </dl>
         </section>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -32,16 +32,12 @@
     <dlentry id="name">
      <dt><xmlatt>name</xmlatt>
       <ph conkeyref="reuse-attributes/required-attr"/></dt>
-     <dd>The name of the metadata property.
-      <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
-     </dd>
+     <dd>The name of the metadata property. </dd>
     </dlentry>
     <dlentry id="content">
      <dt><xmlatt>content</xmlatt>
       <ph conkeyref="reuse-attributes/required-attr"/></dt>
-     <dd>The value for the property named in the <xmlatt>name</xmlatt> attribute.
-      <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
-     </dd>
+     <dd>The value for the property named in the <xmlatt>name</xmlatt> attribute. </dd>
     </dlentry>
     <dlentry id="translate-content">
      <dt><xmlatt>translate-content</xmlatt></dt>

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -29,14 +29,12 @@
         <dlentry>
           <dt><xmlatt>name</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
-          <dd>The name of the parameter.
-            <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+          <dd>The name of the parameter.</dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>value</xmlatt></dt>
           <dd>Specifies the value of a run-time parameter that is specified by the
-              <xmlatt>name</xmlatt> attribute.
-            <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></dd>
+              <xmlatt>name</xmlatt> attribute.</dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>valuetype</xmlatt></dt>
@@ -69,7 +67,6 @@
           <dd>This attribute specifies for a user agent the type of values that will be found at the
             URI designated by <xmlatt>value</xmlatt>. <ph
               conkeyref="reuse-attributes/nonstandard-type"/>
-            <!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>-->
             <ol id="ol_svg_2c2_z1b">
               <li>When <xmlatt>valuetype</xmlatt> is set to "ref", this attribute directly specifies
                 the content type of the resource designated by <xmlatt>value</xmlatt>.</li>
@@ -100,7 +97,7 @@
               <li>When the key specified by <xmlatt>keyref</xmlatt> is not resolvable, the value of
                 the <xmlatt>value</xmlatt> attribute is used as a fallback target for the
                   <xmlelement>param</xmlelement> element.</li>
-            </ol><p><!--<ph conref="../../common/conref-attribute.dita#conref-attribute/define-CDATA"/>--></p>
+            </ol>
           </dd>
         </dlentry>
       </dl>


### PR DESCRIPTION
Removes "This attribute is defined as CDATA / NMTOKEN / NMTOKENS" text and references, which were already commented out in 1.3 and can be cleaned out.

Also fixes the specialization hierarchy of `anchorref` which said it came from `map` (should be `topicref`)