### PR TITLE
Update subject scheme topics for 2.0 consistency

### DIFF
--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -34,22 +34,21 @@
         </dlentry>
       </dl>
     </section>
-<example id="example" otherprops="examples"><title>Example</title><p>In this example, the <xmlatt>value</xmlatt> attribute for the
-          <xmlelement>lomDifficulty</xmlelement> element is bound to the specified set of values.
-        Processors should limit the values for the <xmlatt>value</xmlatt> attribute on the
-          <xmlelement>lomDifficulty</xmlelement> element to the following set of values: easy,
-        medium, or difficult. Other elements that have a <xmlatt>value</xmlatt> attribute are not
-        affected.</p><codeblock>&lt;subjectScheme>
-  &lt;subjectdef keys="difficulty">
-    &lt;subjectdef keys="easy"/>
-    &lt;subjectdef keys="medium"/>
-    &lt;subjectdef keys="difficult"/>
+<example id="example" otherprops="examples"><title>Example</title><p>In this example, the <xmlatt>type</xmlatt> attribute for the <xmlelement>note</xmlelement>
+        element is bound to the specified set of values. Processors should limit the values for the
+          <xmlatt>type</xmlatt> attribute on the <xmlelement>note</xmlelement> element to the
+        following set of values: attention, caution, and danger. Other elements that have a
+          <xmlatt>type</xmlatt> attribute are not affected.</p><codeblock>&lt;subjectScheme>
+  &lt;subjectdef keys="note-values">
+    &lt;subjectdef keys="attention"/>
+    &lt;subjectdef keys="caution"/>
+    &lt;subjectdef keys="danger"/>
   &lt;/subjectdef>
   &lt;!-- ... -->
   &lt;enumerationdef>
-    <b>&lt;elementdef name="lomDifficulty"/></b>
-    &lt;attributedef name="value"/>
-    &lt;subjectdef keyref="difficulty"/>
+    <b>&lt;elementdef name="note"/></b>
+    &lt;attributedef name="type"/>
+    &lt;subjectdef keyref="note-values"/>
   &lt;/enumerationdef>
 &lt;/subjectScheme></codeblock></example>
 </refbody>

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -18,13 +18,13 @@
                 <dlentry>
                     <dt>Bind a set of controlled values to an attribute</dt>
                     <dd>When the <xmlelement>enumerationdef</xmlelement> element contains an
-                            <xmlelement>attributedef</xmlelement> and an
+                            <xmlelement>attributedef</xmlelement> and a
                             <xmlelement>subjectdef</xmlelement> element, the set of controlled
-                        values bound to the attribute apply to all elements.</dd>
-                    <dd>For example, when <xmlelement>enumerationdef</xmlelement> contains only
-                            <codeph>&lt;attributedef name="value"/></codeph>, the
-                            <xmlatt>value</xmlatt> attribute is limited to the specified enumeration
-                        for all elements.</dd>
+                        values bound to the attribute apply to all elements.<p otherprops="examples"
+                            >For example, when <xmlelement>enumerationdef</xmlelement> contains only
+                                <codeph>&lt;attributedef name="value"/></codeph>, the
+                                <xmlatt>value</xmlatt> attribute is limited to the specified
+                            enumeration for all elements.</p></dd>
                 </dlentry>
                 <dlentry>
                     <dt>Limit a set of controlled values to a specific element and attribute
@@ -34,14 +34,15 @@
                             <xmlelement>subjectdef</xmlelement>, <b>and</b> an
                             <xmlelement>elementdef</xmlelement> element, the enumeration applies to
                         the specified attribute <b>only</b> on the specified element. The
-                        enumeration does not apply to the attribute on other elements.</dd>
-                    <dd>For example, when the <xmlelement>enumerationdef</xmlelement> element
-                        contains both <codeph>&lt;attributedef name="value"/></codeph> and
-                            <codeph>&lt;elementdef name="lomDifficulty"/></codeph>, only the
-                            <xmlatt>value</xmlatt> attribute on the
-                            <xmlelement>lomDifficulty</xmlelement> element is limited to the
-                        specified enumeration. The possible values for the <xmlatt>value</xmlatt>
-                        attribute on other elements are not affected.</dd>
+                        enumeration does not apply to the attribute on other elements.<p
+                            otherprops="examples">For example, when the
+                                <xmlelement>enumerationdef</xmlelement> element contains both
+                                <codeph>&lt;attributedef name="type"/></codeph> and
+                                <codeph>&lt;elementdef name="note"/></codeph>, only the
+                                <xmlatt>type</xmlatt> attribute on the <xmlelement>note</xmlelement>
+                            element is limited to the specified enumeration. The possible values for
+                            the <xmlatt>type</xmlatt> attribute on other elements are not
+                            affected.</p></dd>
                 </dlentry>
                 <dlentry>
                     <dt>Specify that an attribute is not valid.</dt>
