### PR TITLE
Minor cleanup in spec files

### DIFF
--- a/doctypes/rng/base/audienceAttDomain.rng
+++ b/doctypes/rng/base/audienceAttDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
      <moduleShortName>audienceAtt-d</moduleShortName>
      <modulePublicIds>
        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Audience Attribute Domain//EN</dtdEnt>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:audienceAttDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <rncMod>urn:oasis:names:tc:dita:rnc:audienceAttDomain.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:audienceAttDomain.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution>@props/audience</domainsContribution>

--- a/doctypes/rng/base/basemap.rng
+++ b/doctypes/rng/base/basemap.rng
@@ -53,12 +53,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Base Map//EN"
          <moduleShortName>basemap</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Base Map//EN</dtdShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:basemap.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:basemap.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:rng:basemap.rng<var presep=":" name="ditaver"/>
-            </rngShell>
+            <rngShell>urn:oasis:names:tc:dita:rng:basemap.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/base/basetopic.rng
+++ b/doctypes/rng/base/basetopic.rng
@@ -52,9 +52,7 @@ UPDATES:
       <moduleShortName>Base topic</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Base Topic//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:basetopic.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:basetopic.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:basetopic.xsd<var presep=":" name="ditaver"/></xsdShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -49,9 +49,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Common Elements//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Common Elements//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:commonElementMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:commonElementGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:commonElementsMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:commonElementsMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
       <domainsContribution/>

--- a/doctypes/rng/base/deliveryTargetAttDomain.rng
+++ b/doctypes/rng/base/deliveryTargetAttDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
      <moduleShortName>deliveryTargetAtt-d</moduleShortName>
      <modulePublicIds>
        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Delivery Target Attribute Domain//EN</dtdEnt>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:deliveryTargetAttDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <rncMod>urn:oasis:names:tc:dita:rnc:deliveryTargetAttDomain.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution>@props/deliveryTarget</domainsContribution>

--- a/doctypes/rng/base/ditavalrefDomain.rng
+++ b/doctypes/rng/base/ditavalrefDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> DITAVAL Ref Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> DITAVAL Ref Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:ditavalrefDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:ditavalrefDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/emphasisDomain.rng
+++ b/doctypes/rng/base/emphasisDomain.rng
@@ -42,7 +42,6 @@
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Emphasis Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Emphasis Domain//EN</dtdEnt>
-        <rncMod>urn:oasis:names:tc:dita:rnc:emphasisDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:emphasisDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/hazardstatementDomain.rng
+++ b/doctypes/rng/base/hazardstatementDomain.rng
@@ -42,8 +42,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Hazard Statement Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Hazard Statement Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:hazardDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:hazardDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:hazardDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/highlightDomain.rng
+++ b/doctypes/rng/base/highlightDomain.rng
@@ -42,7 +42,6 @@
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Highlight Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Highlight Domain//EN</dtdEnt>
-        <rncMod>urn:oasis:names:tc:dita:rnc:highlightDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:highlightDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/mapGroupDomain.rng
+++ b/doctypes/rng/base/mapGroupDomain.rng
@@ -47,8 +47,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Map Group Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Map Group Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:mapGroupMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:mapGroupMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:mapGroupMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -53,9 +53,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       <modulePublicIds>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Map//EN</dtdEnt>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Map//EN</dtdMod>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:mapMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:mapGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:mapMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:mapMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/mediaDomain.rng
+++ b/doctypes/rng/base/mediaDomain.rng
@@ -30,8 +30,6 @@
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Media Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Media Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:mediaDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:mediaDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:mediaDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/metaDeclMod.rng
+++ b/doctypes/rng/base/metaDeclMod.rng
@@ -43,9 +43,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       <moduleShortName>metaDecl</moduleShortName>
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Metadata//EN</dtdMod>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:metaDeclMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:metaDeclGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:metaDeclMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:metaDeclMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
       <domainsContribution/>

--- a/doctypes/rng/base/otherpropsAttDomain.rng
+++ b/doctypes/rng/base/otherpropsAttDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
      <moduleShortName>otherpropsAtt-d</moduleShortName>
      <modulePublicIds>
        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Otherprops Attribute Domain//EN</dtdEnt>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:otherpropsAttDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <rncMod>urn:oasis:names:tc:dita:rnc:otherpropsAttDomain.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution>@props/otherprops</domainsContribution>

--- a/doctypes/rng/base/platformAttDomain.rng
+++ b/doctypes/rng/base/platformAttDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
      <moduleShortName>platformAtt-d</moduleShortName>
      <modulePublicIds>
        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Platform Attribute Domain//EN</dtdEnt>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:platformAttDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <rncMod>urn:oasis:names:tc:dita:rnc:platformAttDomain.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:platformAttDomain.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution>@props/platform</domainsContribution>

--- a/doctypes/rng/base/productAttDomain.rng
+++ b/doctypes/rng/base/productAttDomain.rng
@@ -43,8 +43,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
      <moduleShortName>productAtt-d</moduleShortName>
      <modulePublicIds>
        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Product Attribute Domain//EN</dtdEnt>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:productAttDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <rncMod>urn:oasis:names:tc:dita:rnc:productAttDomain.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:productAttDomain.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution>@props/product</domainsContribution>

--- a/doctypes/rng/base/tblDeclMod.rng
+++ b/doctypes/rng/base/tblDeclMod.rng
@@ -85,9 +85,6 @@ For <entry>, add:
      <moduleShortName>tblDecl</moduleShortName>
      <modulePublicIds>
        <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Exchange Table Model//EN</dtdMod>
