### PR TITLE
Add titlealt to DTDs #16

### DIFF
--- a/doctypes/dtd/base/alternativeTitlesDomain.ent
+++ b/doctypes/dtd/base/alternativeTitlesDomain.ent
@@ -2,11 +2,11 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!--  MODULE:    DITA Map Group Domain                             -->
+<!--  MODULE:    DITA Alternative Titles Domain                    -->
 <!--  VERSION:   2.0                                               -->
 <!--  DATE:      [[[Release date]]]                                     -->
 <!--  PURPOSE:   Define elements and specialization attributes     -->
-<!--             for Map Group Domain                              -->
+<!--             for the Alternative Titles Domain                 -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
@@ -15,16 +15,15 @@
 <!--                                                               -->
 <!--  Refer to this file by the following public identifier or an  -->
 <!--       appropriate system identifier                           -->
-<!-- PUBLIC "-//OASIS//ENTITIES DITA 2.0 Map Group Domain//EN"     -->
-<!--       Delivered as file "mapGroup.ent"                        -->
+<!-- PUBLIC "-//OASIS//ENTITIES DITA 2.0 Alternative Titles Domain//EN" -->
+<!--       Delivered as file "alternativeTitlesDomain.ent"         -->
 <!-- ============================================================= -->
 <!--                                                               -->
-<!--             (C) Copyright OASIS Open 2005, 2009.              -->
+<!--             (C) Copyright OASIS Open 2005, 2021.              -->
 <!--             (C) Copyright IBM Corporation 2001, 2004.         -->
 <!--             All Rights Reserved.                              -->
 <!--                                                               -->
 <!--  UPDATES:                                                     -->
-<!--    2019.10.06 KJE: Add <mapresources>                         -->
 <!--                                                               -->
 <!-- ============================================================= -->
 <!--                                                               -->
@@ -34,14 +33,13 @@
 <!--                    ELEMENT EXTENSION ENTITY DECLARATIONS      -->
 <!-- ============================================================= -->
 
-<!ENTITY % mapgroup-d-topicref
-  "anchorref |
-   keydef |
-   mapref |
-   mapresources |
-   topicgroup |
-   topichead"
+<!ENTITY % alternativeTitles-d-titlealt
+  "navtitle |
+   searchtitle |
+   linktitle |
+   subtitle |
+   titlehint"
 >
 
-<!-- ================ End DITA Map Group Domain ================== -->
+<!-- ================ End DITA Alternative Titles Domain ========= -->
  