@@ -84,7 +85,7 @@
                         <keyword>spec-editors</keyword> and <keyword>tc-reviewers</keyword>.</li>
                 <li>The permissible values for <xmlatt>otherprops</xmlatt> are restricted to the
                     subject <keyword>values-otherprops</keyword>. This means that the only valid
-                    value for <xmlatt>otherprops</xmlatt> is examples<keyword/>.</li>
+                    value for <xmlatt>otherprops</xmlatt> is <keyword>examples</keyword>.</li>
                 <li>The enumeration for the <xmlatt>props</xmlatt> element is empty. No values are
                     valid.</li>
             </ol>

--- a/specification/langRef/base/hasKind.dita
+++ b/specification/langRef/base/hasKind.dita
@@ -37,22 +37,6 @@
     &lt;/subjectdef>
   &lt;/hasKind>
 &lt;/subjectScheme></codeblock>
-      <!--<p>This example specifies that cars, trucks, and motorcycles are kinds of vehicles. In addition, compact, sedan, and station wagon are each a kind of car, while pickup and van are each a type of truck.</p><codeblock>&lt;subjectScheme>
-  &lt;hasKind>
-    &lt;subjectdef keys="vehicle" navtitle="Vehicle">
-      &lt;subjectdef keys="car" navtitle="Passenger car">
-          &lt;subjectdef keys="compact" navtitle="Compact car"/>
-          &lt;subjectdef keys="sedan" navtitle="Sedan"/>
-          &lt;subjectdef keys="stationWagon" navtitle="Station wagon"/>
-      &lt;/subjectdef>
-      &lt;subjectdef keys="truck" navtitle="Truck">
-          &lt;subjectdef keys="pickup" navtitle="Pickup truck"/>
-          &lt;subjectdef keys="van" navtitle="Van"/>
-      &lt;/subjectdef>
-      &lt;subjectdef keys="motorcycle" navtitle="Motorcycle"/>
-    &lt;/subjectdef>
-  &lt;/hasKind>
-&lt;/subjectScheme></codeblock>-->
     </example>
 </refbody>
 </reference>

--- a/specification/langRef/base/hasNarrower.dita
+++ b/specification/langRef/base/hasNarrower.dita
@@ -2,12 +2,10 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="hasNarrower" xml:lang="en-us">
 <title><xmlelement>hasNarrower</xmlelement></title>
-  <abstract>
-    <shortdesc>The <xmlelement>hasNarrower</xmlelement> element specifies that the contained
-      subjects have a narrower focus than the container subject. The way in which a relationship is
-      narrower is not specified. </shortdesc>
-    <!--<shortdesc>For subjects within the <xmlelement>hasNarrower</xmlelement> element, the container subject is more general than each of the contained subjects. That is, this element makes the default hierarchical relationship explicit, although the way in which a relationship is narrower is not specified.</shortdesc>-->
-  </abstract>
+  <shortdesc>The <xmlelement>hasNarrower</xmlelement> element specifies that the contained subjects
+    have a narrower focus than the container subject. The way in which a relationship is narrower is
+    not specified. </shortdesc>
+  <!--<shortdesc>For subjects within the <xmlelement>hasNarrower</xmlelement> element, the container subject is more general than each of the contained subjects. That is, this element makes the default hierarchical relationship explicit, although the way in which a relationship is narrower is not specified.</shortdesc>-->
 <prolog><metadata>
 <keywords>
         <indexterm>subjectScheme<indexterm>elements<indexterm><xmlelement>hasNarrower</xmlelement></indexterm></indexterm></indexterm></keywords>

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -25,6 +25,11 @@
       <draft-comment author="Kristen J Eberlein" time="27 May 2019" audience="spec-editors">
         <p>This material needs to be rewritten and moved elsewhere.</p>
       </draft-comment>
+      <draft-comment author="Robert">Wonder if it should instead just be removed? As someone who
+        works on a processor, this is not really telling me anything that I can use. Same for the
+        second sentence of the short description above, which mirrors this: "The utility of this
+        relationship is primarily for content delivery platforms with advanced
+        capabilities."</draft-comment>
       <p>For filtering and flagging, processors need only inspect the subordinate hierarchies under
         category subjects that are bound to attributes. Filtering and flagging processors do not
         have to understand specific types of relationships. Explicit relationships are useful

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -5,16 +5,20 @@
 <reference id="subjectHead" xml:lang="en-us">
 <title><xmlelement>subjectHead</xmlelement></title>
 <shortdesc>The <xmlelement>subjectHead</xmlelement> element provides a heading for a group of
-subjects, for use if the scheme is displayed. For instance, a scheme might be displayed to let a
-user select subjects as part of faceted browsing. The <xmlelement>subjectHead</xmlelement> element
-itself does not reference a file and cannot be referenced as a key, so it does not define any
-controlled values.</shortdesc>
+    subjects, for use if the scheme is displayed. \</shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>subjectScheme<indexterm>
               elements<indexterm><xmlelement>subjectHead</xmlelement></indexterm></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
