### PR TITLE
Remove mentions of locktitle #16

### DIFF
--- a/specification/archSpec/base/dtd-coding-element-types.dita
+++ b/specification/archSpec/base/dtd-coding-element-types.dita
@@ -74,7 +74,7 @@
 example:<codeblock>&lt;!ENTITY % topichead.attributes
  "keys CDATA #IMPLIED
   copy-to CDATA #IMPLIED
-  %topicref-atts-no-locktitle;
+  %topicref-atts;
   %univ-atts;"
 ></codeblock></p>
           </dd>

--- a/specification/archSpec/base/processing-key-references-general.dita
+++ b/specification/archSpec/base/processing-key-references-general.dita
@@ -22,8 +22,7 @@
 element, other than the <xmlatt>keys</xmlatt>,<ph>
 <xmlatt>processing-role</xmlatt>,</ph> and <xmlatt>id</xmlatt> attributes, are combined as for
 content references, including the special processing for the <xmlatt>xml:lang</xmlatt>,
-<xmlatt>dir</xmlatt>, and <xmlatt>translate</xmlatt> attributes. There is no special processing
-associated with the <xmlatt>locktitle</xmlatt> attribute when attributes are combined.</p>
+<xmlatt>dir</xmlatt>, and <xmlatt>translate</xmlatt> attributes.</p>
         </section>
         <section id="keys-and-condproc">
             <title>Keys and conditional processing</title>

--- a/specification/archSpec/base/relax-ng-coding-element-types.dita
+++ b/specification/archSpec/base/relax-ng-coding-element-types.dita
@@ -105,7 +105,7 @@
     &lt;optional>
       &lt;attribute name="copy-to"/>
     &lt;/optional>
-    &lt;ref name="topicref-atts-no-locktitle"/>
+    &lt;ref name="topicref-atts"/>
     &lt;ref name="univ-atts"/>
   &lt;/define>
   &lt;define name="topichead.element">

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -48,12 +48,7 @@
                                         value are specified, implementations <term
                                                 outputclass="RFC-2119">MAY</term> ignore one of the
                                         two values when they are unable to scale to each direction
-                                        using different factors.</ph></p><p><ph
-                                        id="locktitle-no-purpose">Although
-                                                <xmlatt>locktitle</xmlatt> is available as part of
-                                                <xref
-                                                keyref="attributes-common/commonmapatts"
-                                        />, it has no defined purpose for this element.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
+                                        using different factors.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
                                         element: <xref keyref="attributes-common/dataatts"/>, <xref
 keyref="attributes-common/linkatts"/>, <xref
 keyref="attributes-universal"/>, and <xref

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -16,8 +16,7 @@
           keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-common/commonmapatts"/> (with a narrowed definition of <xmlatt>locktitle</xmlatt>