--- a/doctypes/dtd/base/alternativeTitlesDomain.mod
+++ b/doctypes/dtd/base/alternativeTitlesDomain.mod
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!--  MODULE:    DITA Alternative Titles Domain                    -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                     -->
+<!--  PURPOSE:   Define elements and specialization attributes     -->
+<!--             for the Alternative Titles Domain                 -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                    TYPICAL INVOCATION                         -->
+<!--                                                               -->
+<!--  Refer to this file by the following public identifier or an  -->
+<!--       appropriate system identifier                           -->
+<!-- PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Alternative Titles Domain//EN" -->
+<!--       Delivered as file "alternativeTitlesDomain.mod"         -->
+<!-- ============================================================= -->
+<!--                                                               -->
+<!--             (C) Copyright OASIS Open 2005, 2021.              -->
+<!--             (C) Copyright IBM Corporation 2001, 2004.         -->
+<!--             All Rights Reserved.                              -->
+<!--                                                               -->
+<!--  UPDATES:                                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!--                                                               -->
+<!--                                                               -->
+
+<!-- ============================================================= -->
+<!--                   ELEMENT NAME ENTITIES                       -->
+<!-- ============================================================= -->
+
+<!ENTITY % navtitle      "navtitle"                                  >
+<!ENTITY % searchtitle   "searchtitle"                               >
+<!ENTITY % linktitle     "linktitle"                                 >
+<!ENTITY % subtitle      "subtitle"                                  >
+<!ENTITY % titlehint     "titlehint"                                 >
+
+<!-- ============================================================= -->
+<!--                    COMMON ATTLIST SETS                        -->
+<!-- ============================================================= -->  
+
+
+
+<!-- ============================================================= -->
+<!--                    ELEMENT DECLARATIONS                       -->
+<!-- ============================================================= -->
+
+<!--                    LONG NAME: Navigation Title                -->
+<!ENTITY % navtitle.content
+                       "(%words.cnt; |
+                         %ph; |
+                         %draft-comment; |
+                         %required-cleanup;)*"
+>
+<!ENTITY % navtitle.attributes
+              "title-role
+                          CDATA
+                                    'navigation'
+               %univ-atts;"
+>
+<!ELEMENT  navtitle %navtitle.content;>
+<!ATTLIST  navtitle %navtitle.attributes;>
+
+<!--                    LONG NAME: Search Title                -->
+<!ENTITY % searchtitle.content
+                       "(%words.cnt; |
+                         %ph; |
+                         %draft-comment; |
+                         %required-cleanup;)*"
+>
+<!ENTITY % searchtitle.attributes
+              "title-role
+                          CDATA
+                                    'search'
+               %univ-atts;"
+>
+<!ELEMENT  searchtitle %searchtitle.content;>
+<!ATTLIST  searchtitle %searchtitle.attributes;>
+
+<!--                    LONG NAME: Link Title                -->
+<!ENTITY % linktitle.content
+                       "(%words.cnt; |
+                         %ph; |
+                         %draft-comment; |
+                         %required-cleanup;)*"
+>
+<!ENTITY % linktitle.attributes
+              "title-role
+                          CDATA
+                                    'linking'
+               %univ-atts;"
+>
+<!ELEMENT  linktitle %linktitle.content;>
+<!ATTLIST  linktitle %linktitle.attributes;>
+
+<!--                    LONG NAME: Subtitle                -->
+<!ENTITY % subtitle.content
+                       "(%words.cnt; |
+                         %ph; |
+                         %draft-comment; |
+                         %required-cleanup;)*"
+>
+<!ENTITY % subtitle.attributes
+              "title-role
+                          CDATA
+                                    'subtitle'
+               %univ-atts;"
+>
+<!ELEMENT  subtitle %subtitle.content;>
+<!ATTLIST  subtitle %subtitle.attributes;>
+
+<!--                    LONG NAME: Title hint                -->
+<!ENTITY % titlehint.content
+                       "(%words.cnt; |
+                         %ph; |
+                         %draft-comment; |
+                         %required-cleanup;)*"
+>
+<!ENTITY % titlehint.attributes
+              "title-role
+                          CDATA
+                                    'hint'
+               %univ-atts;"
+>
+<!ELEMENT  titlehint %titlehint.content;>
+<!ATTLIST  titlehint %titlehint.attributes;>
+
+
+<!-- ============================================================= -->
+<!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
+<!-- ============================================================= -->
+  
+<!ATTLIST  navtitle     class CDATA "+ topic/titlealt alternativeTitles-d/navtitle ">
+<!ATTLIST  searchtitle  class CDATA "+ topic/titlealt alternativeTitles-d/searchtitle ">
+<!ATTLIST  linktitle    class CDATA "+ topic/titlealt alternativeTitles-d/linktitle ">
+<!ATTLIST  subtitle     class CDATA "+ topic/titlealt alternativeTitles-d/subtitle ">
+<!ATTLIST  titlehint    class CDATA "+ topic/titlealt alternativeTitles-d/titlehint ">
+
+<!-- ================== End of DITA Alternative Title Domain ===================== -->
+ 

--- a/doctypes/dtd/base/basemap.dtd
+++ b/doctypes/dtd/base/basemap.dtd
@@ -55,6 +55,11 @@
          "mapGroup.ent"
 >%mapgroup-d-dec;
 
+<!ENTITY % alternativetitles-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Alternative Titles Domain//EN"
+         "alternativeTitlesDomain.ent"
+>%alternativetitles-d-dec;
+
 <!ENTITY % ditavalref-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 DITAVAL Ref Domain//EN"
          "ditavalrefDomain.ent"
@@ -120,6 +125,9 @@
                          %mapgroup-d-topicref; |
                          %ditavalref-d-topicref;
                         ">