+    <section id="usage-information">
+      <title>Usage information</title>
+      <p>For example, the <xmlelement>subjectHead</xmlelement> could be displayed as part of a
+        scheme that is rendered to let a user select subjects as part of faceted browsing.</p>
+      <p>The <xmlelement>subjectHead</xmlelement> element itself does not reference a file and
+        cannot be referenced as a key, so it does not define any controlled values.</p>
+    </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>subjectHead</xmlelement> element is specialized from
@@ -57,19 +61,6 @@ controlled values.</shortdesc>
         </dl></p>
     </section>
 <example conkeyref="reuse-examples/example-subjectHead" id="example" otherprops="examples"/>
-<!--<example id="example"><title>Example</title><p>In this example the <q>Server setup</q> label doesn't classify content but, when selected, is equivalent to the union of its child subjects. That is, the heading covers content about planning for any application, installing for any application, any task for web servers, or any task for database servers.</p><codeblock>&lt;subjectScheme toc="yes" search="no">
-  ...
-  &lt;subjectHead>
-    &lt;subjectHeadMeta>
-      &lt;navtitle>Server setup&lt;/navtitle>
-    &lt;/subjectHeadMeta>
-    &lt;subjectdef href="planningTaskType.dita"/>
-    &lt;subjectdef href="installingTaskType.dita"/>
-    &lt;subjectdef href="webServerApp.dita"/>
-    &lt;subjectdef href="databaseApp.dita"/>
-  &lt;/subjectHead>
-  ...
-&lt;/subjectScheme></codeblock></example>-->
 </refbody>
 </reference>
 

--- a/specification/langRef/base/subjectRelHeader.dita
+++ b/specification/langRef/base/subjectRelHeader.dita
@@ -4,7 +4,8 @@
 <reference id="subjectRelHeader" xml:lang="en-us">
 <title><xmlelement>subjectRelHeader</xmlelement></title>
 <shortdesc>The <xmlelement>subjectRelHeader</xmlelement> element specifies the roles played by
-subjects in associations.</shortdesc>
+        subjects in associations established by a
+        <xmlelement>subjectRelTable</xmlelement>.</shortdesc>
 <prolog><metadata>
 <keywords>
                 <indexterm>subjectScheme<indexterm>

--- a/specification/langRef/base/subjectRelTable.dita
+++ b/specification/langRef/base/subjectRelTable.dita
@@ -22,13 +22,12 @@
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>subjectRel</xmlelement> element is specialized from
+      <p>The <xmlelement>subjectRelTable</xmlelement> element is specialized from
           <xmlelement>reltable</xmlelement>. It is defined in the subject scheme module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/reltable-minus-title"
-      />
+      <sectiondiv conkeyref="reuse-attributes/reltable-minus-title"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>
@@ -37,7 +36,7 @@
         subjects in the first column are operating systems which are the environment for an
         application, while subjects in the second column are applications that run in that
         environment. For a user interested in content about the operating system, content about the
-        applications <ph >might</ph> also be relevant.</p>
+        applications might also be relevant.</p>
       <codeblock>&lt;subjectScheme>
   &lt;hasKind>
     &lt;subjectdef keys="operatingSystem">

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -4,8 +4,9 @@
  "reference.dtd">
 <reference id="subjectScheme" xml:lang="en-us">
 <title><xmlelement>subjectScheme</xmlelement></title>
-<shortdesc>The <xmlelement>subjectScheme</xmlelement> element is a specialization of
-      <xmlelement>map</xmlelement>; it defines taxonomic subjects and controlled values.</shortdesc>
+<shortdesc>The <xmlelement>subjectScheme</xmlelement> element
+    <!--is a specialization of <xmlelement>map</xmlelement>; it -->defines taxonomic subjects and
+    controlled values.</shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>subjectScheme<indexterm>elements<indexterm><xmlelement>subjectScheme</xmlelement></indexterm></indexterm></indexterm></keywords>
@@ -49,8 +50,7 @@
         </dlentry>
       </dl>
     </section>
-    <example conkeyref="reuse-examples/example-subjectScheme"
-      id="example" otherprops="examples"/>
+    <example conkeyref="reuse-examples/example-subjectScheme" id="example" otherprops="examples"/>
   </refbody>
 </reference>
 

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -14,8 +14,6 @@
 <refbody>
                 <section id="usage-information">
                         <title>Usage information</title>
-                        <!--KJE: Removed the following paragraph becauses it restates basic information that is applicable to all specializations of  <topicref> elements.-->
-                        <!--<p>The <xmlatt>keys</xmlatt> attribute specified on the <xmlelement>subjectdef</xmlelement> element assigns a key to the subject. A subject with a key can be addressed using a <xmlatt>keyref</xmlatt> attribute.</p>-->
                         <p>The <xmlelement>subjectdef</xmlelement> can use a
                                         <xmlelement>navtitle</xmlelement> element to supply a label
                                 for the subject; the <xmlatt>href</xmlatt> attribute can be used to


### PR DESCRIPTION
Mostly minor edits:
* switching examples to use base elements, not L&T
* update wording for consistency
* fix incorrect element name in inheritance section
* remove some obsolete comments