-       <xsdMod>urn:oasis:names:tc:dita:xsd:tblDeclMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-       <xsdGrp>urn:oasis:names:tc:dita:xsd:tblDeclGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-       <rncMod>urn:oasis:names:tc:dita:rnc:tblDeclMod.rnc<var presep=":" name="ditaver"/></rncMod>
        <rngMod>urn:oasis:names:tc:dita:rng:tblDeclMod.rng<var presep=":" name="ditaver"/></rngMod>
      </modulePublicIds>
      <domainsContribution/>

--- a/doctypes/rng/base/topicMod.rng
+++ b/doctypes/rng/base/topicMod.rng
@@ -51,9 +51,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
       <modulePublicIds>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Topic//EN</dtdEnt>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Topic//EN</dtdMod>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:topicMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:topicGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:topicMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:topicMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/base/utilitiesDomain.rng
+++ b/doctypes/rng/base/utilitiesDomain.rng
@@ -42,8 +42,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Utilities Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Utilities Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:utilitiesDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:utilitiesDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:utilitiesDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/ditaval/ditaval.rng
+++ b/doctypes/rng/ditaval/ditaval.rng
@@ -52,9 +52,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
       <moduleShortName>ditaval</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> DITAVAL//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:xsd:ditaval.rnc<var presep=":" name="ditaver"/></rncShell>
-        <rngShell>urn:oasis:names:tc:dita:xsd:ditaval.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:ditaval.xsd<var presep=":" name="ditaver"/></xsdShell>
+        <rngShell>urn:oasis:names:tc:dita:rng:ditaval.rng<var presep=":" name="ditaver"/></rngShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/subjectScheme/classifyDomain.rng
+++ b/doctypes/rng/subjectScheme/classifyDomain.rng
@@ -44,8 +44,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Subject Classification Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Subject Classification Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:tc:tc:dita:spec:classification:xsd:classifyDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:tc:tc:dita:spec:classification:rnc:classifyDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:tc:tc:dita:spec:classification:rng:classifyDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/subjectScheme/subjectScheme.rng
+++ b/doctypes/rng/subjectScheme/subjectScheme.rng
@@ -56,12 +56,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Subject Scheme Map//EN"
          <moduleShortName>subjectScheme</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Subject Scheme Map//EN</dtdShell>
-            <rncShell>urn:oasis:names:tc:dita:spec:classification:rnc:subjectScheme.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:spec:classification:rng:subjectScheme.rng<var presep=":" name="ditaver"/>
-            </rngShell>
-            <xsdShell>urn:oasis:names:tc:dita:spec:classification:xsd:subjectScheme.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
+            <rngShell>urn:oasis:names:tc:dita:spec:classification:rng:subjectScheme.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -44,10 +44,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Subject Scheme Map//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Subject Scheme Map//EN</dtdEnt>
-        <rncMod>urn:oasis:names:tc:dita:spec:classification:rnc:subjectSchemeMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:spec:classification:rng:subjectSchemeMod.rng<var presep=":" name="ditaver"/></rngMod>
-        <xsdGrp>urn:oasis:names:tc:dita:spec:classification:xsd:subjectSchemeGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <xsdMod>urn:oasis:names:tc:dita:spec:classification:xsd:subjectSchemeMod.xsd<var presep=":" name="ditaver"/></xsdMod>
       </modulePublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/specification/langRef/key-definitions-map-group-elements.ditamap
+++ b/specification/langRef/key-definitions-map-group-elements.ditamap
@@ -5,7 +5,7 @@
  <keydef href="base/anchorref.dita" keys="elements-anchorref" />
  <keydef href="base/keydef.dita" keys="elements-keydef" />
  <keydef href="base/mapref.dita" keys="elements-mapref" />
- <keydef href="base/mapresources.dita" keys="element-mapresources"/>
+ <keydef href="base/mapresources.dita" keys="elements-mapresources"/>
  <keydef href="base/topicgroup.dita" keys="elements-topicgroup" />
  <keydef href="base/topichead.dita" keys="elements-topichead" />
 </map>

--- a/specification/langRef/map-group-elements.ditamap
+++ b/specification/langRef/map-group-elements.ditamap
@@ -6,7 +6,7 @@
   <topicref keyref="elements-anchorref" />
   <topicref keyref="elements-keydef" />
   <topicref keyref="elements-mapref" />
-  <topicref keyref="element-mapresources"/>
+  <topicref keyref="elements-mapresources"/>
   <topicref keyref="elements-topicgroup" />
   <topicref keyref="elements-topichead" />
  </topicref>

--- a/specification/langRef/quick-reference/base-elements-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-elements-a-to-z.dita
@@ -94,7 +94,7 @@
     <sli><xref keyref="elements-lq"/></sli>
     <sli><xref keyref="elements-map"/></sli>
     <sli><xref keyref="elements-mapref"/></sli>
-    <sli><xref keyref="element-mapresources"/></sli>
+    <sli><xref keyref="elements-mapresources"/></sli>
     <sli><xref keyref="elements-media-autoplay"/></sli>
     <sli><xref keyref="elements-media-controls"/></sli>
     <sli><xref keyref="elements-media-loop"/></sli>


### PR DESCRIPTION
* Noticed one element that used an inconsistent key name; fixed that from `element-mapresources` to `elements-mapresources` (to match all other elements)
* Removed documentation about XSD files and RNC files from the RNG grammar files (we do not currently have any XSD or RNC versions of those files)