+<!ENTITY % titlealt     "titlealt |
+                         %alternativeTitles-d-titlealt;
+                        ">                        
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -183,6 +191,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
          "mapGroup.mod"
 >%mapgroup-d-def;
+
+<!ENTITY % alternativetitles-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Alternative Titles Domain//EN"
+         "alternativeTitlesDomain.mod"
+>%alternativetitles-d-def;
 
 <!ENTITY % ditavalref-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"

--- a/doctypes/dtd/base/basetopic.dtd
+++ b/doctypes/dtd/base/basetopic.dtd
@@ -48,6 +48,11 @@
 <!--             DOMAIN ENTITY DECLARATIONS                        -->
 <!-- ============================================================= -->
 
+<!ENTITY % alternativetitles-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Alternative Titles Domain//EN"
+         "alternativeTitlesDomain.ent"
+>%alternativetitles-d-dec;
+
 <!ENTITY % emphasis-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
          "emphasisDomain.ent"
@@ -104,6 +109,9 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
+<!ENTITY % titlealt     "titlealt |
+                         %alternativeTitles-d-titlealt;
+                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -170,6 +178,11 @@
 <!-- ============================================================= -->
 <!--                    DOMAIN ELEMENT INTEGRATION                 -->
 <!-- ============================================================= -->
+
+<!ENTITY % alternativetitles-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Alternative Titles Domain//EN"
+         "alternativeTitlesDomain.mod"
+>%alternativetitles-d-def;
 
 <!ENTITY % emphasis-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"

--- a/doctypes/dtd/base/catalog.xml
+++ b/doctypes/dtd/base/catalog.xml
@@ -36,6 +36,14 @@
            uri="otherpropsAttDomain.ent"/>
    <public publicId="-//OASIS//ENTITIES DITA 2.x Otherprops Attribute Domain//EN"
            uri="otherpropsAttDomain.ent"/>
+   <public publicId="-//OASIS//ELEMENTS DITA 2.0 Alternative Titles Domain//EN"
+           uri="alternativeTitlesDomain.mod"/>
+   <public publicId="-//OASIS//ELEMENTS DITA 2.x Alternative Titles Domain//EN"
+           uri="alternativeTitlesDomain.mod"/>
+   <public publicId="-//OASIS//ENTITIES DITA 2.0 Alternative Titles Domain//EN"
+           uri="alternativeTitlesDomain.ent"/>
+   <public publicId="-//OASIS//ENTITIES DITA 2.x Alternative Titles Domain//EN"
+           uri="alternativeTitlesDomain.ent"/>
    <public publicId="-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
            uri="ditavalrefDomain.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA 2.x DITAVAL Ref Domain//EN"

--- a/doctypes/dtd/base/commonElements.ent
+++ b/doctypes/dtd/base/commonElements.ent
@@ -37,9 +37,7 @@
 <!ENTITY % unknown     "unknown"                                     >
 <!ENTITY % foreign     "foreign"                                     >
 <!ENTITY % title       "title"                                       >
-<!ENTITY % navtitle    "navtitle"                                    >
-<!ENTITY % searchtitle "searchtitle"                                 >
-<!ENTITY % linktext    "linktext"                                    >
+<!ENTITY % titlealt    "titlealt"                                    >
 <!ENTITY % shortdesc   "shortdesc"                                   >
 <!ENTITY % desc        "desc"                                        >
 <!ENTITY % p           "p"                                           >

--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -659,42 +659,21 @@
 <!ATTLIST  title %title.attributes;>
 
 
-<!--                    LONG NAME: Navigation Title                -->
-<!ENTITY % navtitle.content
+<!--                    LONG NAME: Alternate Title                -->
+<!ENTITY % titlealt.content
                        "(%words.cnt; |
                          %ph; |
                          %draft-comment; |
                          %required-cleanup;)*"
 >
