### PR TITLE
Remove navtitle att from example

### DIFF
--- a/specification/langRef/attributes/ditauseconreftarget.dita
+++ b/specification/langRef/attributes/ditauseconreftarget.dita
@@ -32,29 +32,28 @@
         "-dita-use-conref-target" does not fit the syntax required by the XML grammar
       files.</p></section>
     <example id="example" otherprops="examples">
-      <p>This example shows a DITA 1.3 map where the <xmlelement>topichead</xmlelement> element uses
-          <xmlatt>conref</xmlatt>. It specifies the <xmlatt>navtitle</xmlatt> attribute as well as
-        the <xmlatt>toc</xmlatt> attribute. In the resolved element, <xmlatt>navtitle</xmlatt> from
-        the referencing element is not preserved because it uses <keyword>-dita-use-conref-target</keyword>. The
-          <xmlatt>toc</xmlatt> attribute from the referencing element overrides the
-          <xmlatt>toc</xmlatt> attribute on the referenced element using normal conref resolution
-        rules.</p>
-      <note>In earlier versions of DITA, <xmlatt>navtitle</xmlatt> was required on the
-          <xmlelement>topichead</xmlelement> element. While it is no longer required, the example
-        still illustrates the expected DITA 1.3 processing for both required and non-required
-        attributes.</note>
+      <p>This example shows a DITA map where the <xmlelement>topichead</xmlelement> element uses
+          <xmlatt>conref</xmlatt>. It specifies the <xmlatt>deliveryTarget</xmlatt> attribute as
+        well as the <xmlatt>toc</xmlatt> attribute. In the resolved element,
+          <xmlatt>deliveryTarget</xmlatt> from the referencing element is not preserved because it
+        uses <keyword>-dita-use-conref-target</keyword>. The <xmlatt>toc</xmlatt> attribute from the
+        referencing element overrides the <xmlatt>toc</xmlatt> attribute on the referenced element
+        using normal conref resolution rules.</p>
       <fig id="example-fig1">
         <title>Before resolution</title>
         <codeblock>&lt;map>&lt;title>Conref demonstration&lt;/title>
   &lt;topichead id="heading"
-             navtitle="This is a heading"
+             deliveryTarget="pdf"
              toc="yes"
              linking="normal">
+    &lt;topicmeta>
+       &lt;navtitle>This is a heading&lt;/navtitle>
+    &lt;/topicmeta>
     &lt;topicref href="topic.dita" navtitle="content"/>
   &lt;/topichead>
 
   &lt;topichead conref="#heading"
-             navtitle="-dita-use-conref-target"
+             deliveryTarget="-dita-use-conref-target"
              toc="no">
   &lt;/topichead>
 &lt;/map></codeblock>
@@ -63,15 +62,21 @@
         <title>Effective result post-resolution</title>
         <codeblock>&lt;map>&lt;title>Conref demonstration&lt;/title>
   &lt;topichead id="heading"
-             navtitle="This is a heading"
+             deliveryTarget="pdf"
              toc="yes"
              linking="normal">
+    &lt;topicmeta>
+       &lt;navtitle>This is a heading&lt;/navtitle>
+    &lt;/topicmeta>
     &lt;topicref href="topic.dita" navtitle="content"/>
   &lt;/topichead>
 
-  &lt;topichead navtitle="This is a heading"
+  &lt;topichead deliveryTarget="pdf"
              toc="no"
              linking="normal">
+    &lt;topicmeta>
+       &lt;navtitle>This is a heading&lt;/navtitle>
+    &lt;/topicmeta>
     &lt;topicref href="topic.dita" navtitle="content"/>
   &lt;/topichead>
 &lt;/map>


### PR DESCRIPTION
Code sample used the now-removed `@navtitle`, and contained a note about older DITA 1.x behaviors that we do not need to preserve in DITA 2.0. Updating the sample to use 2.0 markup and remove the note.