### PR TITLE
Remove obsolete entities

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -79,9 +79,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
 <!ENTITY % relcell     "relcell"                                     >
 <!ENTITY % topicmeta   "topicmeta"                                   >
 <!ENTITY % keytext     "keytext"                                     >
-<!ENTITY % shortdesc   "shortdesc"                                   >
-<!ENTITY % linktext    "linktext"                                    >
-<!ENTITY % searchtitle "searchtitle"                                 >
 <!ENTITY % ux-window   "ux-window"                                   >
 
 <!-- ============================================================= -->


### PR DESCRIPTION
These three entities were moved to the `commonElements` when class attributes were synchronized; these copies were missed and should be removed (they are now duplicates).