-<!ENTITY % navtitle.attributes
-              "%univ-atts;"
+<!ENTITY % titlealt.attributes
+              "title-role
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
-<!ELEMENT  navtitle %navtitle.content;>
-<!ATTLIST  navtitle %navtitle.attributes;>
-
-<!--                    LONG NAME: Search Title                    -->
-<!ENTITY % searchtitle.content
-                       "(%words.cnt; |
-                         %ph;)*"
->
-<!ENTITY % searchtitle.attributes
-              "%univ-atts;"
->
-<!ELEMENT  searchtitle %searchtitle.content;>
-<!ATTLIST  searchtitle %searchtitle.attributes;>
-
-
-<!--                    LONG NAME: linktext                        -->
-<!ENTITY % linktext.content
-                       "(%words.cnt; |
-                         %ph;)*"
->
-<!ENTITY % linktext.attributes
-              "%univ-atts;"
->
-<!ELEMENT  linktext %linktext.content;>
-<!ATTLIST  linktext %linktext.attributes;>
-
+<!ELEMENT  titlealt %titlealt.content;>
+<!ATTLIST  titlealt %titlealt.attributes;>
 
 <!--                    LONG NAME: Short Description               -->
 <!ENTITY % shortdesc.content
@@ -1882,13 +1861,11 @@
 <!ATTLIST  keyword        class CDATA "- topic/keyword "    >
 <!ATTLIST  li             class CDATA "- topic/li "         >
 <!ATTLIST  lines          class CDATA "- topic/lines "      >
-<!ATTLIST  linktext       class CDATA "- topic/linktext "   >
 <!ATTLIST  longdescref    class CDATA "- topic/longdescref ">
 <!ATTLIST  longquoteref   class CDATA "- topic/longquoteref ">
 <!ATTLIST  lq             class CDATA "- topic/lq "         >
 <!ATTLIST  media-source   class CDATA "- topic/media-source ">
 <!ATTLIST  media-track    class CDATA "- topic/media-track ">
-<!ATTLIST  navtitle       class CDATA "- topic/navtitle "   >
 <!ATTLIST  note           class CDATA "- topic/note "       >
 <!ATTLIST  object         class CDATA "- topic/object "     >
 <!ATTLIST  ol             class CDATA "- topic/ol "         >
@@ -1898,7 +1875,6 @@
 <!ATTLIST  pre            class CDATA "- topic/pre "        >
 <!ATTLIST  q              class CDATA "- topic/q "          >
 <!ATTLIST  required-cleanup   class CDATA "- topic/required-cleanup ">
-<!ATTLIST  searchtitle    class CDATA "- topic/searchtitle ">
 <!ATTLIST  shortdesc      class CDATA "- topic/shortdesc "  >
 <!ATTLIST  simpletable    class CDATA "- topic/simpletable ">
 <!ATTLIST  sl             class CDATA "- topic/sl "         >
@@ -1910,6 +1886,7 @@
 <!ATTLIST  term           class CDATA "- topic/term "       >
 <!ATTLIST  text           class CDATA "- topic/text "       >
 <!ATTLIST  title          class CDATA "- topic/title "      >
+<!ATTLIST  titlealt       class CDATA "- topic/titlealt "   >
 <!ATTLIST  tm             class CDATA "- topic/tm "         >
 <!ATTLIST  ul             class CDATA "- topic/ul "         >
 <!ATTLIST  unknown        class CDATA "- topic/unknown "    >

--- a/doctypes/dtd/base/ditavalrefDomain.mod
+++ b/doctypes/dtd/base/ditavalrefDomain.mod
@@ -73,10 +73,7 @@
                        "(%ditavalmeta;)?"
 >
 <!ENTITY % ditavalref.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                scope
@@ -99,7 +96,7 @@
 
 <!--                    LONG NAME: Ditavalmeta                     -->
 <!ENTITY % ditavalmeta.content
