### PR TITLE
Improve reuse in attribute sections

### DIFF
--- a/specification/langRef/base/brand.dita
+++ b/specification/langRef/base/brand.dita
@@ -13,10 +13,9 @@
 </metadata></prolog>
 <refbody>
   <section id="attributes">
-   <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref
-     keyref="attributes-universal"/>.</p>
-  </section>
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/only-universal"/>
+    </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows that product "MyMedDevice" is associated with the brand
         "ExampleCo".</p><codeblock>&lt;prodinfo&gt;

--- a/specification/langRef/base/category.dita
+++ b/specification/langRef/base/category.dita
@@ -22,8 +22,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/component.dita
+++ b/specification/langRef/base/component.dita
@@ -26,8 +26,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref
-     keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
   </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/copyrholder.dita
+++ b/specification/langRef/base/copyrholder.dita
@@ -14,8 +14,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/critdates.dita
+++ b/specification/langRef/base/critdates.dita
@@ -19,8 +19,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/fallback.dita
+++ b/specification/langRef/base/fallback.dita
@@ -19,8 +19,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/featnum.dita
+++ b/specification/langRef/base/featnum.dita
@@ -5,8 +5,7 @@
         <indexterm>elements<indexterm>prolog<indexterm><xmlelement>featnum</xmlelement></indexterm></indexterm></indexterm><indexterm>prolog elements<indexterm><xmlelement>featnum</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows that the topic is associated with feature number 135 of the
         product <keyword>MyController</keyword>.</p><codeblock>&lt;prodinfo&gt;

--- a/specification/langRef/base/keywords.dita
+++ b/specification/langRef/base/keywords.dita
@@ -34,8 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/base/platform.dita
+++ b/specification/langRef/base/platform.dita
@@ -12,6 +12,5 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prodinfo.dita
+++ b/specification/langRef/base/prodinfo.dita
@@ -20,8 +20,7 @@
         </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples">    <title>Example</title>
             <p>The following code sample shows that a product is about the product

--- a/specification/langRef/base/prodname.dita
+++ b/specification/langRef/base/prodname.dita
@@ -5,6 +5,5 @@
         <indexterm>elements<indexterm>prolog<indexterm><xmlelement>prodname</xmlelement></indexterm></indexterm></indexterm><indexterm>prolog elements<indexterm><xmlelement>prodname</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/prognum.dita
+++ b/specification/langRef/base/prognum.dita
@@ -4,6 +4,5 @@
         <indexterm>elements<indexterm>prolog<indexterm><xmlelement>prognum</xmlelement></indexterm></indexterm></indexterm><indexterm>prolog elements<indexterm><xmlelement>prognum</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-prodinfo"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/series.dita
+++ b/specification/langRef/base/series.dita
@@ -5,8 +5,7 @@
         <indexterm>elements<indexterm>prolog<indexterm><xmlelement>series</xmlelement></indexterm></indexterm></indexterm><indexterm>prolog elements<indexterm><xmlelement>series</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+            <p conkeyref="reuse-attributes/only-universal"/>
     </section><example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows that the topic is associated with series X of the product
           <keyword>myLearningApp</keyword>.</p><codeblock>&lt;prodinfo&gt;

--- a/specification/langRef/base/titlealts.dita
+++ b/specification/langRef/base/titlealts.dita
@@ -7,8 +7,7 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
       </section>
 <example id="example" otherprops="examples"><title>Example</title>
          <p>The following code sample shows how the <xmlelement>titlealts</xmlelement> element

--- a/specification/langRef/base/vrmlist.dita
+++ b/specification/langRef/base/vrmlist.dita
@@ -15,8 +15,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows the version numbers associated with
           <keyword>Widge-o-matic</keyword>, as described in the topic.</p><codeblock>&lt;prolog&gt;


### PR DESCRIPTION
We have a common variable for elements that use universal atts (and only those atts).

This updates relevant metadata elements to use that variable, rather than redefining the text.