-        given below), <xref keyref="attributes-universal/idatts"/>, <xref keyref="attributes-common/linkatts"/>
+          keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-universal/idatts"/>, <xref keyref="attributes-common/linkatts"/>
         (with a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
           keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/metadataatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
@@ -33,11 +32,6 @@
             that is, you cannot reference individual elements inside a topic. References to content
             other than DITA topics should use the <xmlatt>format</xmlatt> attribute to identify the
             kind of resource being referenced.</dd>
-        </dlentry>
-        <dlentry id="locktitle" platform="lwdita">
-          <dt><xmlatt>locktitle</xmlatt></dt>
-          <dd>The value of the <xmlatt>locktitle</xmlatt> attribute is set to
-            <keyword>yes</keyword>. </dd>
         </dlentry>
       </dl>
   </section>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -28,7 +28,7 @@
           <dt>Common map attributes</dt>
           <dd>Includes several attributes that are used on a variety of map elements:
               <xmlatt>cascade</xmlatt>, <xmlatt>chunk</xmlatt>, <xmlatt>collection-type</xmlatt>,
-              <xmlatt>keyscope</xmlatt>, <xmlatt>linking</xmlatt>, <xmlatt>locktitle</xmlatt>,
+              <xmlatt>keyscope</xmlatt>, <xmlatt>linking</xmlatt>,
               <xmlatt>processing-role</xmlatt>, <xmlatt>search</xmlatt>, and
             <xmlatt>toc</xmlatt>.</dd>
         </dlentry>
@@ -418,30 +418,6 @@
                 <dd> </dd>
               </dlentry>
             </dl></dd>
-        </dlentry>
-        <dlentry>
-          <dt><xmlatt>locktitle</xmlatt> (common map attributes)</dt>
-          <dd>If the <xmlatt>locktitle</xmlatt> attribute is set to <keyword>yes</keyword>, the
-            content of the <xmlelement>navtitle</xmlelement> element is used for a navigation title,
-            if it is present. If the <xmlatt>locktitle</xmlatt> attribute is not present or set to
-              <keyword>no</keyword>, the content of the <xmlelement>navtitle</xmlelement> element is
-            ignored, and the title of the referenced topic is used as a navigation title.
-              <p>Allowable values for <xmlatt>locktitle</xmlatt> are:<dl>
-                <dlentry>
-                  <dt>yes </dt>
-                  <dd>The content of the <xmlelement>navtitle</xmlelement> element is used for a
-                    navigation title.</dd>
-                </dlentry>
-                <dlentry>
-                  <dt>no </dt>
-                  <dd>The content of the <xmlelement>navtitle</xmlelement> element is ignored. This
-                    is the processing default. </dd>
-                </dlentry>
-                <dlentry conkeyref="reuse-attributes/ditauseconref" platform="dita">
-                  <dt> </dt>
-                  <dd> </dd>
-                </dlentry>
-              </dl></p></dd>
         </dlentry>
         <dlentry id="name">
           <dt><xmlatt>name</xmlatt> (data-element attributes)</dt>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -24,7 +24,7 @@
           keyref="attributes-common/topicrefatts"/>, <xref
           keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element
-        also uses <xmlatt>processing-role</xmlatt>, <xmlatt>locktitle</xmlatt>, and
+        also uses <xmlatt>processing-role</xmlatt> and
           <xmlatt>toc</xmlatt> from <xref keyref="attributes-common/commonmapatts"/>.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/href-on-topicref">

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -27,8 +27,8 @@
           <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
         narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-          keyref="attributes-common/commonmapatts"/> (with the exclusion of <xmlatt>chunk</xmlatt>,
-          <xmlatt>collection-type</xmlatt>,  <xmlatt>locktitle</xmlatt> and a narrowed definition of
+          keyref="attributes-common/commonmapatts"/> (with the exclusion of <xmlatt>chunk</xmlatt> and
+          <xmlatt>collection-type</xmlatt>, and a narrowed definition of
           <xmlatt>processing-role</xmlatt>, given below), <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -39,8 +39,7 @@
                                         keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>. This element also
                                 uses <xmlatt>processing-role</xmlatt>, <xmlatt>toc</xmlatt>,
-                                        <xmlatt>collection-type</xmlatt>, <xmlatt>linking</xmlatt>,
-                                and <xmlatt>locktitle</xmlatt> from <xref
+                                        <xmlatt>collection-type</xmlatt>, and <xmlatt>linking</xmlatt> from <xref
                                         keyref="attributes-common/commonmapatts"/>. <dl>
                                         <dlentry
                                                 conkeyref="reuse-attributes/href-on-topicref">

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -45,7 +45,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and <xref
-          keyref="attributes-common/commonmapatts"/> (except for <xmlatt>locktitle</xmlatt>).</p>
+          keyref="attributes-common/commonmapatts"/>.</p>
       <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
         from <xref keyref="attributes-common/linkatts"/> are also available.</p>
     </section>

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -39,7 +39,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
 keyref="attributes-universal"/>, <xref keyref="attributes-common/commonmapatts"
-/> (except for <xmlatt>locktitle</xmlatt>), and <xmlatt>copy-to</xmlatt> from <xref
+/>, and <xmlatt>copy-to</xmlatt> from <xref
 keyref="attributes-common/topicrefatts"/>. This element also uses
 the <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes from <xref
 keyref="attributes-common/linkatts"/>.</p>


### PR DESCRIPTION
The `@locktitle` attribute was removed with #16 but there are still several references to it in the spec content; this update removes all mention of the attribute.