### PR TITLE
Fix attlist of resourceid

### DIFF
--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -28,9 +28,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below) and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> and the attributes defined below.</p>
       <dl>
         <dlentry id="appname">
           <dt><xmlatt>appname</xmlatt></dt>


### PR DESCRIPTION
`@id` no longer has an "exception" type case for the `<resourceid>` element; we removed the definition, this just updates the lead-in text so that it no longer refers to the definition.