### PR TITLE
Add titlealt to prolog

### DIFF
--- a/doctypes/dtd/base/topic.mod
+++ b/doctypes/dtd/base/topic.mod
@@ -316,7 +316,8 @@
 
 <!--                    LONG NAME: prolog                          -->
 <!ENTITY % prolog.content
-                       "((%author;)*,
+                       "((%titlealt;)*,
+                         (%author;)*,
                          (%source;)?,
                          (%publisher;)?,
                          (%copyright;)*,


### PR DESCRIPTION
With #16 the `<titlealt>` element should be the first allowed in the prolog. This was missed when bringing DTDs up to date to match the RNG.