### PR TITLE
Make it easier to reuse stentry atts

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -692,6 +692,16 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                         <title>Common for <xmlelement>stentry</xmlelement> and
                                         <xmlelement>entry</xmlelement></title>
                         <dl>
+                                <dlentry id="stentry-colspan">
+                                        <dt><xmlatt>colspan</xmlatt></dt>
+                                        <dd>Specifies the number of columns that a cell is to span
+                                                inside a simple table.</dd>
+                                </dlentry>
+                                <dlentry id="stentry-rowspan">
+                                        <dt><xmlatt>rowspan</xmlatt></dt>
+                                        <dd>Specifies the number of rows that a cells is to span
+                                                inside a simple table.</dd>
+                                </dlentry>
                                 <dlentry id="headers-att">
                                         <dt><xmlatt>headers</xmlatt></dt>
                                         <dd>Specifies one or more <xmlelement>entry</xmlelement>

--- a/specification/common/reuse-w-lwdita/reuse-stentry.dita
+++ b/specification/common/reuse-w-lwdita/reuse-stentry.dita
@@ -13,13 +13,13 @@
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
-        <dlentry>
-          <dt><xmlatt>colspan</xmlatt></dt>
-          <dd>Specifies the number of columns that a cell is to span inside a simple table.</dd>
+        <dlentry conkeyref="reuse-attributes/stentry-colspan">
+          <dt/>
+          <dd/>
         </dlentry>
-        <dlentry>
-          <dt><xmlatt>rowspan</xmlatt></dt>
-          <dd>Specifies the number of rows that a cells is to span inside a simple table.</dd>
+        <dlentry conkeyref="reuse-attributes/stentry-rowspan">
+          <dt/>
+          <dd/>
         </dlentry>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>


### PR DESCRIPTION
Move colspan/rowspan into the common attribute topic, so that they can be reused by elements in the tech comm spec that specialize stentry.