-                       "((%navtitle;)?,
+                       "((%titlealt;)*,
                          ((%dvrResourcePrefix;)?,
                           (%dvrResourceSuffix;)?,
                           (%dvrKeyscopePrefix;)?,

--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -110,11 +110,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               locktitle
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                format
                           CDATA
                                     #IMPLIED
@@ -165,11 +160,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                           (external |
                            local |
                            peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               locktitle
-                          (no |
-                           yes |
                            -dita-use-conref-target)
                                     #IMPLIED
                format
@@ -224,11 +214,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               locktitle
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                format
                           CDATA
                                     #IMPLIED
@@ -278,11 +263,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               locktitle
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                linking
                           (none |
                            normal |
@@ -323,11 +303,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                           (external |
                            local |
                            peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               locktitle
-                          (no |
-                           yes |
                            -dita-use-conref-target)
                                     #IMPLIED
                format
@@ -551,9 +526,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
 <!--                    LONG NAME: Topic Metadata                  -->
 <!ENTITY % topicmeta.content
                        "((%keytext;)?,
-                         (%navtitle;)?,
-                         (%linktext;)?,
-                         (%searchtitle;)?,
+                         (%titlealt;)*,
                          (%shortdesc;)?,
                          (%author;)*,
                          (%source;)?,

--- a/doctypes/dtd/base/mapGroup.mod
+++ b/doctypes/dtd/base/mapGroup.mod
@@ -48,58 +48,6 @@
 <!--                    COMMON ATTLIST SETS                        -->
 <!-- ============================================================= -->  
 
-<!ENTITY % topicref-atts-no-locktitle
-              "collection-type
-                          (choice |
-                           family |
-                           sequence |
-                           unordered |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               type
-                          CDATA
-                                    #IMPLIED
-               cascade
-                          CDATA
-                                    #IMPLIED
-               processing-role
-                          (normal |
-                           resource-only |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               scope
-                          (external |
-                           local |
-                           peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               format
-                          CDATA
-                                    #IMPLIED
-               linking
-                          (none |
-                           normal |
-                           sourceonly |
-                           targetonly |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               toc
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               search
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               chunk
-                          CDATA
-                                    #IMPLIED
-               keyscope
-                          CDATA
-                                    #IMPLIED"
->
 
 <!-- ============================================================= -->
 <!--                    ELEMENT DECLARATIONS                       -->
@@ -114,16 +62,13 @@
                           %topicref;)*)"
 >
 <!ENTITY % topichead.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               keys
+              "keys
                           CDATA
                                     #IMPLIED
                copy-to
                           CDATA
                                     #IMPLIED
-               %topicref-atts-no-locktitle;
+               %topicref-atts;
                %univ-atts;"
 >
 <!ELEMENT  topichead %topichead.content;>
@@ -139,7 +84,7 @@
                           %topicref;)*)"
 >
 <!ENTITY % topicgroup.attributes
-              "%topicref-atts-no-locktitle;
+              "%topicref-atts;
                %univ-atts;"
 >
 <!ELEMENT  topicgroup %topicgroup.content;>
@@ -153,10 +98,7 @@
                           %topicref;)*)"
 >
 <!ENTITY % anchorref.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref
@@ -193,11 +135,6 @@
                           (external |
                            local |
                            peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               locktitle
-                          (no |
-                           yes |
                            -dita-use-conref-target)
                                     #IMPLIED
                format
@@ -241,10 +178,7 @@
                          (%data.elements.incl;)*)"
 >
 <!ENTITY % mapref.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref
@@ -274,10 +208,7 @@
                           %topicref;)*)"
 >
 <!ENTITY % keydef.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref
@@ -314,11 +245,6 @@
                           (external |
                            local |
                            peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               locktitle
-                          (no |
-                           yes |
                            -dita-use-conref-target)
                                     #IMPLIED
                format

--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -221,7 +221,6 @@
 <!--                    LONG NAME: Topic                           -->
 <!ENTITY % topic.content
                        "((%title;),
-                         (%titlealts;)?,
                          (%shortdesc; |
                           %abstract;)?,
                          (%prolog;)?,
@@ -247,19 +246,6 @@
                         CDATA
                                   "&included-domains;"
 >
-
-
-<!--                    LONG NAME: Title Alternatives              -->
-<!ENTITY % titlealts.content
-                       "((%navtitle;)?,
-                         (%searchtitle;)?)"
->
-<!ENTITY % titlealts.attributes
-              "%univ-atts;"
->
-<!ELEMENT  titlealts %titlealts.content;>
-<!ATTLIST  titlealts %titlealts.attributes;>
-
 
 <!--                    LONG NAME: Abstract                        -->
 <!ENTITY % abstract.content
@@ -383,6 +369,16 @@
 <!ELEMENT  link %link.content;>
 <!ATTLIST  link %link.attributes;>
 
