### PR TITLE
Make href, format, scope consistent for new elements

### DIFF
--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -1704,9 +1704,14 @@
                keyref
                           CDATA
                                     #IMPLIED
-               
                format
                           CDATA
+                                    #IMPLIED
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
                                     #IMPLIED
                tabindex
                           NMTOKEN
@@ -1759,9 +1764,14 @@
                keyref
                           CDATA
                                     #IMPLIED
-               
                format
                           CDATA
+                                    #IMPLIED
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
                                     #IMPLIED
                tabindex
                           NMTOKEN
@@ -1786,6 +1796,12 @@
                format
                           CDATA
                                     #IMPLIED
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
+                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  media-source %media-source.content;>
@@ -1802,6 +1818,15 @@
                                     #IMPLIED
                keyref
                           CDATA
+                                    #IMPLIED
+               format
+                          CDATA
+                                    #IMPLIED
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
                                     #IMPLIED
                kind       (subtitles |
                            captions |

--- a/doctypes/dtd/base/hazardstatementDomain.mod
+++ b/doctypes/dtd/base/hazardstatementDomain.mod
@@ -77,6 +77,9 @@
               "href
                           CDATA
                                     #IMPLIED
+               format
+                          CDATA
+                                    #IMPLIED
                scope
                           (external |
                            local |

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -3091,6 +3091,16 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         <attribute name="format"/>
       </optional>
       <optional>
+        <attribute name="scope">
+          <choice>
+            <value>external</value>
+            <value>local</value>
+            <value>peer</value>
+            <value>-dita-use-conref-target</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
         <attribute name="tabindex">
           <data type="NMTOKEN"/>
         </attribute>
@@ -3184,6 +3194,16 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         <attribute name="format"/>
       </optional>
       <optional>
+        <attribute name="scope">
+          <choice>
+            <value>external</value>
+            <value>local</value>
+            <value>peer</value>
+            <value>-dita-use-conref-target</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
         <attribute name="height">
           <data type="NMTOKEN"/>
         </attribute>
@@ -3228,6 +3248,16 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       <optional>
         <attribute name="format"/>
       </optional>
+      <optional>
+        <attribute name="scope">
+          <choice>
+            <value>external</value>
+            <value>local</value>
+            <value>peer</value>
+            <value>-dita-use-conref-target</value>
+          </choice>
+        </attribute>
+      </optional>
       <ref name="univ-atts"/>
     </define>
     <define name="media-source.element">
@@ -3253,6 +3283,19 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       </optional>
       <optional>
         <attribute name="keyref"/>
+      </optional>
+      <optional>
+        <attribute name="format"/>
+      </optional>
+      <optional>
+        <attribute name="scope">
+          <choice>
+            <value>external</value>
+            <value>local</value>
+            <value>peer</value>
+            <value>-dita-use-conref-target</value>
+          </choice>
+        </attribute>
       </optional>
       <optional>
         <attribute name="kind">

--- a/doctypes/rng/base/hazardstatementDomain.rng
+++ b/doctypes/rng/base/hazardstatementDomain.rng
@@ -135,6 +135,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
           <attribute name="href"/>
         </optional>
         <optional>
+          <attribute name="format"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>

--- a/specification/common/reuse-w-lwdita/reuse-audio.dita
+++ b/specification/common/reuse-w-lwdita/reuse-audio.dita
@@ -10,21 +10,18 @@
       <div platform="dita">
         <p>The <xmlelement>audio</xmlelement> element is modeled on the HTML5
             <xmlelement>audio</xmlelement> element.</p>
-        <p>An audio resource can be referenced by <xmlatt>data</xmlatt>,
-          <xmlatt>datakeyref</xmlatt>, and nested <xmlelement>media-source</xmlelement> elements.
-          Nested <xmlelement>media-source</xmlelement> elements enable extensive configuration of
-          how the audio resource is presented.</p>
-        <p>Behaviors such as auto-playing, looping, and muting are determined by child elements.
-          When not specified, the default behavior is determined by the user agent that is used to
+        <p>An audio resource can be referenced by <xmlatt>href</xmlatt>, <xmlatt>keyref</xmlatt>,
+          and nested <xmlelement>media-source</xmlelement> elements.</p>
+        <p>Behaviors such as auto-playing, looping, and muting are determined by attributes. When
+          not specified, the default behavior is determined by the user agent that is used to
           present the media.</p>
       </div>
       <div platform="lwdita">
         <p>The audio component is modeled on the HTML5 <xmlelement>audio</xmlelement> element.</p>
-        <p>An audio resource can be referenced by <xmlatt>data</xmlatt>,
-          <xmlatt>datakeyref</xmlatt>, and nested media-source components. Nested media-source
-          components enable extensive configuration of how the audio resource is presented.</p>
-        <p>Behaviors such as auto-playing, looping, and muting are determined by child components.
-          When not specified, the default behavior is determined by the user agent that is used to
+        <p>An audio resource can be referenced by <xmlatt>href</xmlatt>, <xmlatt>keyref</xmlatt>,
+          and nested media-source components.</p>
+        <p>Behaviors such as auto-playing, looping, and muting are determined by attributes. When
+          not specified, the default behavior is determined by the user agent that is used to
           present the media.</p>
       </div>
       <draft-comment author="Kristen J Eberlein" time="22 April 2019" audience="tc-reviewers">
@@ -44,55 +41,78 @@
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
           <dlentry>
-            <dt><xmlatt>data</xmlatt></dt>
+            <dt><xmlatt>autoplay</xmlatt></dt>
+            <dd>Specifies whether the resource automatically plays when it is presented. The
+              following values are recognized: <keyword>true</keyword>, <keyword>false</keyword>,
+              and <keyword>-dita-use-conref-target </keyword>. The default value is
+                <keyword>true</keyword>.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>controls</xmlatt></dt>
+            <dd>Specifies whether the presentation of the resource includes user interface controls.
+              The following values are recognized: <keyword>true</keyword>,
+              <keyword>false</keyword>, and <keyword>-dita-use-conref-target </keyword>. The default
+              value is <keyword>true</keyword>.</dd>
+          </dlentry>
+          <dlentry platform="dita">
+            <dt><xmlatt>format</xmlatt></dt>
+            <dd>Specifies the MIME type for the resource. This attribute enables processors to avoid
+              loading unsupported resources. If <xmlatt>format</xmlatt> is not specified
+              and <xmlatt>keyref</xmlatt> is specified, the effective type for the key named by the
+                <xmlatt>keyref</xmlatt> attribute is used as the value. If an explicit <xmlatt
+               >format</xmlatt> is not specified on either the
+                <xmlelement>audio</xmlelement> element or key definition, processors can use other
+              means, such the URI file extension, to determine the effective MIME type of the
+              resource.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>href</xmlatt></dt>
             <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
             <dd>Specifies the absolute or relative URI of the audio resource. If
-                <xmlatt>data</xmlatt> is specified, <xmlatt>type</xmlatt> should be specified
+                <xmlatt>href</xmlatt> is specified, specify <xmlatt>format</xmlatt>
               also.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>datakeyref</xmlatt></dt>
-            <dd>Provides a key reference to the audio resource. When specified and the key is
-              resolvable, the key-provided URI is used. If the key referenced by
-                <xmlatt>datakeyref</xmlatt> cannot be resolved, and <xmlatt>data</xmlatt> is
-              specified, that value provided by <xmlatt>data</xmlatt> is used as a fallback. If the
-              key referenced by <xmlatt>datakeyref</xmlatt> has no associated resource, only link
-              text, and the<xmlelement> audio</xmlelement> element does not contain a
-                <xmlelement>fallback</xmlelement> element, the link text becomes fallback
-              content.</dd>
-            <dd>
-              <draft-comment author="Kristen J Eberlein" time="17 May 2019" audience="tc-reviewers">
-                <p>Robert and I discussed and reworked the above description today, in response to
-                  feedback from Chris Nitchie. </p>
-                <p>However, this content is really about key resolution; we need to ensure that this
-                  is covered clearly (and probably with normative language) in the primary topics
-                  about key resolution.</p>
-              </draft-comment>
-            </dd>
+            <dt><xmlatt>keyref</xmlatt></dt>
+            <dd>Specifies a key reference to the audio resource.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>loop</xmlatt></dt>
+            <dd>Specifies whether the resource loops when played. The following values are
+              recognized: <keyword>true</keyword>, <keyword>false</keyword>, and
+                <keyword>-dita-use-conref-target </keyword>. The default value is
+                <keyword>true</keyword>.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>muted</xmlatt></dt>
+            <dd>Specifies whether the resource is muted. The following values are recognized:
+                <keyword>true</keyword>, <keyword>false</keyword>, and
+                <keyword>-dita-use-conref-target </keyword>. The default value is
+                <keyword>true</keyword>.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>scope</xmlatt></dt>
+            <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
+              between the current document and the target resource. Resources in the same
+              information unit are considered <codeph>"local"</codeph>; resources in the same system
+              as the referencing content but not part of the same information unit are considered
+                <codeph>"peer"</codeph>; and resources outside the system, such as Web pages, are
+              considered <codeph>"external"</codeph>.</dd>
           </dlentry>
           <dlentry>
             <dt><xmlatt>tabindex</xmlatt></dt>
-            <dd>Indicates whether the audio resource can be focused and where it participates in
+            <dd>Specifies whether the audio resource can be focused and where it participates in
               sequential keyboard navigation. See <xref
-                href="https://html.spec.whatwg.org/#the-tabindex-attribute" format="html"
-                scope="external"><xmlatt>tabindex</xmlatt></xref> in the HTML specification (WHATWG
-              version).</dd>
-            <dd><!--<draft-comment author="Kristen J Eberlein" time="28 April 2019" audience="tc-reviewers"><p>Would this be a better description? "Indicates whether the audio object can be focused and where it participates in sequential keyboard navigation."</p><p>Note that changes that we make in this topic should be mirrored in the description of <xmlatt>tabindex</xmlatt> in the <xmlelement>video</xmlelement> topic.</p></draft-comment>--></dd>
-          </dlentry>
-          <dlentry>
-            <dt><xmlatt>type</xmlatt></dt>
-            <dd>Indicates the MIME type for the audio resource. This attribute enables processors to
-              avoid loading unsupported resources. If <xmlatt>type</xmlatt> is not specified and
-                <xmlatt>datakeyref</xmlatt> is specified, the effective type for the key named by
-              the <xmlatt>datakeyref</xmlatt> attribute is used as the value. If an explicit
-                <xmlatt>type</xmlatt> is not specified on either the <xmlelement>audio</xmlelement>
-              element or key definition, processors can use other means, such the URI file
-              extension, to determine the effective MIME type of the audio resource.</dd>
+                href="https://html.spec.whatwg.org/dev/interaction.html#the-tabindex-attribute"
+                format="html" scope="external"><xmlatt>tabindex</xmlatt></xref> in the HTML
+              specification (WHATWG version).</dd>
           </dlentry>
         </dl>
       </div>
       <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+          keyref="attributes-universal"/>.<draft-comment author="rodaande">This needs to be examined
+          in line of the element moving into the base vocabulary; likely, some additional attributes
+          are now present.</draft-comment></p>
     </section>
   </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-media-source.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-source.dita
@@ -25,28 +25,26 @@
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
+          <dlentry platform="dita">
+            <dt><xmlatt>format</xmlatt></dt>
+            <dd>Specifies the format of the resource being addressed.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>href</xmlatt></dt>
+            <dd>Specifies the URI of the media resource.</dd>
+          </dlentry>
           <dlentry>
             <dt><xmlatt>keyref</xmlatt></dt>
-            <dd>A key reference to the media resource. If both <xmlatt>keyref</xmlatt> and
-                <xmlatt>value</xmlatt> are specified, the resource referenced by
-                <xmlatt>keyref</xmlatt> takes precedence unless the key cannot be resolved, in which
-              case the resource specified by <xmlatt>value</xmlatt> is used as a fallback.</dd>
-          </dlentry>
-          <dlentry conkeyref="reuse-attributes/media-source-name">
-            <dt><xmlatt>name</xmlatt></dt>
-            <dd>The value is fixed to <keyword>source</keyword>.</dd>
+            <dd>Specifies a key reference to the media resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>type</xmlatt></dt>
-            <dd>Specifies the MIME type of the resource specified by <xmlatt>value</xmlatt>.</dd>
-          </dlentry>
-          <dlentry conkeyref="reuse-attributes/media-source-value">
-            <dt><xmlatt>value</xmlatt></dt>
-            <dd>Specifies the URL of the media resource.</dd>
-          </dlentry>
-          <dlentry>
-            <dt><xmlatt>valuetype</xmlatt></dt>
-            <dd>The value is fixed to <keyword>ref</keyword>.</dd>
+            <dt><xmlatt>scope</xmlatt></dt>
+            <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
+              between the current document and the target resource. Resources in the same
+              information unit are considered <codeph>"local"</codeph>; resources in the same system
+              as the referencing content but not part of the same information unit are considered
+                <codeph>"peer"</codeph>; and resources outside the system, such as Web pages, are
+              considered <codeph>"external"</codeph>.</dd>
           </dlentry>
         </dl>
       </div>
@@ -55,6 +53,8 @@
             keyref="attributes-localization"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>, and the attributes defined below.</p>
+        <draft-comment author="Robert">Need to update these atts now that the element is part of the
+          base vocabulary.</draft-comment>
         <dl>
           <dlentry conkeyref="reuse-attributes/media-source-name">
             <dt><xmlatt>name</xmlatt></dt>

--- a/specification/common/reuse-w-lwdita/reuse-media-track.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-track.dita
@@ -28,31 +28,32 @@
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
+          <dlentry platform="dita">
+            <dt><xmlatt>format</xmlatt></dt>
+            <dd>Specifies the format of the resource being addressed.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>href</xmlatt></dt>
+            <dd>Specifies the URI of the track resource.</dd>
+          </dlentry>
           <dlentry>
             <dt><xmlatt>keyref</xmlatt></dt>
-            <dd>A key reference to the track resource. If both <xmlatt>keyref</xmlatt> and
-                <xmlatt>value</xmlatt> are specified, the resource referenced by
-                <xmlatt>keyref</xmlatt> takes precedence unless the key cannot be resolved, in which
-              case the resource specified by <xmlatt>value</xmlatt> is used as a fallback.</dd>
+            <dd>Specifies a key reference to the track resource.</dd>
           </dlentry>
-          <dlentry conkeyref="reuse-attributes/media-track-name">
-            <dt><xmlatt>name</xmlatt></dt>
-            <dd>The value is fixed to <keyword>track</keyword>.</dd>
-          </dlentry>
-          <dlentry conkeyref="reuse-attributes/media-track-type">
-            <dt><xmlatt>type</xmlatt></dt>
+          <dlentry>
+            <dt><xmlatt>kind</xmlatt></dt>
             <dd>Specifies the usage for the track resource. This attribute is modeled on the
                 <xmlatt>kind</xmlatt> attribute on the HTML5 <xmlelement>track</xmlelement> element,
               as described by the <xref
-                href="https://www.w3.org/TR/2011/WD-html5-author-20110809/the-track-element.html#attr-track-kind"
-                format="html" scope="external"><cite>W3C HTML5 specification</cite></xref>. The
-              values for this attribute are derived from the HTML5 standard:<dl>
+                href="https://html.spec.whatwg.org/dev/media.html#dom-TrackList-getKind-categories"
+                format="html" scope="external"><cite>HTML specification, WHATWG
+                version</cite></xref>. The values for this attribute are derived from the HTML5 standard:<dl>
                 <dlentry>
                   <dt>captions</dt>
                   <dd>Transcription or translation of the dialogue, sound effects, relevant musical
                     cues, and other relevant audio information. This is intended for use when the
-                    soundtrack is unavailable (for example, because it is muted or because the user
-                    is hard-of-hearing). This information is rendered over the video and labeled as
+                    soundtrack is unavailable, for example, because it is muted or because the user
+                    is hard-of-hearing. This information is rendered over the video and labeled as
                     appropriate for hard-of-hearing users.</dd>
                 </dlentry>
                 <dlentry>
@@ -64,9 +65,9 @@
                 <dlentry>
                   <dt>descriptions</dt>
                   <dd>Textual descriptions of the video component of the media resource. This is
-                    intended for audio synthesis when the visual component is unavailable (for
+                    intended for audio synthesis when the visual component is unavailable, for
                     example, because the user is interacting with the application without a screen
-                    or because the user is blind). Descriptions are synthesized as separate audio
+                    or because the user is blind. Descriptions are synthesized as separate audio
                     tracks.</dd>
                 </dlentry>
                 <dlentry>
@@ -77,8 +78,8 @@
                 <dlentry>
                   <dt>subtitles</dt>
                   <dd>Transcription or translation of the dialogue, suitable for when the sound is
-                    available but not understood (for example, because the user does not understand
-                    the language of the soundtrack). Subtitles are rendered over the video.</dd>
+                    available but not understood, for example, because the user does not understand
+                    the language of the soundtrack. Subtitles are rendered over the video.</dd>
                 </dlentry>
                 <dlentry>
                   <dt>-dita-use-conref-target</dt>
@@ -86,9 +87,18 @@
                 </dlentry>
               </dl></dd>
           </dlentry>
-          <dlentry conkeyref="reuse-attributes/media-track-value">
-            <dt><xmlatt>valuetype</xmlatt></dt>
-            <dd>The value is fixed to "ref".</dd>
+          <dlentry>
+            <dt><xmlatt>scope</xmlatt></dt>
+            <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
+              between the current document and the target resource. Resources in the same
+              information unit are considered <codeph>"local"</codeph>; resources in the same system
+              as the referencing content but not part of the same information unit are considered
+                <codeph>"peer"</codeph>; and resources outside the system, such as Web pages, are
+              considered <codeph>"external"</codeph>.</dd>
+          </dlentry>
+          <dlentry>
+            <dt><xmlatt>srclang</xmlatt></dt>
+            <dd>Specifies the language of the track resource.</dd>
           </dlentry>
         </dl>
       </div>
@@ -97,6 +107,8 @@
             keyref="attributes-localization"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>, and the attributes defined below.</p>
+        <draft-comment author="Robert">Need to update these atts now that the element is part of the
+          base vocabulary.</draft-comment>
         <dl>
           <dlentry conkeyref="reuse-attributes/media-track-name">
             <dt><xmlatt>name</xmlatt></dt>

--- a/specification/common/reuse-w-lwdita/reuse-video.dita
+++ b/specification/common/reuse-w-lwdita/reuse-video.dita
@@ -10,21 +10,18 @@
       <div platform="dita">
         <p>The <xmlelement>video</xmlelement> element is modeled on the HTML5
             <xmlelement>video</xmlelement> element.</p>
-        <p>A video resource can be referenced by <xmlatt>data</xmlatt>, <xmlatt>datakeyref</xmlatt>,
-          and nested <xmlelement>media-source</xmlelement> elements. Nested
-            <xmlelement>media-source</xmlelement> elements enable extensive configuration of how the
-          video resource is presented.</p>
-        <p>Behaviors such as auto-playing, looping, and muting are determined by child elements.
-          When not specified, the default behavior is determined by the user agent that is used to
+        <p>A video resource can be referenced by <xmlatt>href</xmlatt>, <xmlatt>keyref</xmlatt>, and
+          nested <xmlelement>media-source</xmlelement> elements.</p>
+        <p>Behaviors such as auto-playing, looping, and muting are determined by attributes. When
+          not specified, the default behavior is determined by the user agent that is used to
           present the media.</p>
       </div>
       <div platform="lwdita">
         <p>The video component is modeled on the HTML5 <xmlelement>video</xmlelement> element.</p>
-        <p>A video resource can be referenced by <xmlatt>data</xmlatt>, <xmlatt>datakeyref</xmlatt>,
-          and nested media-source components. Nested media-source components enable extensive
-          configuration of how the video resource is presented.</p>
-        <p>Behaviors such as auto-playing, looping, and muting are determined by child components.
-          When not specified, the default behavior is determined by the user agent that is used to
+        <p>A video resource can be referenced by <xmlatt>href</xmlatt>, <xmlatt>keyref</xmlatt>, and
+          nested media-source components.</p>
+        <p>Behaviors such as auto-playing, looping, and muting are determined by attributes. When
+          not specified, the default behavior is determined by the user agent that is used to
           present the media.</p>
       </div>
     </section>
@@ -52,24 +49,33 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
         /> and the attributes defined below.</p>
+      <draft-comment author="rodaande">This list was significantly reworked when the element moved
+        into the base vocabulary; need to validate that the list is still correct for
+        LwDITA.</draft-comment>
       <dl>
-        <dlentry platform="dita">
-          <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
-          <dt><xmlatt>data</xmlatt></dt>
-          <dd>Specifies the absolute or relative URI of the video resource. If <xmlatt>data</xmlatt>
-            is specified, <xmlatt>type</xmlatt> should be specified also.</dd>
+        <dlentry>
+          <dt><xmlatt>autoplay</xmlatt></dt>
+          <dd>Specifies whether the resource automatically plays when it is presented. The following
+            values are recognized: <keyword>true</keyword>, <keyword>false</keyword>, and
+              <keyword>-dita-use-conref-target </keyword>. The default value is
+              <keyword>true</keyword>.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>controls</xmlatt></dt>
+          <dd>Specifies whether the presentation of the resource includes user interface controls.
+            The following values are recognized: <keyword>true</keyword>, <keyword>false</keyword>,
+            and <keyword>-dita-use-conref-target </keyword>. The default value is
+              <keyword>true</keyword>.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <!-- Identical to definition in video topic -->
-          <dt><xmlatt>datakeyref</xmlatt></dt>
-          <dd>Provides a key reference to the video resource. When specified and the key is
-            resolvable, the key-provided URI is used. If the key referenced by
-              <xmlatt>datakeyref</xmlatt> cannot be resolved, and <xmlatt>data</xmlatt> is
-            specified, that value provided by <xmlatt>data</xmlatt> is used as a fallback. If the
-            key referenced by <xmlatt>datakeyref</xmlatt> has no associated resource, only link
-            text, and the video<xmlelement/> element does not contain a
-              <xmlelement>fallback</xmlelement> element, the link text becomes fallback
-            content.</dd>
+          <dt><xmlatt>format</xmlatt></dt>
+          <dd>Specifies the MIME type for the resource. This attribute enables processors to avoid
+            loading unsupported resources. If <xmlatt>format</xmlatt> is not specified and
+              <xmlatt>keyref</xmlatt> is specified, the effective type for the key named by the
+              <xmlatt>keyref</xmlatt> attribute is used as the value. If an explicit
+              <xmlatt>format</xmlatt> is not specified on either the <xmlelement>video</xmlelement>
+            element or key definition, processors can use other means, such the URI file extension,
+            to determine the effective MIME type of the resource.</dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>height</xmlatt></dt>
@@ -80,15 +86,55 @@
             unit is px (pixels). Possible values include: "5", "5in", and "10.5cm". </dd>
         </dlentry>
         <dlentry platform="dita">
-          <!-- Identical to definition in video topic -->
-          <dt><xmlatt>type</xmlatt></dt>
-          <dd>Indicates the MIME type for the video resource. This attribute enables processors to
-            avoid loading unsupported resources. If <xmlatt>type</xmlatt> is not specified and
-              <xmlatt>datakeyref</xmlatt> is specified, the effective type for the key named by the
-              <xmlatt>datakeyref</xmlatt> attribute is used as the value. If an explicit
-              <xmlatt>type</xmlatt> is not specified on either the <xmlelement>video</xmlelement>
-            element or key definition, processors can use other means, such the URI file extension,
-            to determine the effective MIME type of the video.</dd>
+          <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
+          <dt><xmlatt>href</xmlatt></dt>
+          <dd>Specifies the absolute or relative URI of the video resource. If <xmlatt>href</xmlatt>
+            is specified, specify <xmlatt>format</xmlatt> also.</dd>
+        </dlentry>
+        <dlentry platform="dita">
+          <dt><xmlatt>keyref</xmlatt></dt>
+          <dd>Specifies a key reference to the video resource.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>loop</xmlatt></dt>
+          <dd>Specifies whether the resource loops when played. The following values are recognized:
+              <keyword>true</keyword>, <keyword>false</keyword>, and
+              <keyword>-dita-use-conref-target </keyword>. The default value is
+              <keyword>true</keyword>.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>muted</xmlatt></dt>
+          <dd>Specifies whether the resource is muted. The following values are recognized:
+              <keyword>true</keyword>, <keyword>false</keyword>, and
+              <keyword>-dita-use-conref-target </keyword>. The default value is
+              <keyword>true</keyword>.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>poster</xmlatt></dt>
+          <dd>Specifies the absolute or relative URI of the image that is rendered before video
+            playback begins.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>posterkeyref</xmlatt></dt>
+          <dd>Specifies a key reference for the poster image.</dd>
+        </dlentry>
+        <dlentry>
+          <dt><xmlatt>scope</xmlatt></dt>
+          <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
+            between the current document and the target resource. Resources in the same information
+            unit are considered <codeph>"local"</codeph>; resources in the same system as the
+            referencing content but not part of the same information unit are considered
+              <codeph>"peer"</codeph>; and resources outside the system, such as Web pages, are
+            considered <codeph>"external"</codeph>.</dd>
+        </dlentry>
+        <dlentry platform="dita">
+          <dt><xmlatt>tabindex</xmlatt></dt>
+          <dd><draft-comment author="rodaande">Need to add the linked version of the HTML spec into
+              our resources.</draft-comment>Specifies whether the video resource can be focused and
+            where it participates in sequential keyboard navigation. See <xref
+              href="https://html.spec.whatwg.org/#the-tabindex-attribute" format="html"
+              scope="external"><xmlatt>tabindex</xmlatt></xref> in the HTML specification (WHATWG
+            version).</dd>
         </dlentry>
         <dlentry>
           <dt><xmlatt>width</xmlatt></dt>
@@ -97,14 +143,6 @@
             of measure from the set of cm, em, in, mm, pc, pt, px, and Q (centimeters, ems, inches,
             picas, points, pixels, millimeters, and quarter-millimeters, respectively). The default
             unit is px (pixels). Possible values include: "5", "5in", and "10.5cm". </dd>
-        </dlentry>
-        <dlentry platform="dita">
-          <dt><xmlatt>tabindex</xmlatt></dt>
-          <dd>Indicates whether the video resource can be focused and where it participates in
-            sequential keyboard navigation. See <xref
-              href="https://html.spec.whatwg.org/#the-tabindex-attribute" format="html"
-              scope="external"><xmlatt>tabindex</xmlatt></xref> in the HTML specification (WHATWG
-            version).</dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -36,6 +36,12 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
+        <dlentry id="format">
+          <dt><xmlatt>format</xmlatt></dt>
+          <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->Identifies
+            the format of the resource that is referenced. See <xref keyref="attributes-format"/>
+            for details on supported values.</dd>
+        </dlentry>
         <dlentry conkeyref="reuse-attributes/image-href">
           <dt/>
           <dd/>


### PR DESCRIPTION
Fixes based on this thread, as discussed at TC meeting November 10, 2020: https://lists.oasis-open.org/archives/dita/202011/msg00013.html

* Ensure all media elements that have `@href` also have `@format` and `@scope`
* Add `@format` to hazardsymbol, which missed the update in DITA 1.3 (and update langRef topic accordingly)
* Bring all attribute and reuse topics up to date based on the multimedia updates in #351 which did not get properly committed with the rest of that update