### PR TITLE
Removing deprecated items from #36

### DIFF
--- a/doctypes/dtd/base/commonElements.ent
+++ b/doctypes/dtd/base/commonElements.ent
@@ -69,7 +69,6 @@
 <!ENTITY % term        "term"                                        >
 <!ENTITY % ph          "ph"                                          >
 <!ENTITY % tm          "tm"                                          >
-<!ENTITY % boolean     "boolean"                                     >
 <!ENTITY % state       "state"                                       >
 <!ENTITY % image       "image"                                       >
 <!ENTITY % alt         "alt"                                         >

--- a/doctypes/dtd/base/hazardstatementDomain.mod
+++ b/doctypes/dtd/base/hazardstatementDomain.mod
@@ -89,9 +89,6 @@
                keyref
                           CDATA
                                     #IMPLIED
-               longdescref
-                          CDATA
-                                    #IMPLIED
                height
                           NMTOKEN
                                     #IMPLIED

--- a/doctypes/dtd/base/mapGroup.mod
+++ b/doctypes/dtd/base/mapGroup.mod
@@ -152,12 +152,6 @@
                            yes |
                            -dita-use-conref-target)
                                     #IMPLIED
-               print
-                          (no |
-                           printonly |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                search
                           (no |
                            yes |
@@ -259,12 +253,6 @@
                                     #IMPLIED
                toc
                           (no |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               print
-                          (no |
-                           printonly |
                            yes |
                            -dita-use-conref-target)
                                     #IMPLIED

--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -360,9 +360,6 @@
                keyref
                           CDATA
                                     #IMPLIED
-               query
-                          CDATA
-                                    #IMPLIED
                %relational-atts;
                %univ-atts;"
 >

--- a/doctypes/dtd/subjectScheme/classifyDomain.mod
+++ b/doctypes/dtd/subjectScheme/classifyDomain.mod
@@ -65,9 +65,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               query
-                          CDATA
-                                    #IMPLIED
                type
                           CDATA
                                     #IMPLIED
@@ -114,9 +111,6 @@
                           CDATA
                                     #IMPLIED
                keys
-                          CDATA
-                                    #IMPLIED
-               query
                           CDATA
                                     #IMPLIED
                collection-type
@@ -177,9 +171,6 @@
                           CDATA
                                     #IMPLIED
                keys
-                          CDATA
-                                    #IMPLIED
-               query
                           CDATA
                                     #IMPLIED
                collection-type

--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -103,12 +103,6 @@
                            yes |
                            -dita-use-conref-target)
                                     'no'
-               print
-                          (no |
-                           printonly |
-                           yes |
-                           -dita-use-conref-target)
-                                    #IMPLIED
                search
                           (no |
                            yes |
@@ -176,9 +170,6 @@
                           CDATA
                                     #IMPLIED
                keys
-                          CDATA
-                                    #IMPLIED
-               query
                           CDATA
                                     #IMPLIED
                processing-role
@@ -457,9 +448,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               query
-                          CDATA
-                                    #IMPLIED
                copy-to
                           CDATA
                                     #IMPLIED
@@ -662,9 +650,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               query
-                          CDATA
-                                    #IMPLIED
                copy-to
                           CDATA
                                     #IMPLIED
@@ -720,9 +705,6 @@
                           CDATA
                                     #IMPLIED
                keys
-                          CDATA
-                                    #IMPLIED
-               query
                           CDATA
                                     #IMPLIED
                collection-type

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -2315,7 +2315,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="longdescref.element">
           <element name="longdescref" dita:longName="Long description reference">
-            <a:documentation>A reference to a textual description of the graphic or object. This element is a replacement for the longdescref attribute on image and object elements.</a:documentation>
+            <a:documentation>A reference to a textual description of the graphic or object.</a:documentation>
             <ref name="longdescref.attlist"/>
             <ref name="longdescref.content"/>
           </element>
@@ -2325,14 +2325,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
       </div>
       <div>
-        <a:documentation xml:space="preserve">LONG NAME: Object (Streaming/Executable Data)
-        
-    The longdescre attribute is an error which appeared in the
-    original DTD implementation of OASIS DITA. It is an error that
-    is not part of the standard. It was left here to provide time
-    to change documents, but it will be removed at a later date.
-    The longdescref (with ending F) should be used instead.
-        </a:documentation>
+        <a:documentation xml:space="preserve">LONG NAME: Object (Streaming/Executable Data)</a:documentation>
         <define name="object.content">
           <optional>
             <ref name="desc"/>

--- a/doctypes/rng/base/hazardstatementDomain.rng
+++ b/doctypes/rng/base/hazardstatementDomain.rng
@@ -151,9 +151,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
           <attribute name="keyref"/>
         </optional>
         <optional>
-          <attribute name="longdescref"/>
-        </optional>
-        <optional>
           <attribute name="height">
             <data type="NMTOKEN"/>
           </attribute>

--- a/doctypes/rng/base/mapGroupDomain.rng
+++ b/doctypes/rng/base/mapGroupDomain.rng
@@ -254,16 +254,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
           </attribute>
         </optional>
         <optional>
-          <attribute name="print">
-            <choice>
-              <value>no</value>
-              <value>printonly</value>
-              <value>yes</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
           <attribute name="search">
             <choice>
               <value>no</value>
@@ -416,16 +406,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
           <attribute name="toc">
             <choice>
               <value>no</value>
-              <value>yes</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
-          <attribute name="print">
-            <choice>
-              <value>no</value>
-              <value>printonly</value>
               <value>yes</value>
               <value>-dita-use-conref-target</value>
             </choice>

--- a/doctypes/rng/base/topicMod.rng
+++ b/doctypes/rng/base/topicMod.rng
@@ -580,9 +580,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
           <optional>
             <attribute name="keyref"/>
           </optional>
-          <optional>
-            <attribute name="query"/>
-          </optional>
           <ref name="relational-atts"/>
           <ref name="univ-atts"/>
         </define>
@@ -631,9 +628,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
                 <value>sequence</value>
                 <value>unordered</value>
                 <value>-dita-use-conref-target</value>
-                <a:documentation>NOTE: The TC is maintaining the value "tree", which was
-                  in the 1.2 DTDs but never defined for documented, only in the DTD version
-                  of linklist.</a:documentation>
               </choice>
             </attribute>
           </optional>
@@ -709,9 +703,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Topic//EN"
                 <value>sequence</value>
                 <value>unordered</value>
                 <value>-dita-use-conref-target</value>
-                <a:documentation>NOTE: The TC is maintaining the value "tree", which was
-                  in the 1.2 DTDs but never defined for documented, only in the DTD version
-                  of linkpool.</a:documentation>
               </choice>
             </attribute>
           </optional>

--- a/doctypes/rng/subjectScheme/classifyDomain.rng
+++ b/doctypes/rng/subjectScheme/classifyDomain.rng
@@ -115,9 +115,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
           <attribute name="keys"/>
         </optional>
         <optional>
-          <attribute name="query"/>
-        </optional>
-        <optional>
           <attribute name="type"/>
         </optional>
         <optional>
@@ -191,9 +188,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         </optional>
         <optional>
           <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="query"/>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -284,9 +278,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         </optional>
         <optional>
           <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="query"/>
         </optional>
         <optional>
           <attribute name="collection-type">

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -170,16 +170,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
         </attribute>
       </optional>
       <optional>
-        <attribute name="print">
-          <choice>
-            <value>no</value>
-            <value>printonly</value>
-            <value>yes</value>
-            <value>-dita-use-conref-target</value>
-          </choice>
-        </attribute>
-      </optional>
-      <optional>
         <attribute name="search">
           <choice>
             <value>no</value>
@@ -275,9 +265,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
         </optional>
         <optional>
           <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="query"/>
         </optional>
         <optional>
           <attribute name="processing-role">
@@ -700,9 +687,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
           <attribute name="keys"/>
         </optional>
         <optional>
-          <attribute name="query"/>
-        </optional>
-        <optional>
           <attribute name="copy-to"/>
         </optional>
         <optional>
@@ -768,7 +752,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectdef.element">
         <element name="subjectdef" dita:longName="Subject definition">
-          <a:documentation><![CDATA[The <subjectdef> element defines a subject (also known as a controlled value) within a scheme. To make the subject easy to identify, a <subjectdef> may use a keys attribute to assign a key to the subject. A subject with a key can be identified elsewhere with a keyref. The <subjectdef> may use a navtitle element or attribute to supply a label for the subject. The <subjectdef> may also refer to a topic that captures the consensus definition for the subject.]]></a:documentation>
+          <a:documentation><![CDATA[The <subjectdef> element defines a subject (also known as a controlled value) within a scheme. To make the subject easy to identify, a <subjectdef> may use a keys attribute to assign a key to the subject. A subject with a key can be identified elsewhere with a keyref. The <subjectdef> may use a navtitle element to supply a label for the subject. The <subjectdef> may also refer to a topic that captures the consensus definition for the subject.]]></a:documentation>
           <ref name="subjectdef.attlist"/>
           <ref name="subjectdef.content"/>
         </element>
@@ -1038,9 +1022,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
           <attribute name="keys"/>
         </optional>
         <optional>
-          <attribute name="query"/>
-        </optional>
-        <optional>
           <attribute name="copy-to"/>
         </optional>
         <optional>
@@ -1125,9 +1106,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
         </optional>
         <optional>
           <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="query"/>
         </optional>
         <optional>
           <attribute name="collection-type" a:defaultValue="family">


### PR DESCRIPTION
Noted several items in the grammar files that were not fully cleaned up with changes for #36 
* Leftover entity for boolean
* `@query` still defined for many elements
* `@longdescref` was removed from image but still on hazard specialization
* `@print` still defined for many elements
* Cleaned up a bunch of doc comments in RNG that referred to removed attributes