+<!--                    LONG NAME: link text                       -->
+<!ENTITY % linktext.content
+                       "(%words.cnt; |
+                         %ph;)*"
+>
+<!ENTITY % linktext.attributes
+              "%univ-atts;"
+>
+<!ELEMENT  linktext %linktext.content;>
+<!ATTLIST  linktext %linktext.attributes;>
 
 <!--                    LONG NAME: linklist                        -->
 <!ENTITY % linklist.content
@@ -451,7 +447,6 @@
 <!ATTLIST  linkpool %linkpool.attributes;>
 
 
-
 <!-- ============================================================= -->
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
@@ -463,12 +458,12 @@
 <!ATTLIST  linkinfo       class CDATA "- topic/linkinfo "   >
 <!ATTLIST  linklist       class CDATA "- topic/linklist "   >
 <!ATTLIST  linkpool       class CDATA "- topic/linkpool "   >
+<!ATTLIST  linktext       class CDATA "- topic/linktext "   >
 <!ATTLIST  no-topic-nesting   class CDATA "- topic/no-topic-nesting ">
 <!ATTLIST  prolog         class CDATA "- topic/prolog "     >
 <!ATTLIST  related-links   class CDATA "- topic/related-links ">
 <!ATTLIST  section        class CDATA "- topic/section "    >
 <!ATTLIST  sectiondiv     class CDATA "- topic/sectiondiv " >
-<!ATTLIST  titlealts      class CDATA "- topic/titlealts "  >
 <!ATTLIST  topic          class CDATA "- topic/topic "      >
 
 <!-- ================== End of DITA Topic Module ==================== -->

--- a/doctypes/dtd/subjectScheme/classifyDomain.mod
+++ b/doctypes/dtd/subjectScheme/classifyDomain.mod
@@ -56,10 +56,7 @@
                           %topicref;)*)"
 >
 <!ENTITY % topicsubject.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref
@@ -110,10 +107,7 @@
                           %topicref;)*)"
 >
 <!ENTITY % topicapply.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref
@@ -176,10 +170,7 @@
                          (%data.elements.incl;)*)"
 >
 <!ENTITY % subjectref.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref

--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -88,11 +88,6 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               locktitle
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                format
                           CDATA
                                     #IMPLIED
@@ -492,11 +487,6 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               locktitle
-                          (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                format
                           CDATA
                                     #IMPLIED
@@ -553,7 +543,7 @@
 
 <!--                    LONG NAME: Subject Heading Metadata        -->
 <!ENTITY % subjectHeadMeta.content
-                       "((%navtitle;)?,
+                       "((%titlealt;)*,
                          (%shortdesc;)?)"
 >
 <!ENTITY % subjectHeadMeta.attributes
@@ -693,11 +683,6 @@
                processing-role
                           (normal |
                            resource-only |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               locktitle
-                          (no |
-                           yes |
                            -dita-use-conref-target)
                                     #IMPLIED
                format

--- a/doctypes/rng/base/catalog.xml
+++ b/doctypes/rng/base/catalog.xml
@@ -35,6 +35,10 @@
               uri="otherpropsAttDomain.rng"/>
       <system systemId="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.x"
               uri="otherpropsAttDomain.rng"/>
+      <system systemId="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0"
+              uri="alternativeTitlesDomain.rng"/>
+      <system systemId="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.x"
+              uri="alternativeTitlesDomain.rng"/>
       <system systemId="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0"
               uri="ditavalrefDomain.rng"/>
       <system systemId="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.x"
@@ -109,6 +113,10 @@
            uri="otherpropsAttDomain.rng"/>
       <uri name="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.x"
            uri="otherpropsAttDomain.rng"/>
+      <uri name="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0"
+              uri="alternativeTitlesDomain.rng"/>
+      <uri name="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.x"
+              uri="alternativeTitlesDomain.rng"/>
       <uri name="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0"
            uri="ditavalrefDomain.rng"/>
       <uri name="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.x"


### PR DESCRIPTION
Adds DTD support for #16 new `<titlealt>` element.

Also a couple cleanup items in files that were being touched:
* Fixed comments in headers
* Removed `@navtitle` that was still declared in map DTD modules
* Added the new alternative titles modules to the RNG catalg