### PR TITLE
Add IDs to attribute definitions

### DIFF
--- a/specification/base-relationship-tables.ditamap
+++ b/specification/base-relationship-tables.ditamap
@@ -83,7 +83,11 @@
     <topicref href="archSpec/base/usage-of-conditional-processing-attributes.dita"/>
    </relcell>
    <relcell>
-    <topicref keyref="attributes-metadata"/>
+    <topicref keyref="attributes-universal">
+     <topicmeta>
+      <linktext>Metadata attributes</linktext>
+     </topicmeta>
+    </topicref>
     <topicref href="langRef/containers/ditaval-elements.dita"/>
    </relcell>
   </relrow>
@@ -92,7 +96,11 @@
     <topicref href="archSpec/base/filtering.dita"/>
    </relcell>
    <relcell>
-    <topicref keyref="attributes-metadata"/>
+    <topicref keyref="attributes-universal">
+     <topicmeta>
+      <linktext>Metadata attributes</linktext>
+     </topicmeta>
+    </topicref>
     <topicref href="langRef/ditaval/ditaval-val.dita">
      <topicmeta>
       <linktext>DITAVAL markup with extended filtering example</linktext>
@@ -182,7 +190,11 @@
   </relrow>
   <relrow>
    <relcell>
-    <topicref keyref="attributes-localization"/>
+    <topicref keyref="attributes-universal">
+     <topicmeta>
+      <linktext>Localization attributes</linktext>
+     </topicmeta>
+    </topicref>
    </relcell>
    <relcell>
     <topicref href="archSpec/base/translation.dita"/>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -77,7 +77,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-s
                                                 keyref="attributes-common/architecturalatts"/>.</p>
                                 <dl>
                                         <dlentry id="topic-id">
-                                                <dt><xmlatt>id</xmlatt>
+                                                <dt id="attr-id"><xmlatt>id</xmlatt>
                                                   <ph conref="#conref-attribute/required-attr"
                                                   /></dt>
                                                 <dd>Provides an anchor point. This ID is usually
@@ -107,7 +107,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn
 keyref="attributes-universal"/> and the attribute defined below.</p>
 <dl>
 <dlentry id="callout">
-<dt><xmlatt>callout</xmlatt></dt>
+<dt id="attr-callout"><xmlatt>callout</xmlatt></dt>
 <dd>Specifies the character that is used for the footnote link, for example, a number or an
                                                   alphabetical character. The attribute also can
                                                   specify a short string of
@@ -118,7 +118,7 @@ keyref="attributes-universal"/> and the attribute defined below.</p>
 <sectiondiv>
 <dl>
 <dlentry id="lomdatatype">
-<dt><xmlatt>datatype</xmlatt></dt>
+<dt id="attr-datatype"><xmlatt>datatype</xmlatt></dt>
 <dd>Available for describing the type of data contained in the value attribute for this metadata
 element. The default value is the empty string "".</dd>
 </dlentry>
@@ -156,7 +156,8 @@ element. The default value is the empty string "".</dd>
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-on-topicref">
-                                                <dt><xmlatt>href</xmlatt></dt>
+                                                <dt id="attr-href-topicref"
+                                                  ><xmlatt>href</xmlatt></dt>
                                                 <dd>Specifies the referenced resource. See <xref
                                                   keyref="attributes-href"/> for detailed
                                                   information on supported values and processing
@@ -179,7 +180,8 @@ element. The default value is the empty string "".</dd>
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-for-booklist">
-                                                <dt><xmlatt>href</xmlatt></dt>
+                                                <dt id="attr-href-booklist"
+                                                  ><xmlatt>href</xmlatt></dt>
                                                 <dd>References a manual listing for the current
                                                   element. See <xref keyref="attributes-href"/> for
                                                   detailed information on supported values and
@@ -225,7 +227,8 @@ element. The default value is the empty string "".</dd>
                                         references.</p>
                                 <dl>
                                         <dlentry id="format-mapref">
-                                                <dt><xmlatt>format</xmlatt></dt>
+                                                <dt id="attr-format-mapref"
+                                                  ><xmlatt>format</xmlatt></dt>
                                                 <dd>Specifies the format of the resource. By
                                                   default, it is set to <keyword>ditamap</keyword>.
                                                   Otherwise, the attribute is the same as described
@@ -238,7 +241,7 @@ element. The default value is the empty string "".</dd>
                                         is a default of "no".</p>
                                 <dl>
                                         <dlentry id="toc-default-no">
-                                                <dt><xmlatt>toc</xmlatt></dt>
+                                                <dt id="attr-toc"><xmlatt>toc</xmlatt></dt>
                                                 <dd>Specifies whether the resource appears in the
                                                   table of contents (TOC). If the value is not
                                                   specified locally, but is specified on an
@@ -298,7 +301,8 @@ of map.-->
                                         with a default of "resource-only"</p>
                                 <dl>
                                         <dlentry id="processing-role-default-resource-only">
-                                                <dt><xmlatt>processing-role</xmlatt></dt>
+                                                <dt id="attr-processing-role"
+                                                  ><xmlatt>processing-role</xmlatt></dt>
                                                 <dd>Specifies the role that the resource plays in
                                                   processing. By default, this is set to
                                                   <keyword>resource-only</keyword>. Otherwise, the
@@ -351,7 +355,8 @@ keyref="attributes-universal"/> (with a narrowed definition of
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="translate-NO">
-                                                <dt><xmlatt>translate</xmlatt></dt>
+                                                <dt id="attr-translate"
+                                                  ><xmlatt>translate</xmlatt></dt>
                                                 <dd>Specifies whether the content of the element is
                                                   translatable. The default value is "no". Setting
                                                   <xmlatt>translate</xmlatt> to "yes" overrides the
@@ -384,7 +389,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>id</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
-                                                <dt><xmlatt>id</xmlatt>
+                                                <dt id="attr-id-required"><xmlatt>id</xmlatt>
                                                   <ph conref="#conref-attribute/required-attr"
                                                   /></dt>
                                                 <dd>Defines an ID by which the element <ph
@@ -392,7 +397,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                         </dlentry>
                                 </dl>
                         </sectiondiv><dl id="linklist-and-linkpool">
-                                <dlentry>
+                                <dlentry id="attr-duplicates">
                                         <dt><xmlatt>duplicates</xmlatt></dt>
                                         <dd>Specifies whether duplicate links are removed from a
                                                 group of links. Duplicate links are links that
@@ -419,7 +424,8 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                                   and "no" for other links.</p></dd>
                                 </dlentry>
                                 <dlentry>
-                                        <dt><xmlatt>collection-type</xmlatt></dt>
+                                        <dt id="attr-collection-type"
+                                                  ><xmlatt>collection-type</xmlatt></dt>
                                         <dd>See <xref
                                         keyref="attributes-common/collection-type"
                                                 /> for a full definition and list of supported
@@ -439,7 +445,8 @@ keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry id="importance-optreq">
-                                                <dt><xmlatt>importance</xmlatt></dt>
+                                                <dt id="attr-importance-syn2"
+                                                  ><xmlatt>importance</xmlatt></dt>
                                                 <dd>The attribute indicates whether this item in a
                                                   syntax diagram is <keyword>optional</keyword> or
                                                   <keyword>required</keyword>. Output processors <ph
@@ -467,7 +474,8 @@ keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
-                                                <dt><xmlatt>importance</xmlatt></dt>
+                                                <dt id="attr-importance-syn3"
+                                                  ><xmlatt>importance</xmlatt></dt>
                                                 <dd>The attribute indicates whether this item in a
                                                   syntax diagram is <keyword>optional</keyword>,
                                                   <keyword>required</keyword>, or
@@ -502,7 +510,8 @@ keyref="attributes-universal"/> (with a narrowed definition of
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry>
-                                                <dt><xmlatt>importance</xmlatt></dt>
+                                                <dt id="attr-importance-syn4"
+                                                  ><xmlatt>importance</xmlatt></dt>
                                                 <dd>The attribute indicates whether this item in a
                                                   syntax diagram is <keyword>optional</keyword>,
                                                   <keyword>required</keyword>, or
@@ -540,13 +549,13 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 apart from <xmlatt>alt</xmlatt></title>
                         <dl>
                                 <dlentry id="image-href">
-                                        <dt><xmlatt>href</xmlatt></dt>
+                                        <dt id="attr-href"><xmlatt>href</xmlatt></dt>
                                         <dd>Specifies the image. See <xref keyref="attributes-href"
                                                 /> for detailed information on supported values and
                                                 processing implications.</dd>
                                 </dlentry>
                                 <dlentry id="image-scope">
-                                        <dt><xmlatt>scope</xmlatt></dt>
+                                        <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
                                         <dd>Specifies the relationship between the current document
                                                 and the target resource. Allowable values are
                                                   <keyword>local</keyword>, <keyword>peer</keyword>,
@@ -557,13 +566,13 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                                 on values.</dd>
                                 </dlentry>
                                 <dlentry id="image-height">
-                                        <dt><xmlatt>height</xmlatt></dt>
+                                        <dt id="attr-height"><xmlatt>height</xmlatt></dt>
                                         <dd>Specifies the vertical dimension for the resulting display.<!-- If necessary, the image <term outputclass="RFC-2119">SHOULD</term> be scaled to the specified size.-->
                                                 <ph conref="#conref-attribute/height-width-units"/>
                                                 <!--If a height value is specified and no width value is specified, the width <term outputclass="RFC-2119">SHOULD</term> be scaled by the same factor as the height. --><!--<ph conref="#conref-attribute/height-width-warning"/>--></dd>
                                 </dlentry>
                                 <dlentry id="image-width">
-                                        <dt><xmlatt>width</xmlatt></dt>
+                                        <dt id="attr-width"><xmlatt>width</xmlatt></dt>
                                         <dd>Specifies the horizontal dimension for the resulting
                                                 display.
                                                   <!--If necessary, the image <term outputclass="RFC-2119">SHOULD</term> be scaled to the specified size. --><ph
@@ -571,7 +580,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                                 <!--If a width value is specified and no height value is specified, the height <term outputclass="RFC-2119">SHOULD</term> be scaled by the same factor as the width. <ph conref="#conref-attribute/height-width-warning"/>--></dd>
                                 </dlentry>
                                 <dlentry id="image-align">
-                                        <dt><xmlatt>align</xmlatt></dt>
+                                        <dt id="attr-align"><xmlatt>align</xmlatt></dt>
                                         <dd>Specifies the horizontal alignment of an image when
                                                 placement is specified as <keyword>break</keyword>.
                                                 Common values include <keyword>left</keyword>,
@@ -579,7 +588,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                                   <keyword>center</keyword>.</dd>
                                 </dlentry>
                                 <dlentry id="image-scale">
-                                        <dt><xmlatt>scale</xmlatt></dt>
+                                        <dt id="attr-scale"><xmlatt>scale</xmlatt></dt>
                                         <dd>Specifies a percentage as an unsigned integer by which
                                                 to scale the image in the absence of any specified
                                                 image height or width; a value of 100 implies that
@@ -595,7 +604,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                         </dd>
                                 </dlentry>
                                 <dlentry id="image-scalefit">
-                                        <dt><xmlatt>scalefit</xmlatt></dt>
+                                        <dt id="attr-scalefit"><xmlatt>scalefit</xmlatt></dt>
                                         <dd>Specifies whether an image is scaled up or down to fit
                                                 within available space. Allowable values are
                                                   <keyword>yes</keyword>, <keyword>no</keyword>, and
@@ -620,7 +629,7 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                         </dd>
                                 </dlentry>
                                 <dlentry id="image-placement">
-                                        <dt><xmlatt>placement</xmlatt></dt>
+                                        <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
                                         <dd>Specifies whether an image is displayed inline or on a
                                                 separate line. The default value is inline.
                                                 Allowable values are: <keyword>inline</keyword>,
@@ -643,7 +652,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
 />.</p>
                                         <dl>
                                                 <dlentry id="map-attribute-id">
-                                                  <dt><xmlatt>id</xmlatt></dt>
+                                                  <dt id="attr-id-map"><xmlatt>id</xmlatt></dt>
                                                   <dd>Specifies an ID for the map. Note that maps do
                                                   not require IDs (unlike topics), and the map ID is
                                                   not included in references to elements within a
@@ -651,7 +660,8 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                                   /></dd>
                                                 </dlentry>
                                                 <dlentry id="map-attribute-anchorref">
-                                                  <dt><xmlatt>anchorref</xmlatt></dt>
+                                                  <dt id="attr-anchorref"
+                                                  ><xmlatt>anchorref</xmlatt></dt>
                                                   <dd>Specifies a location within another map
                                                   document where this map will be anchored.
                                                   Resolution of the map is deferred until the final
@@ -680,17 +690,17 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                         <xmlelement>entry</xmlelement></title>
                         <dl>
                                 <dlentry id="stentry-colspan">
-                                        <dt><xmlatt>colspan</xmlatt></dt>
+                                        <dt id="attr-colspan"><xmlatt>colspan</xmlatt></dt>
                                         <dd>Specifies the number of columns that a cell is to span
                                                 inside a simple table.</dd>
                                 </dlentry>
                                 <dlentry id="stentry-rowspan">
-                                        <dt><xmlatt>rowspan</xmlatt></dt>
+                                        <dt id="attr-rowspan"><xmlatt>rowspan</xmlatt></dt>
                                         <dd>Specifies the number of rows that a cells is to span
                                                 inside a simple table.</dd>
                                 </dlentry>
                                 <dlentry id="headers-att">
-                                        <dt><xmlatt>headers</xmlatt></dt>
+                                        <dt id="attr-headers"><xmlatt>headers</xmlatt></dt>
                                         <dd>Specifies one or more <xmlelement>entry</xmlelement>
                                                 headers that apply to the current entry. The
                                                   <xmlatt>headers</xmlatt> attribute contains an
@@ -699,7 +709,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                                 same table. </dd>
                                 </dlentry>
                                 <dlentry id="tablescope">
-                                        <dt><xmlatt>scope</xmlatt></dt>
+                                        <dt id="attr-scope-simpletable"><xmlatt>scope</xmlatt></dt>
                                         <dd>Specifies that the current entry is a header for other
                                                 table entries. Allowable values are:<dl>
                                                   <dlentry>
@@ -755,7 +765,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
-                                                <dt>importance</dt>
+                                                <dt id="attr-importance-step">importance</dt>
                                                 <dd>Describes whether the current
                                                   <xmlelement>step</xmlelement> or
                                                   <xmlelement>substep</xmlelement> is optional or
@@ -772,7 +782,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                 <title>DITAVAL related common attributes</title>
                                 <dl>
 <dlentry id="ditaval-outputclass">
-<dt><xmlatt>outputclass</xmlatt></dt>
+<dt id="attr-outputclass"><xmlatt>outputclass</xmlatt></dt>
 <dd>If the <xmlatt>action</xmlatt> attribute is set to "flag", treat the flagged element as if the full <xmlatt>outputclass</xmlatt>
 value in the DITAVAL was specified on that element's <xmlatt>outputclass</xmlatt> attribute. If two
 or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same element, treat the
@@ -782,7 +792,7 @@ element already specifies <xmlatt>outputclass</xmlatt>, treat the flagged elemen
 DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</dd>
 </dlentry>
                                         <dlentry id="ditaval-color">
-                                                <dt><xmlatt>color</xmlatt></dt>
+                                                <dt id="attr-color"><xmlatt>color</xmlatt></dt>
                                                 <dd>If the <xmlatt>action</xmlatt> attribute is set
                                                 to "flag", specifies the color to use to flag text.
                                                 Colors can be entered by name or
@@ -791,7 +801,8 @@ DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</
                                                 to "flag", this attribute is ignored.</dd>
                                         </dlentry>
                                         <dlentry id="ditaval-backcolor">
-                                                <dt><xmlatt>backcolor</xmlatt></dt>
+                                                <dt id="attr-backcolor"
+                                                ><xmlatt>backcolor</xmlatt></dt>
                                                 <dd>If the <xmlatt>action</xmlatt> attribute is set
                                                 to "flag", specifies the color to use as background
                                                 for flagged text. Colors can be entered by name or
@@ -801,7 +812,7 @@ DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</
                                                 to "flag", this attribute is ignored.</dd>
                                         </dlentry>
                                         <dlentry id="ditaval-style">
-                                                <dt><xmlatt>style</xmlatt></dt>
+                                                <dt id="attr-style"><xmlatt>style</xmlatt></dt>
                                                 <dd>If the <xmlatt>action</xmlatt> attribute is set
                                                 to "flag", specifies the text styles to use for
                                                 flagged text. This attribute can contain multiple
@@ -810,7 +821,8 @@ DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</
                                                 "flag", this attribute is ignored.</dd>
                                         </dlentry>
                                         <dlentry id="ditaval-imageref">
-                                                <dt><xmlatt>imageref</xmlatt></dt>
+                                                <dt id="attr-imageref"
+                                                ><xmlatt>imageref</xmlatt></dt>
                                                 <dd>Provides a URI reference to the image file,
                                                 using the same syntax as the <xmlatt>href</xmlatt>
                                                 attribute. See <xref
@@ -831,19 +843,19 @@ DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</
                         <title>Definition list entries for multimedia domain</title>
                         <dl>
                                 <dlentry id="media-source-name">
-                                        <dt><xmlatt>name</xmlatt></dt>
+                                        <dt id="attr-name"><xmlatt>name</xmlatt></dt>
                                         <dd>The value is fixed to <keyword>source</keyword>.</dd>
                                 </dlentry>
                                 <dlentry id="media-source-value">
-                                        <dt><xmlatt>value</xmlatt></dt>
+                                        <dt id="attr-value"><xmlatt>value</xmlatt></dt>
                                         <dd>Specifies the URI of the media resource.</dd>
                                 </dlentry>
                                 <dlentry id="media-track-name">
-                                        <dt><xmlatt>name</xmlatt></dt>
+                                        <dt id="attr-name-track"><xmlatt>name</xmlatt></dt>
                                         <dd>The value is fixed to <keyword>track</keyword>.</dd>
                                 </dlentry>
                                 <dlentry id="media-track-type">
-                                        <dt><xmlatt>type</xmlatt></dt>
+                                        <dt id="attr-type"><xmlatt>type</xmlatt></dt>
                                         <dd>Specifies the usage for the track resource. This
                                                 attribute is modeled on the <xmlatt>kind</xmlatt>
                                                 attribute on the HTML5
@@ -902,15 +914,15 @@ DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</
                                                 </dl></dd>
                                 </dlentry>
                                 <dlentry id="media-track-value">
-                                        <dt><xmlatt>value</xmlatt></dt>
+                                        <dt id="attr-value-track"><xmlatt>value</xmlatt></dt>
                                         <dd>Specifies the URI of the track resource.</dd>
                                 </dlentry>
                                 <dlentry id="video-poster-name">
-                                        <dt><xmlatt>name</xmlatt></dt>
+                                        <dt id="attr-name-poster"><xmlatt>name</xmlatt></dt>
                                         <dd>The value is fixed to <keyword>poster</keyword>.</dd>
                                 </dlentry>
                                 <dlentry id="video-poster-value">
-                                        <dt><xmlatt>value</xmlatt></dt>
+                                        <dt id="attr-value-poster"><xmlatt>value</xmlatt></dt>
                                         <dd>Specifies the URL of the image.</dd>
                                 </dlentry>
                         </dl>

--- a/specification/common/reuse-w-lwdita/reuse-audio.dita
+++ b/specification/common/reuse-w-lwdita/reuse-audio.dita
@@ -41,21 +41,21 @@
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
           <dlentry>
-            <dt><xmlatt>autoplay</xmlatt></dt>
+            <dt id="attr-autoplay"><xmlatt>autoplay</xmlatt></dt>
             <dd>Specifies whether the resource automatically plays when it is presented. The
               following values are recognized: <keyword>true</keyword>, <keyword>false</keyword>,
               and <keyword>-dita-use-conref-target </keyword>. The default value is
                 <keyword>true</keyword>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>controls</xmlatt></dt>
+            <dt id="attr-controls"><xmlatt>controls</xmlatt></dt>
             <dd>Specifies whether the presentation of the resource includes user interface controls.
               The following values are recognized: <keyword>true</keyword>,
               <keyword>false</keyword>, and <keyword>-dita-use-conref-target </keyword>. The default
               value is <keyword>true</keyword>.</dd>
           </dlentry>
           <dlentry platform="dita">
-            <dt><xmlatt>format</xmlatt></dt>
+            <dt id="attr-format"><xmlatt>format</xmlatt></dt>
             <dd>Specifies the MIME type for the resource. This attribute enables processors to avoid
               loading unsupported resources. If <xmlatt>format</xmlatt> is not specified
               and <xmlatt>keyref</xmlatt> is specified, the effective type for the key named by the
@@ -66,32 +66,32 @@
               resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>href</xmlatt></dt>
+            <dt id="attr-href"><xmlatt>href</xmlatt></dt>
             <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
             <dd>Specifies the absolute or relative URI of the audio resource. If
                 <xmlatt>href</xmlatt> is specified, specify <xmlatt>format</xmlatt>
               also.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>keyref</xmlatt></dt>
+            <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
             <dd>Specifies a key reference to the audio resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>loop</xmlatt></dt>
+            <dt id="attr-loop"><xmlatt>loop</xmlatt></dt>
             <dd>Specifies whether the resource loops when played. The following values are
               recognized: <keyword>true</keyword>, <keyword>false</keyword>, and
                 <keyword>-dita-use-conref-target </keyword>. The default value is
                 <keyword>true</keyword>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>muted</xmlatt></dt>
+            <dt id="attr-muted"><xmlatt>muted</xmlatt></dt>
             <dd>Specifies whether the resource is muted. The following values are recognized:
                 <keyword>true</keyword>, <keyword>false</keyword>, and
                 <keyword>-dita-use-conref-target </keyword>. The default value is
                 <keyword>true</keyword>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>scope</xmlatt></dt>
+            <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
             <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
               between the current document and the target resource. Resources in the same
               information unit are considered <codeph>"local"</codeph>; resources in the same system
@@ -100,7 +100,7 @@
               considered <codeph>"external"</codeph>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>tabindex</xmlatt></dt>
+            <dt id="attr-tabindex"><xmlatt>tabindex</xmlatt></dt>
             <dd>Specifies whether the audio resource can be focused and where it participates in
               sequential keyboard navigation. See <xref
                 href="https://html.spec.whatwg.org/dev/interaction.html#the-tabindex-attribute"

--- a/specification/common/reuse-w-lwdita/reuse-fn.dita
+++ b/specification/common/reuse-w-lwdita/reuse-fn.dita
@@ -107,7 +107,7 @@
         /> and the attribute defined below.</p>
       <dl>
         <dlentry id="callout">
-          <dt><xmlatt>callout</xmlatt></dt>
+          <dt id="attr-callout"><xmlatt>callout</xmlatt></dt>
           <dd>Specifies the character that is used for the footnote link, for example, a number or
             an alphabetical character. The attribute also can specify a short string of
             characters.<!-- When no <xmlatt>callout</xmlatt> value is specified, footnotes are typically numbered.--></dd>

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -22,19 +22,19 @@
             ><xmlatt>outputclass</xmlatt></xref>.</p>
       <dl>
         <dlentry platform="dita">
-          <dt><xmlatt>align</xmlatt></dt>
+          <dt id="attr-align"><xmlatt>align</xmlatt></dt>
           <dd>Controls the horizontal alignment of an image when <xmlatt>placement</xmlatt> is
             specified as <keyword>break</keyword>. Common values include <keyword>left</keyword>,
               <keyword>right</keyword>, and <keyword>center</keyword>.</dd>
         </dlentry>
         <dlentry id="format">
-          <dt><xmlatt>format</xmlatt></dt>
+          <dt id="attr-format"><xmlatt>format</xmlatt></dt>
           <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->Identifies
             the format of the resource that is referenced. See <xref keyref="attributes-format"/>
             for details on supported values.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>height</xmlatt></dt>
+          <dt id="attr-height"><xmlatt>height</xmlatt></dt>
           <dd>Indicates the vertical dimension for the resulting display. The value of this
             attribute is a real number (expressed in decimal notation) optionally followed by a unit
             of measure from the set of pc, pt, px, in, cm, mm, em (picas, points, pixels, inches,
@@ -43,19 +43,19 @@
               <keyword>10.5cm</keyword>. </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>href</xmlatt></dt>
+          <dt id="attr-href"><xmlatt>href</xmlatt></dt>
           <dd>Provides a reference to the image. See <xref keyref="attributes-href"/> for detailed
             information on supported values and processing implications.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>placement</xmlatt></dt>
+          <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
           <dd>Indicates whether an image is displayed inline or on a separate line. The default
             value is inline. Allowable values are <keyword>inline</keyword>,
               <keyword>break</keyword>, or and <xref keyref="attributes-useconreftarget"
               >"-dita-use-conref-target"</xref>.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>scale</xmlatt></dt>
+          <dt id="attr-scale"><xmlatt>scale</xmlatt></dt>
           <dd>Specifies a percentage as an unsigned integer by which to scale the image in the
             absence of any specified image height or width; a value of 100 implies that the image
             should be presented at its intrinsic size. If a value has been specified for the
@@ -70,7 +70,7 @@
           </dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>scalefit</xmlatt></dt>
+          <dt id="attr-scalefit"><xmlatt>scalefit</xmlatt></dt>
           <dd>Allows an image to be scaled up or down to fit within available space. Allowable
             values are<keyword> yes</keyword>, <keyword>no</keyword>, and <xref
               keyref="attributes-useconreftarget">"-dita-use-conref-target"</xref>. If
@@ -87,7 +87,7 @@
           </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>scope</xmlatt></dt>
+          <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
           <dd>Identifies the closeness of the relationship between the current document and the
             target resource. Allowable values are <keyword>local</keyword>, <keyword>peer</keyword>,
               <keyword>external</keyword>, and <xref keyref="attributes-useconreftarget"
@@ -95,7 +95,7 @@
             information on values.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>width</xmlatt></dt>
+          <dt id="attr-width"><xmlatt>width</xmlatt></dt>
           <dd>Indicates the horizontal dimension for the resulting display. The value of this
             attribute is a real number (expressed in decimal notation) optionally followed by a unit
             of measure from the set of pc, pt, px, in, cm, mm, em (picas, points, pixels, inches,

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -39,13 +39,13 @@
               ><xmlatt>outputclass</xmlatt></xref>.</p>
         <dl>
           <dlentry>
-            <dt><xmlatt>keys</xmlatt>
+            <dt id="attr-keys"><xmlatt>keys</xmlatt>
               <ph>(REQUIRED)</ph></dt>
             <dd>Specifies the required key. Otherwise, the attribute is the same as that described
               in <xref keyref="attributes-keys"/>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>href</xmlatt></dt>
+            <dt id="attr-href"><xmlatt>href</xmlatt></dt>
             <dd>Specifies the referenced resource. In the case of a key definition for variable
               text, this attribute might be omitted. See <xref keyref="attributes-href"/> for
               detailed information on supported values and processing implications.
@@ -54,7 +54,7 @@
               kind of resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>processing-role</xmlatt></dt>
+            <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt></dt>
             <dd>Specifies the role that the resource plays in processing. By default, this is set to
                 <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <xref
                 keyref="attributes-common/commonmapatts"/>.</dd>

--- a/specification/common/reuse-w-lwdita/reuse-map.dita
+++ b/specification/common/reuse-w-lwdita/reuse-map.dita
@@ -65,7 +65,7 @@
           attribute defined below.</p>
         <dl>
           <dlentry id="map-attribute-anchorref" platform="dita">
-            <dt><xmlatt>anchorref</xmlatt></dt>
+            <dt id="attr-anchorref"><xmlatt>anchorref</xmlatt></dt>
             <dd>Identifies a location within another map document where this map will be anchored.
               Resolution of the map is deferred until the final step in the delivery of any rendered
               content. For example, <codeph>anchorref=&quot;map1.ditamap#a1&quot;</codeph> allows
@@ -74,7 +74,7 @@
                 <filepath>map1.ditamap</filepath> is rendered for delivery.</dd>
           </dlentry>
           <dlentry id="map-attribute-id">
-            <dt><xmlatt>id</xmlatt></dt>
+            <dt id="attr-id"><xmlatt>id</xmlatt></dt>
             <dd>Allows an ID to be specified for the map. Note that maps do not require IDs (unlike
               topics), and the map ID is not included in references to elements within a map. This
               attribute is defined with the XML Data Type ID.</dd>

--- a/specification/common/reuse-w-lwdita/reuse-media-source.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-source.dita
@@ -26,19 +26,19 @@
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
           <dlentry platform="dita">
-            <dt><xmlatt>format</xmlatt></dt>
+            <dt id="attr-format"><xmlatt>format</xmlatt></dt>
             <dd>Specifies the format of the resource being addressed.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>href</xmlatt></dt>
+            <dt id="attr-href"><xmlatt>href</xmlatt></dt>
             <dd>Specifies the URI of the media resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>keyref</xmlatt></dt>
+            <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
             <dd>Specifies a key reference to the media resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>scope</xmlatt></dt>
+            <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
             <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
               between the current document and the target resource. Resources in the same
               information unit are considered <codeph>"local"</codeph>; resources in the same system
@@ -57,11 +57,11 @@
           base vocabulary.</draft-comment>
         <dl>
           <dlentry conkeyref="reuse-attributes/media-source-name">
-            <dt><xmlatt>name</xmlatt></dt>
+            <dt id="attr-name"><xmlatt>name</xmlatt></dt>
             <dd>The value is fixed to <keyword>source</keyword>.</dd>
           </dlentry>
           <dlentry conkeyref="reuse-attributes/media-source-value">
-            <dt><xmlatt>value</xmlatt></dt>
+            <dt id="attr-value"><xmlatt>value</xmlatt></dt>
             <dd>Specifies the URL of the media resource.</dd>
           </dlentry>
         </dl>

--- a/specification/common/reuse-w-lwdita/reuse-media-track.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-track.dita
@@ -29,19 +29,19 @@
             keyref="attributes-universal"/> and the attributes defined below.</p>
         <dl>
           <dlentry platform="dita">
-            <dt><xmlatt>format</xmlatt></dt>
+            <dt id="attr-format"><xmlatt>format</xmlatt></dt>
             <dd>Specifies the format of the resource being addressed.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>href</xmlatt></dt>
+            <dt id="attr-href"><xmlatt>href</xmlatt></dt>
             <dd>Specifies the URI of the track resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>keyref</xmlatt></dt>
+            <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
             <dd>Specifies a key reference to the track resource.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>kind</xmlatt></dt>
+            <dt id="attr-kind"><xmlatt>kind</xmlatt></dt>
             <dd>Specifies the usage for the track resource. This attribute is modeled on the
                 <xmlatt>kind</xmlatt> attribute on the HTML5 <xmlelement>track</xmlelement> element,
               as described by the <xref
@@ -88,7 +88,7 @@
               </dl></dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>scope</xmlatt></dt>
+            <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
             <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
               between the current document and the target resource. Resources in the same
               information unit are considered <codeph>"local"</codeph>; resources in the same system
@@ -97,7 +97,7 @@
               considered <codeph>"external"</codeph>.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>srclang</xmlatt></dt>
+            <dt id="attr-srclang"><xmlatt>srclang</xmlatt></dt>
             <dd>Specifies the language of the track resource.</dd>
           </dlentry>
         </dl>
@@ -111,11 +111,11 @@
           base vocabulary.</draft-comment>
         <dl>
           <dlentry conkeyref="reuse-attributes/media-track-name">
-            <dt><xmlatt>name</xmlatt></dt>
+            <dt id="attr-name"><xmlatt>name</xmlatt></dt>
             <dd>The value is fixed to <keyword>track</keyword>.</dd>
           </dlentry>
           <dlentry conkeyref="reuse-attributes/media-track-type">
-            <dt><xmlatt>type</xmlatt></dt>
+            <dt id="attr-type"><xmlatt>type</xmlatt></dt>
             <dd>Specifies the usage for the track resource. This attribute is modeled on the
                 <xmlatt>kind</xmlatt> attribute on the HTML5 <xmlelement>track</xmlelement> element,
               as described by the <xref
@@ -162,7 +162,7 @@
               </dl></dd>
           </dlentry>
           <dlentry conkeyref="reuse-attributes/media-track-value">
-            <dt><xmlatt>valuetype</xmlatt></dt>
+            <dt id="attr-valuetype"><xmlatt>valuetype</xmlatt></dt>
             <dd>The value is fixed to "ref".</dd>
           </dlentry>
         </dl>

--- a/specification/common/reuse-w-lwdita/reuse-note.dita
+++ b/specification/common/reuse-w-lwdita/reuse-note.dita
@@ -19,13 +19,13 @@
                     below.</p>
                 <dl>
                     <dlentry>
-                        <dt><xmlatt>othertype</xmlatt></dt>
+                        <dt id="attr-othertype"><xmlatt>othertype</xmlatt></dt>
                         <dd>Specifies an alternate note type. This value is used as the
                             user-provided note title when the <xmlatt>type</xmlatt> attribute value
                             is set to <keyword>other</keyword>.</dd>
                     </dlentry>
                     <dlentry>
-                        <dt><xmlatt>type</xmlatt></dt>
+                        <dt id="attr-type"><xmlatt>type</xmlatt></dt>
                         <dd>Specifies the type of a note. Note that this differs from the
                                 <xmlatt>type</xmlatt> attribute on many other DITA elements. See
                                 <xref keyref="attributes-type"/> for detailed information on

--- a/specification/common/reuse-w-lwdita/reuse-topic.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topic.dita
@@ -16,7 +16,7 @@
         attribute defined below.</p>
       <dl>
         <dlentry id="topic-id">
-          <dt><xmlatt>id</xmlatt>
+          <dt id="attr-id"><xmlatt>id</xmlatt>
             <ph>(REQUIRED)</ph></dt>
           <dd>Provides an anchor point. This ID is usually required as part of the
               <xmlatt>href</xmlatt> or <xmlatt>conref</xmlatt> syntax when cross referencing or

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -25,7 +25,7 @@
             ><xmlatt>outputclass</xmlatt></xref>.</p>
       <dl>
         <dlentry id="href-on-topicref">
-          <dt><xmlatt>href</xmlatt></dt>
+          <dt id="attr-href"><xmlatt>href</xmlatt></dt>
           <dd>Points to the resource that is represented by the <xmlelement>topicref</xmlelement>.
             See <xref keyref="attributes-href"/> for detailed information on supported values and
             processing implications. References to DITA content cannot be below the topic level:

--- a/specification/common/reuse-w-lwdita/reuse-video.dita
+++ b/specification/common/reuse-w-lwdita/reuse-video.dita
@@ -54,21 +54,21 @@
         LwDITA.</draft-comment>
       <dl>
         <dlentry>
-          <dt><xmlatt>autoplay</xmlatt></dt>
+          <dt id="attr-autoplay"><xmlatt>autoplay</xmlatt></dt>
           <dd>Specifies whether the resource automatically plays when it is presented. The following
             values are recognized: <keyword>true</keyword>, <keyword>false</keyword>, and
               <keyword>-dita-use-conref-target </keyword>. The default value is
               <keyword>true</keyword>.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>controls</xmlatt></dt>
+          <dt id="attr-controls"><xmlatt>controls</xmlatt></dt>
           <dd>Specifies whether the presentation of the resource includes user interface controls.
             The following values are recognized: <keyword>true</keyword>, <keyword>false</keyword>,
             and <keyword>-dita-use-conref-target </keyword>. The default value is
               <keyword>true</keyword>.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>format</xmlatt></dt>
+          <dt id="attr-format"><xmlatt>format</xmlatt></dt>
           <dd>Specifies the MIME type for the resource. This attribute enables processors to avoid
             loading unsupported resources. If <xmlatt>format</xmlatt> is not specified and
               <xmlatt>keyref</xmlatt> is specified, the effective type for the key named by the
@@ -78,7 +78,7 @@
             to determine the effective MIME type of the resource.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>height</xmlatt></dt>
+          <dt id="attr-height"><xmlatt>height</xmlatt></dt>
           <dd>Indicates the vertical dimension for the resulting display. The value of this
             attribute is a real number (expressed in decimal notation) optionally followed by a unit
             of measure from the set of cm, em, in, mm, pc, pt, px, and Q (centimeters, ems, inches,
@@ -87,39 +87,39 @@
         </dlentry>
         <dlentry platform="dita">
           <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
-          <dt><xmlatt>href</xmlatt></dt>
+          <dt id="attr-href"><xmlatt>href</xmlatt></dt>
           <dd>Specifies the absolute or relative URI of the video resource. If <xmlatt>href</xmlatt>
             is specified, specify <xmlatt>format</xmlatt> also.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>keyref</xmlatt></dt>
+          <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
           <dd>Specifies a key reference to the video resource.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>loop</xmlatt></dt>
+          <dt id="attr-loop"><xmlatt>loop</xmlatt></dt>
           <dd>Specifies whether the resource loops when played. The following values are recognized:
               <keyword>true</keyword>, <keyword>false</keyword>, and
               <keyword>-dita-use-conref-target </keyword>. The default value is
               <keyword>true</keyword>.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>muted</xmlatt></dt>
+          <dt id="attr-muted"><xmlatt>muted</xmlatt></dt>
           <dd>Specifies whether the resource is muted. The following values are recognized:
               <keyword>true</keyword>, <keyword>false</keyword>, and
               <keyword>-dita-use-conref-target </keyword>. The default value is
               <keyword>true</keyword>.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>poster</xmlatt></dt>
+          <dt id="attr-poster"><xmlatt>poster</xmlatt></dt>
           <dd>Specifies the absolute or relative URI of the image that is rendered before video
             playback begins.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>posterkeyref</xmlatt></dt>
+          <dt id="attr-posterkeyref"><xmlatt>posterkeyref</xmlatt></dt>
           <dd>Specifies a key reference for the poster image.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>scope</xmlatt></dt>
+          <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
           <dd>The <xmlatt>scope</xmlatt> attribute describes the closeness of the relationship
             between the current document and the target resource. Resources in the same information
             unit are considered <codeph>"local"</codeph>; resources in the same system as the
@@ -128,7 +128,7 @@
             considered <codeph>"external"</codeph>.</dd>
         </dlentry>
         <dlentry platform="dita">
-          <dt><xmlatt>tabindex</xmlatt></dt>
+          <dt id="attr-tabindex"><xmlatt>tabindex</xmlatt></dt>
           <dd><draft-comment author="rodaande">Need to add the linked version of the HTML spec into
               our resources.</draft-comment>Specifies whether the video resource can be focused and
             where it participates in sequential keyboard navigation. See <xref
@@ -137,7 +137,7 @@
             version).</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>width</xmlatt></dt>
+          <dt id="attr-width"><xmlatt>width</xmlatt></dt>
           <dd>Indicates the horizontal dimension for the resulting display. The value of this
             attribute is a real number (expressed in decimal notation) optionally followed by a unit
             of measure from the set of cm, em, in, mm, pc, pt, px, and Q (centimeters, ems, inches,

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -93,7 +93,7 @@
       <p>Common attributes, including those in the groups listed above, are defined as follows.</p>
       <dl>
         <dlentry id="align">
-          <dt><xmlatt>align</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-align"><xmlatt>align</xmlatt> (complex table attributes)</dt>
           <dd>Describes the alignment of text in a table column. Allowable values are: <dl>
               <dlentry>
                 <dt>left </dt>
@@ -125,7 +125,7 @@
                 <xmlelement>entry</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="anchorref" platform="dita">
-          <dt><xmlatt>anchorref</xmlatt></dt>
+          <dt id="attr-anchorref"><xmlatt>anchorref</xmlatt></dt>
           <dd>Identifies a location within another map file where this map will be anchored at
             runtime. Resolution of the map is deferred until the final step in the delivery of any
             rendered content. For example, <codeph>anchorref="map1.ditamap/a1"</codeph> causes this
@@ -134,7 +134,7 @@
             for delivery. </dd>
         </dlentry>
         <dlentry id="cascade" platform="dita">
-          <dt><xmlatt>cascade</xmlatt> (common map attributes)</dt>
+          <dt id="attr-cascade"><xmlatt>cascade</xmlatt> (common map attributes)</dt>
           <dd>
             <p>Controls how metadata attributes cascade within a map. There are two defined values
               that should be supported: <keyword>merge</keyword> and <keyword>nomerge</keyword>.</p>
@@ -146,7 +146,7 @@
           </dd>
         </dlentry>
         <dlentry id="char">
-          <dt><xmlatt>char</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-char"><xmlatt>char</xmlatt> (complex table attributes)</dt>
           <dd>Specifies the character for aligning the table entry data. <p>Default source for
                 <xmlelement>entry</xmlelement> elements starting in this column. If character
               alignment is specified, the value is the single alignment character source for any
@@ -159,7 +159,7 @@
               <xmlelement>entry</xmlelement>.</p><!--Comment in DITA 1.3 Phase 1 review asked what it means if the "r" isn't actually specified. The language here could be cleaned up, but is essentially the same as the language in the OASIS Exchange Model, so leaving it alone now; don't want to force processors to add an error for this condition in DITA, when not required in other languages that use this model.--></dd>
         </dlentry>
         <dlentry id="charoff">
-          <dt><xmlatt>charoff</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-charoff"><xmlatt>charoff</xmlatt> (complex table attributes)</dt>
           <dd>Specifies the horizontal offset of alignment character when
               <codeph>align="char"</codeph>. <p>Default source for <xmlelement>entry</xmlelement>
               elements starting in this column. For character alignment on an entry in the column,
@@ -174,7 +174,7 @@
               <xmlelement>entry</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="chunk" platform="dita">
-          <dt><xmlatt>chunk</xmlatt> (common map attributes)</dt>
+          <dt id="attr-chunk"><xmlatt>chunk</xmlatt> (common map attributes)</dt>
           <dd>When a set of topics is transformed using a map, the <xmlatt>chunk</xmlatt> attribute
             allows documents that contain multiple topics to be broken into smaller files and
             multiple individual topics to be combined into larger combined documents.<p>For a
@@ -182,7 +182,7 @@
                 href="../../archSpec/base/chunking.dita"/>.</p></dd>
         </dlentry>
         <dlentry id="collection-type" platform="dita">
-          <dt><xmlatt>collection-type</xmlatt> (common map attributes)</dt>
+          <dt id="attr-collection-type"><xmlatt>collection-type</xmlatt> (common map attributes)</dt>
           <dd>Collection types describe how links relate to each other. The processing default is
               <keyword>unordered</keyword>, although no default is specified in the DTD or Schema.
             Allowable values are:<dl id="colltypevalues">
@@ -207,14 +207,14 @@
             </dl></dd>
         </dlentry>
         <dlentry id="colsep">
-          <dt><xmlatt>colsep</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-colsep"><xmlatt>colsep</xmlatt> (complex table attributes)</dt>
           <dd>Column separator. A value of 0 indicates no separators; 1 indicates separators. <p>The
                 <xmlatt>colsep</xmlatt> attribute is available on the following table elements:
                 <xmlelement>table</xmlelement>, <xmlelement>tgroup</xmlelement>,
                 <xmlelement>colspec</xmlelement>, and <xmlelement>entry</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="compact" platform="dita">
-          <dt><xmlatt>compact</xmlatt></dt>
+          <dt id="attr-compact"><xmlatt>compact</xmlatt></dt>
           <dd>Indicates close vertical spacing between list items. Expanded spacing is the
             processing default. The output result of compact spacing depends on the processor or
             browser. Allowable values are: <dl>
@@ -233,7 +233,7 @@
             </dl></dd>
         </dlentry>
         <dlentry id="copy-to" platform="dita">
-          <dt><xmlatt>copy-to</xmlatt> (topicref-element attributes)</dt>
+          <dt id="attr-copy-to"><xmlatt>copy-to</xmlatt> (topicref-element attributes)</dt>
           <dd>
             <!--Updated based on TC meeting 1 April 2014, to allow references to non DITA, but disallow non local.-->
             <p>Use the <xmlatt>copy-to</xmlatt> attribute on the <xmlelement>topicref</xmlelement>
@@ -253,13 +253,13 @@
           </dd>
         </dlentry>
         <dlentry id="datatype" platform="dita">
-          <dt><xmlatt>datatype</xmlatt> (data-element attributes)</dt>
+          <dt id="attr-datatype"><xmlatt>datatype</xmlatt> (data-element attributes)</dt>
           <dd>Describes the type of data contained in the <xmlatt>value</xmlatt> attribute or within
             the <xmlelement>data</xmlelement> element. A typical use of <xmlatt>datatype</xmlatt>
             will be the identifying URI for an XML Schema datatype. </dd>
         </dlentry>
         <dlentry id="DITAArchVersion">
-          <dt><xmlatt>DITAArchVersion</xmlatt> (architectural attributes)</dt>
+          <dt id="attr-DITAArchVersion"><xmlatt>DITAArchVersion</xmlatt> (architectural attributes)</dt>
           <dd>Designates the version of the architecture that is in use. The default value will
             increase with each release of DITA. This attribute is in the namespace
             "http://dita.​oasis-open.​org/​architecture/​2005/". This attribute is defined with the
@@ -267,7 +267,7 @@
             current default is <keyword>2.0</keyword>.</dd>
         </dlentry>
         <dlentry id="encoding">
-          <dt><xmlatt>encoding</xmlatt> (inclusion attributes)</dt>
+          <dt id="attr-encoding"><xmlatt>encoding</xmlatt> (inclusion attributes)</dt>
           <dd><draft-comment author="Kristen J Eberlein" time="29 April 2019"
               audience="spec-editors">
               <p>Can we replace "should" in the following definition?</p>
@@ -283,7 +283,7 @@
               implementation-dependent.</p></dd>
         </dlentry>
         <dlentry id="expanse">
-          <dt><xmlatt>expanse</xmlatt> (display attributes)</dt>
+          <dt id="attr-expanse"><xmlatt>expanse</xmlatt> (display attributes)</dt>
           <dd>Determines the horizontal placement of the element. Allowable values are: <dl>
               <dlentry>
                 <dt><keyword>column</keyword></dt>
@@ -314,19 +314,19 @@
               processors or output formats might not be able to support all values. </p></dd>
         </dlentry>
         <dlentry id="expiry">
-          <dt><xmlatt>expiry</xmlatt> (date attributes)</dt>
+          <dt id="attr-expiry"><xmlatt>expiry</xmlatt> (date attributes)</dt>
           <dd>The date when the information should be retired or refreshed, entered as YYYY-MM-DD,
             where YYYY is the year, MM is the month from 01 to 12, and DD is the day from 01-31.
           </dd>
         </dlentry>
         <dlentry id="format">
-          <dt><xmlatt>format</xmlatt> (link-relationship attributes)</dt>
+          <dt id="attr-format"><xmlatt>format</xmlatt> (link-relationship attributes)</dt>
           <dd>The <xmlatt>format</xmlatt> attribute identifies the format of the resource being
             referenced. See <xref keyref="attributes-format"/> for details on supported values.
           </dd>
         </dlentry>
         <dlentry id="frame">
-          <dt><xmlatt>frame</xmlatt> (display attributes)</dt>
+          <dt id="attr-frame"><xmlatt>frame</xmlatt> (display attributes)</dt>
           <dd>Specifies which portion of a border should surround the element. Allowable values are: <dl>
               <dlentry>
                 <dt>all </dt>
@@ -365,35 +365,35 @@
             </p></dd>
         </dlentry>
         <dlentry id="golive">
-          <dt><xmlatt>golive</xmlatt> (date attributes)</dt>
+          <dt id="attr-golive"><xmlatt>golive</xmlatt> (date attributes)</dt>
           <dd>The publication or general availability (GA) date, entered as YYYY-MM-DD, where YYYY
             is the year, MM is the month from 01 to 12, and DD is the day from 01-31. </dd>
         </dlentry>
         <dlentry id="href">
-          <dt><xmlatt>href</xmlatt> (link-relationship attributes)</dt>
+          <dt id="attr-href"><xmlatt>href</xmlatt> (link-relationship attributes)</dt>
           <dd>Provides a reference to a resource. See <xref keyref="attributes-href"/> for detailed
             information on supported values and processing implications.</dd>
         </dlentry>
         <dlentry id="keycol">
-          <dt><xmlatt>keycol</xmlatt> (simpletable attributes)</dt>
+          <dt id="attr-keycol"><xmlatt>keycol</xmlatt> (simpletable attributes)</dt>
           <dd>Defines the column that contains headings for each row. No value indicates no key
             column. When present, the numerical value causes the specified column to be treated as a
             vertical header. </dd>
         </dlentry>
         <dlentry id="keyref">
-          <dt><xmlatt>keyref</xmlatt></dt>
+          <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
           <dd><ph id="keyrefDescription"><xmlatt>keyref</xmlatt> provides a redirectable reference
               based on a key defined within a map. See <xref keyref="attributes-keyref"/> for
               information on using this attribute. </ph></dd>
         </dlentry>
         <dlentry id="keyscope" platform="dita">
-          <dt><xmlatt>keyscope</xmlatt> (common map attributes)</dt>
+          <dt id="attr-keyscope"><xmlatt>keyscope</xmlatt> (common map attributes)</dt>
           <dd>Specifies that the element marks the boundaries of a key scope. See <xref
               keyref="attributes-keyscope"/> for details on how to use the <xmlatt>keyscope</xmlatt>
             attribute.</dd>
         </dlentry>
         <dlentry id="linking" platform="dita">
-          <dt><xmlatt>linking</xmlatt> (common map attributes)</dt>
+          <dt id="attr-linking"><xmlatt>linking</xmlatt> (common map attributes)</dt>
           <dd>Defines some specific linking characteristics of a topic&apos;s current location in
             the map. <ph conkeyref="reuse-attributes/inherit-in-map"/> Allowable values are:<dl>
               <dlentry>
@@ -420,11 +420,11 @@
             </dl></dd>
         </dlentry>
         <dlentry id="name">
-          <dt><xmlatt>name</xmlatt> (data-element attributes)</dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt> (data-element attributes)</dt>
           <dd>Defines a unique name for the object.</dd>
         </dlentry>
         <dlentry id="parse">
-          <dt><xmlatt>parse</xmlatt> (inclusion attributes)</dt>
+          <dt id="attr-parse"><xmlatt>parse</xmlatt> (inclusion attributes)</dt>
           <dd>Specifies the processing expectations for the referenced resource. Processors must
             support the following values:<dl>
               <dlentry>
@@ -458,7 +458,7 @@
               with care.</note></dd>
         </dlentry>
         <dlentry id="processing-role">
-          <dt><xmlatt>processing-role</xmlatt> (common map attributes)</dt>
+          <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt> (common map attributes)</dt>
           <dd>Describes the processing role of the referenced topic. The processing default is
               <keyword>normal</keyword>. <ph conkeyref="reuse-attributes/may-inherit"/> Allowable
             values are:<dl>
@@ -479,7 +479,7 @@
             </dl></dd>
         </dlentry>
         <dlentry id="relcolwidth">
-          <dt><xmlatt>relcolwidth</xmlatt> (simpletable attributes)</dt>
+          <dt id="attr-relcolwidth"><xmlatt>relcolwidth</xmlatt> (simpletable attributes)</dt>
           <dd>Specifies the width of each column in relationship to the width of the other columns.
             The value is a space separated list of relative column widths; each column width is
             specified as a positive integer or decimal number followed by an asterisk character.
@@ -489,7 +489,7 @@
               relative widths of 90/240 and 150/240 (37.5% and 62.5%).</p></dd>
         </dlentry>
         <dlentry id="rowsep">
-          <dt><xmlatt>rowsep</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-rowsep"><xmlatt>rowsep</xmlatt> (complex table attributes)</dt>
           <dd>Row separator. A value of <keyword>0</keyword> indicates no separators;
               <keyword>1</keyword> indicates separators. <p>The <xmlatt>rowsep</xmlatt> attribute is
               available on the following table elements: <xmlelement>table</xmlelement>,
@@ -497,7 +497,7 @@
                 <xmlelement>colspec</xmlelement>, and <xmlelement>entry</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="rowheader">
-          <dt><xmlatt>rowheader</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-rowheader"><xmlatt>rowheader</xmlatt> (complex table attributes)</dt>
           <dd>Indicates whether the entries in the respective column <term outputclass="RFC-2119"
               >SHOULD</term> be considered row headers. Allowable values are: <dl>
               <dlentry>
@@ -532,7 +532,7 @@
             <xmlelement>colspec</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="scale">
-          <dt><xmlatt>scale</xmlatt> (display attributes)</dt>
+          <dt id="attr-scale"><xmlatt>scale</xmlatt> (display attributes)</dt>
           <dd>Specifies a percentage, selected from an enumerated list, that is used to resize fonts
             in relation to the normal text size. This attribute is primarily useful for
             print-oriented display. <p>The <xmlatt>scale</xmlatt> attribute provides an acknowledged
@@ -548,7 +548,7 @@
               processors or output formats might not be able to support all values. </p></dd>
         </dlentry>
         <dlentry id="scope">
-          <dt><xmlatt>scope</xmlatt> (link-relationship attributes)</dt>
+          <dt id="attr-scope"><xmlatt>scope</xmlatt> (link-relationship attributes)</dt>
           <dd>The <xmlatt>scope</xmlatt> attribute identifies the closeness of the relationship
             between the current document and the target resource. Allowable values are
               <keyword>local</keyword>, <keyword>peer</keyword>, <keyword>external</keyword>, and
@@ -556,7 +556,7 @@
             more information on these values.</dd>
         </dlentry>
         <dlentry id="search" platform="dita">
-          <dt><xmlatt>search</xmlatt> (common map attributes)</dt>
+          <dt id="attr-search"><xmlatt>search</xmlatt> (common map attributes)</dt>
           <dd>Describes whether the target is available for searching. <ph
               conkeyref="reuse-attributes/inherit-in-map"/> Allowable values are: <dl>
               <dlentry>
@@ -575,26 +575,26 @@
             </dl></dd>
         </dlentry>
         <dlentry id="specentry">
-          <dt><xmlatt>specentry</xmlatt> (specialization attributes)</dt>
+          <dt id="attr-specentry"><xmlatt>specentry</xmlatt> (specialization attributes)</dt>
           <dd>The specialized entry attribute allows architects of specialized types to define a
             fixed or default header title for a specialized <xmlelement>stentry</xmlelement>
             element. Not intended for direct use by authors. </dd>
         </dlentry>
         <dlentry id="specializations">
-          <dt><xmlatt>specializations</xmlatt> (architectural attributes)</dt>
+          <dt id="attr-specializations"><xmlatt>specializations</xmlatt> (architectural attributes)</dt>
           <dd>Indicates the specialized attribute domains that are included in the grammar file.
             This attribute is defined with the XML data type CDATA. The value will differ depending
             on what domains are included in the current DTD or Schema; a sample value is
               <codeph>@props/audience @props/deliveryTarget @base/newBaseAtt</codeph>.</dd>
         </dlentry>
         <dlentry id="spectitle">
-          <dt><xmlatt>spectitle</xmlatt> (specialization attributes)</dt>
+          <dt id="attr-spectitle"><xmlatt>spectitle</xmlatt> (specialization attributes)</dt>
           <dd>The specialized title attribute allows architects of specialized types to define a
             fixed or default title for a specialized element. Not intended for direct use by
             authors. </dd>
         </dlentry>
         <dlentry id="toc" platform="dita">
-          <dt><xmlatt>toc</xmlatt> (common map attributes)</dt>
+          <dt id="attr-toc"><xmlatt>toc</xmlatt> (common map attributes)</dt>
           <dd>Specifies whether a topic appears in the table of contents (TOC). <ph
               conkeyref="reuse-attributes/inherit-in-map"/> Allowable values are:<dl>
               <dlentry>
@@ -612,16 +612,16 @@
             </dl></dd>
         </dlentry>
         <dlentry id="type" platform="dita">
-          <dt><xmlatt>type</xmlatt> (link-relationship attributes)</dt>
+          <dt id="attr-type"><xmlatt>type</xmlatt> (link-relationship attributes)</dt>
           <dd>Describes the target of a reference. See <xref keyref="attributes-type"/> for detailed
             information on supported values and processing implications. </dd>
         </dlentry>
         <dlentry id="value">
-          <dt><xmlatt>value</xmlatt> (data-element attributes)</dt>
+          <dt id="attr-value"><xmlatt>value</xmlatt> (data-element attributes)</dt>
           <dd>Specifies a value associated with the current property or element. </dd>
         </dlentry>
         <dlentry id="valign">
-          <dt><xmlatt>valign</xmlatt> (complex table attributes)</dt>
+          <dt id="attr-valign"><xmlatt>valign</xmlatt> (complex table attributes)</dt>
           <dd>Indicates the vertical alignment of text in a table entry (cell). Allowable values
             are: <dl>
               <dlentry>
@@ -645,7 +645,7 @@
                 <xmlelement>row</xmlelement>, and <xmlelement>entry</xmlelement>.</p></dd>
         </dlentry>
         <dlentry id="xmlspace">
-          <dt><xmlatt>xml:space</xmlatt></dt>
+          <dt id="attr-xml:space"><xmlatt>xml:space</xmlatt></dt>
           <dd>This attribute is provided on <xmlelement>pre</xmlelement>,
               <xmlelement>lines</xmlelement>, and on elements specialized from those. It ensures
             that parsers in editors and transforms respect the white space, including line-end
@@ -654,7 +654,7 @@
             defined, it has a fixed value of "preserve".</dd>
         </dlentry>
         <dlentry id="xmlnsditaarch">
-          <dt><xmlatt>xmlns:ditaarch</xmlatt> (architectural attributes)</dt>
+          <dt id="attr-xmlns:ditaarch"><xmlatt>xmlns:ditaarch</xmlatt> (architectural attributes)</dt>
           <dd>Declares the default DITA namespace. Although this is technically a namespace rather
             than an attribute, it is included here because it is specified as an attribute in the
             DTD grammar files distributed by OASIS. The value is fixed to

--- a/specification/langRef/attributes/specializationAttributes.dita
+++ b/specification/langRef/attributes/specializationAttributes.dita
@@ -17,13 +17,13 @@
     <section id="section-1">
       <dl>
         <dlentry id="specentry">
-          <dt><xmlatt>specentry</xmlatt></dt>
+          <dt id="attr-specentry"><xmlatt>specentry</xmlatt></dt>
           <dd>The specialized entry attribute allows architects of specialized types to define a
             fixed or default header title for a specialized <xmlelement>stentry</xmlelement>
             element. Not intended for direct use by authors. </dd>
         </dlentry>
         <dlentry id="spectitle">
-          <dt><xmlatt>spectitle</xmlatt></dt>
+          <dt id="attr-spectitle"><xmlatt>spectitle</xmlatt></dt>
           <dd>The specialized title attribute allows architects of specialized types to define a
             fixed or default title for a specialized element. Not intended for direct use by
             authors. </dd>

--- a/specification/langRef/attributes/universalAttributes.dita
+++ b/specification/langRef/attributes/universalAttributes.dita
@@ -53,14 +53,14 @@
         a shell, are noted in the list.</p>
       <dl>
         <dlentry id="audience">
-          <dt><xmlatt>audience</xmlatt>
+          <dt id="attr-audience"><xmlatt>audience</xmlatt>
             <i>(specialized attribute)</i></dt>
           <dd>Indicates the intended audience for the element. <ph
               conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="base" platform="dita">
-          <dt><xmlatt>base</xmlatt></dt>
+          <dt id="attr-base"><xmlatt>base</xmlatt></dt>
           <dd>A generic attribute that has no specific purpose. It is intended to act as a base for
             specialized attributes that have a simple value syntax like the conditional processing
             attributes (one or more alphanumeric values separated by whitespace), but is not itself
@@ -71,7 +71,7 @@
             details.</dd>
         </dlentry>
         <dlentry id="class">
-          <dt><xmlatt>class</xmlatt>
+          <dt id="attr-class"><xmlatt>class</xmlatt>
             <i>(not for use by authors)</i></dt>
           <dd><i>This attribute is not for use by authors. If an editor displays
                 <xmlatt>class</xmlatt> attribute values, do not edit them.</i> The
@@ -86,37 +86,37 @@
             value, which varies for each element.</dd>
         </dlentry>
         <dlentry id="conaction" platform="dita">
-          <dt><xmlatt>conaction</xmlatt></dt>
+          <dt id="attr-conaction"><xmlatt>conaction</xmlatt></dt>
           <dd>This attribute enables users to push content into a new location. Allowable values are
               <keyword>mark</keyword>, <keyword>pushafter</keyword>, <keyword>pushbefore</keyword>,
               <keyword>pushreplace</keyword>, and <keyword>-dita-use-conref-target</keyword>. See
               <xref keyref="attributes-conaction"/> for examples and details about the syntax.</dd>
         </dlentry>
         <dlentry id="conkeyref" platform="dita">
-          <dt><xmlatt>conkeyref</xmlatt></dt>
+          <dt id="attr-conkeyref"><xmlatt>conkeyref</xmlatt></dt>
           <dd>Allows the conref feature to operate using a key instead of a URI. See <xref
               keyref="attributes-conkeyref"/> for more details about the syntax and behaviors.</dd>
         </dlentry>
         <dlentry id="conref">
-          <dt><xmlatt>conref</xmlatt></dt>
+          <dt id="attr-conref"><xmlatt>conref</xmlatt></dt>
           <dd>This attribute is used to reference an ID on content that can be reused. See <xref
               keyref="attributes-conref"/> for examples and details about the syntax. </dd>
         </dlentry>
         <dlentry id="conrefend" platform="dita">
-          <dt><xmlatt>conrefend</xmlatt></dt>
+          <dt id="attr-conrefend"><xmlatt>conrefend</xmlatt></dt>
           <dd>The <xmlatt>conrefend</xmlatt> attribute is used when reusing a range of elements
             through <xmlatt>conref</xmlatt>. The syntax is the same as for the
               <xmlatt>conref</xmlatt> attribute; see <xref keyref="attributes-conrefend"/> for
             examples. </dd>
         </dlentry>
         <dlentry id="deliveryTarget">
-          <dt><xmlatt>deliveryTarget</xmlatt>
+          <dt id="attr-deliveryTarget"><xmlatt>deliveryTarget</xmlatt>
             <i>(specialized attribute)</i></dt>
           <dd><ph conkeyref="reuse-general/deliveryTarget-simpleDefinition"/>
             <ph conkeyref="reuse-attributes/may-inherit"/></dd>
         </dlentry>
         <dlentry id="dir">
-          <dt><xmlatt>dir</xmlatt></dt>
+          <dt id="attr-dir"><xmlatt>dir</xmlatt></dt>
           <dd>Specifies the directionality of text: left-to-right (<keyword>ltr</keyword>, the
             processing default) or right-to-left (<keyword>rtl</keyword>). The value
               <keyword>lro</keyword> indicates an override of normal bidirectional text
@@ -127,7 +127,7 @@
               href="../../archSpec/base/diratt.dita"/> for more information.</dd>
         </dlentry>
         <dlentry id="id">
-          <dt><xmlatt>id</xmlatt></dt>
+          <dt id="attr-id"><xmlatt>id</xmlatt></dt>
           <dd>An anchor point. This ID is the target for references by <xmlatt>href</xmlatt> and
               <xmlatt>conref</xmlatt> attributes and for external applications that refer to DITA
             content. This attribute is defined with the XML data type NMTOKEN, except where noted
@@ -135,7 +135,7 @@
               href="../../archSpec/base/id.dita"/> for more details.</dd>
         </dlentry>
         <dlentry id="importance">
-          <dt><xmlatt>importance</xmlatt></dt>
+          <dt id="attr-importance"><xmlatt>importance</xmlatt></dt>
           <dd>A range of values that describe an importance or priority attributed to an element.
             For example, in steps of a task, the attribute indicates whether a step is optional or
             required. This attribute is not used for DITAVAL-based filtering or flagging;
@@ -147,7 +147,7 @@
               <keyword>-dita-use-conref-target</keyword>. </dd>
         </dlentry>
         <dlentry id="otherprops">
-          <dt><xmlatt>otherprops</xmlatt>
+          <dt id="attr-otherprops"><xmlatt>otherprops</xmlatt>
             <i>(specialized attribute)</i></dt>
           <dd>This attribute can be used for any other properties that might be needed to describe
             an audience, or to provide selection criteria for the element. Alternatively, the
@@ -157,7 +157,7 @@
           </dd>
         </dlentry>
         <dlentry id="outputclass">
-          <dt><xmlatt>outputclass</xmlatt></dt>
+          <dt id="attr-outputclass"><xmlatt>outputclass</xmlatt></dt>
           <dd>Names a role that the element is playing. The role must be consistent with the basic
             semantic and expectations for the element. In particular, the
               <xmlatt>outputclass</xmlatt> attribute can be used for styling during output
@@ -165,21 +165,21 @@
             processing. </dd>
         </dlentry>
         <dlentry id="platform">
-          <dt><xmlatt>platform</xmlatt>
+          <dt id="attr-platform"><xmlatt>platform</xmlatt>
             <i>(specialized attribute)</i></dt>
           <dd>Indicates operating system and hardware. <ph conkeyref="reuse-attributes/may-inherit"
             />
           </dd>
         </dlentry>
         <dlentry id="product">
-          <dt><xmlatt>product</xmlatt>
+          <dt id="attr-product"><xmlatt>product</xmlatt>
             <i>(specialized attribute)</i></dt>
           <dd>Contains the name of the product to which the element applies. <ph
               conkeyref="reuse-attributes/may-inherit"/>
           </dd>
         </dlentry>
         <dlentry id="props">
-          <dt><xmlatt>props</xmlatt></dt>
+          <dt id="attr-props"><xmlatt>props</xmlatt></dt>
           <dd>Root attribute from which new metadata attributes can be specialized. <ph
               conkeyref="reuse-attributes/propertyvalueattr"/>
             <ph conkeyref="reuse-attributes/may-inherit"/>
@@ -190,7 +190,7 @@
             details.</dd>
         </dlentry>
         <dlentry id="rev">
-          <dt><xmlatt>rev</xmlatt></dt>
+          <dt id="attr-rev"><xmlatt>rev</xmlatt></dt>
           <dd>Indicates a revision level of an element that identifies when the element was added or
             modified. It can be used to flag outputs when it matches a run-time parameter; it cannot
             be used for filtering. It is not sufficient to be used for version control. <ph
@@ -198,13 +198,13 @@
           </dd>
         </dlentry>
         <dlentry id="status">
-          <dt><xmlatt>status</xmlatt></dt>
+          <dt id="attr-status"><xmlatt>status</xmlatt></dt>
           <dd>The modification status of the current element. Allowable values are:
               <keyword>new</keyword>, <keyword>changed</keyword>, <keyword>deleted</keyword>,
               <keyword>unchanged</keyword>, and <keyword>-dita-use-conref-target</keyword>.</dd>
         </dlentry>
         <dlentry id="translate">
-          <dt><xmlatt>translate</xmlatt></dt>
+          <dt id="attr-translate"><xmlatt>translate</xmlatt></dt>
           <dd>Indicates whether the content of the element should be translated or not. Allowable
             values are <keyword>yes</keyword>, <keyword>no</keyword>, and
               <keyword>-dita-use-conref-target</keyword>. See <xref
@@ -212,7 +212,7 @@
             each element.</dd>
         </dlentry>
         <dlentry id="xml-lang">
-          <dt><xmlatt>xml:lang</xmlatt></dt>
+          <dt id="attr-xml-lang"><xmlatt>xml:lang</xmlatt></dt>
           <dd>Specifies the language of the element content. The <xmlatt>xml:lang</xmlatt> attribute
             and its values are described in the XML Recommendation at <xref format="html"
               scope="external" href="http://www.w3.org/TR/REC-xml/#sec-lang-tag"

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -31,7 +31,7 @@
           <xmlatt>id</xmlatt>, given below).</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>id</xmlatt>
+          <dt id="attr-id"><xmlatt>id</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Provides an integration point that another map <ph>can</ph> reference in order to
             insert its navigation into the current navigation tree. The <xmlatt>anchorref</xmlatt>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -70,7 +70,7 @@
                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
                 <dl>
                     <dlentry>
-                        <dt><xmlatt>href</xmlatt></dt>
+                        <dt id="attr-href"><xmlatt>href</xmlatt></dt>
                         <dd>Specifies an <xmlelement>anchor</xmlelement> element in this or another
                             DITA map. When rendered, the contents of the current element are copied
                             to the location of the <xmlelement>anchor</xmlelement> element. See
@@ -78,12 +78,12 @@
                             referencing a map element.</dd>
                     </dlentry>
                     <dlentry>
-                        <dt><xmlatt>type</xmlatt></dt>
+                        <dt id="attr-type"><xmlatt>type</xmlatt></dt>
                         <dd>Specifies the type of the referenced resource. By default, this is set
                             to <keyword>anchor</keyword>.</dd>
                     </dlentry>
                     <dlentry>
-                        <dt><xmlatt>format</xmlatt></dt>
+                        <dt id="attr-format"><xmlatt>format</xmlatt></dt>
                         <dd>Specifies the format of the referenced resource. By default, this is set
                             to <keyword>ditamap</keyword>.</dd>
                     </dlentry>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -27,7 +27,7 @@
                 attributes defined below.</p>
             <dl>
                 <dlentry>
-                    <dt><xmlatt>name</xmlatt>
+                    <dt id="attr-name"><xmlatt>name</xmlatt>
                         <ph
                             conkeyref="reuse-attributes/required-attr"
                         /></dt>

--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -27,7 +27,7 @@
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry id="type">
-          <dt><xmlatt>type</xmlatt></dt>
+          <dt id="attr-type"><xmlatt>type</xmlatt></dt>
           <dd>Specifies the type of audience for whom the content of the topic is intended. <ph
               conkeyref="reuse-attributes/nonstandard-type"/>
             <ph otherprops="examples">For example, possible values enumerated in earlier versions of
@@ -36,7 +36,7 @@
                 <keyword>executive</keyword>, and <keyword>services</keyword>.</ph></dd>
         </dlentry>
         <dlentry id="job">
-          <dt><xmlatt>job</xmlatt></dt>
+          <dt id="attr-job"><xmlatt>job</xmlatt></dt>
           <dd>Specifies the high-level task the audience for the topic is trying to accomplish.
             Different audiences might read the same topic in terms of different high-level tasks;
             for example, an administrator might read the topic while administering, while a
@@ -49,7 +49,7 @@
                 <keyword>migrating</keyword>.</ph></dd>
         </dlentry>
         <dlentry id="experiencelevel">
-          <dt><xmlatt>experiencelevel</xmlatt></dt>
+          <dt id="attr-experiencelevel"><xmlatt>experiencelevel</xmlatt></dt>
           <dd>Indicates the level of experience the audience is assumed to possess. Different
             audiences might have different experience levels with respect to the same topic; for
             example, a topic might require general knowledge from a programmer, but expert knowledge
@@ -58,7 +58,7 @@
                 <keyword>general</keyword>, and <keyword>expert</keyword>.</ph></dd>
         </dlentry>
         <dlentry id="name">
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>Specifies a name for the audience, which can be used in <xmlatt>audience</xmlatt>
             attributes.</dd>
         </dlentry>

--- a/specification/langRef/base/audio.dita
+++ b/specification/langRef/base/audio.dita
@@ -11,7 +11,10 @@
       </keywords>
     </metadata>
   </prolog>
-  <refbody>
+  <refbody><section id="attr-href">add href id</section><section id="attr-keyref">
+    <title>add keyref id</title>
+    <p></p>
+  </section>
     <section conkeyref="reuse-audio/usage-information" id="usage-information"><title/><p/></section>
     <section conkeyref="reuse-audio/rendering-expectations" id="rendering-expectations"
       ><title/><p/></section>

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -23,18 +23,18 @@
           <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>colnum</xmlatt></dt>
+          <dt id="attr-colnum"><xmlatt>colnum</xmlatt></dt>
           <dd>Indicates the number of a column in the table, counting from the first logical column
             to the last column.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>colname</xmlatt></dt>
+          <dt id="attr-colname"><xmlatt>colname</xmlatt></dt>
           <dd><ph>Specifies a name for the column defined by this element. The
                 <xmlelement>entry</xmlelement> element can use <xmlatt>colname</xmlatt> to refer to
               the name of this column.</ph></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>colwidth</xmlatt></dt>
+          <dt id="attr-colwidth"><xmlatt>colwidth</xmlatt></dt>
           <dd>Describes the column width.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/copyright.dita
+++ b/specification/langRef/base/copyright.dita
@@ -25,7 +25,7 @@
      keyref="attributes-universal"/> and the attribute defined below.</p>
    <dl>
     <dlentry id="type">
-     <dt><xmlatt>type</xmlatt></dt>
+     <dt id="attr-type"><xmlatt>type</xmlatt></dt>
      <dd>Indicates the legal status of the copyright holder. <ph
        conkeyref="reuse-attributes/nonstandard-type"/>
       <ph otherprops="examples">For example, possible values enumerated in earlier versions of DITA

--- a/specification/langRef/base/copyryear.dita
+++ b/specification/langRef/base/copyryear.dita
@@ -18,7 +18,7 @@
           keyref="attributes-universal"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="year">
-          <dt><xmlatt>year</xmlatt></dt>
+          <dt id="attr-year"><xmlatt>year</xmlatt></dt>
           <dd>Specifies the year in YYYY format. </dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -18,7 +18,7 @@
           keyref="attributes-common/dateatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="date">
-          <dt><xmlatt>date</xmlatt>
+          <dt id="attr-date"><xmlatt>date</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the document creation date. The format is YYYY-MM-DD where YYYY is the year,
             MM is the month from 01 to 12, and DD is the day from 01-31. See <xref format="html"

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -29,15 +29,15 @@
         defined below.</p>
       <dl>
         <dlentry id="author">
-          <dt><xmlatt>author</xmlatt></dt>
+          <dt id="attr-author"><xmlatt>author</xmlatt></dt>
           <dd>Designates the originator of the draft comment.</dd>
         </dlentry>
         <dlentry id="disposition">
-          <dt><xmlatt>disposition</xmlatt></dt>
+          <dt id="attr-disposition"><xmlatt>disposition</xmlatt></dt>
           <dd>Specifies the status of the draft comment. </dd>
         </dlentry>
         <dlentry id="time">
-          <dt><xmlatt>time</xmlatt></dt>
+          <dt id="attr-time"><xmlatt>time</xmlatt></dt>
           <dd>Specifies when the draft comment was created.</dd>
         </dlentry>
         <dlentry conkeyref="reuse-attributes/translate-NO"

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -41,7 +41,7 @@
         and the attribute defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>The name of the metadata item. For this element the default value is
             "dvrKeyscopePrefix".</dd>
         </dlentry>

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -41,7 +41,7 @@
         and the attribute defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>The name of the metadata item. For this element the default value is
             "dvrKeyscopeSuffix".</dd>
         </dlentry>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -41,7 +41,7 @@
         and the attribute defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>The name of the metadata item. For this element the default value is
             "dvrResourcePrefix".</dd>
         </dlentry>

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -46,7 +46,7 @@
         and the attribute defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>The name of the metadata item. For this element the default value is
             "dvrResourceSuffix".</dd>
         </dlentry>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -24,7 +24,7 @@
         defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt>
+          <dt id="attr-name"><xmlatt>name</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the element to which the set of controlled values are bound </dd>
         </dlentry>

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -24,7 +24,7 @@
         />.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>rotate</xmlatt></dt>
+          <dt id="attr-rotate"><xmlatt>rotate</xmlatt></dt>
           <dd>Specifies whether the contents of the entry is rotated. Supported values are:<dl>
               <dlentry>
                 <dt>1</dt>
@@ -43,28 +43,28 @@
                 <xmlatt>rotate</xmlatt> attribute can be ignored.</p></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>colname</xmlatt></dt>
+          <dt id="attr-colname"><xmlatt>colname</xmlatt></dt>
           <dd>Specifies the column name in which an entry is found. <ph>The value is a reference to
               the <xmlatt>colname</xmlatt> attribute on the <xmlelement>colspec</xmlelement>
               element.</ph>
           </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>namest</xmlatt></dt>
+          <dt id="attr-namest"><xmlatt>namest</xmlatt></dt>
           <dd>Specifies the first logical column that is included in a horizontal span. <ph>The
               value is a reference to the <xmlatt>colname</xmlatt> attribute on the
                 <xmlelement>colspec</xmlelement> element.</ph>
           </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>nameend</xmlatt></dt>
+          <dt id="attr-nameend"><xmlatt>nameend</xmlatt></dt>
           <dd>Specifies the last logical column that is included in a horizontal span. <ph>The value
               is a reference to the <xmlatt>colname</xmlatt> attribute on the
                 <xmlelement>colspec</xmlelement> element.</ph>
           </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>morerows</xmlatt></dt>
+          <dt id="attr-morerows"><xmlatt>morerows</xmlatt></dt>
           <dd>Specifies the number of additional rows to add in a vertical span. </dd>
         </dlentry>
         <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -28,7 +28,7 @@
           />, and the attributes defined below.</p>
         <dl>
           <dlentry id="type">
-            <dt><xmlatt>type</xmlatt></dt>
+            <dt id="attr-type"><xmlatt>type</xmlatt></dt>
             <dd>Indicates the level of hazard. The values correspond to the signal words defined by
               the ANSI Z535.6 standard:<dl>
                 <dlentry>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -37,7 +37,7 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
         attributes defined below.</p>
       <dl>
         <dlentry id="format">
-          <dt><xmlatt>format</xmlatt></dt>
+          <dt id="attr-format"><xmlatt>format</xmlatt></dt>
           <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->Identifies
             the format of the resource that is referenced. See <xref keyref="attributes-format"/>
             for details on supported values.</dd>

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -28,12 +28,12 @@
         attributes defined below.</p>
       <dl>
         <dlentry id="start">
-          <dt><xmlatt>start</xmlatt></dt>
+          <dt id="attr-start"><xmlatt>start</xmlatt></dt>
           <dd>Specifies an identifier that indicates the start of an index
             range.<!--<draft-comment author="Eliot Kimber">Specifies a string that serves as the identifier for the start of an index range. </draft-comment>--></dd>
         </dlentry>
         <dlentry id="end">
-          <dt><xmlatt>end</xmlatt></dt>
+          <dt id="attr-end"><xmlatt>end</xmlatt></dt>
           <dd>Specifies an identifier that indicates the end of an index
             range.<!-- is indicated by whichever comes first of the following:<draft-comment author="Eliot Kimber">Specifies a value to be matched against an earlier @start value to indicate that this index term is the end of the index range.</draft-comment><ul><li>Applicable scope boundary</li><li>An <xmlelement>indexterm</xmlelement> element with an <xmlatt>end</xmlatt> attribute with a value that matches that <xmlatt>start</xmlatt> attribute that began the index range<draft-comment author="Eliot Kimber">This is giving the general rule for determining the end of a range. That rule is already stated elsewhere and shouldn't be repeated here.</draft-comment></li></ul>--></dd>
         </dlentry>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -22,11 +22,11 @@
         attributes defined below.</p>
       <dl>
         <dlentry id="reftitle">
-          <dt><xmlatt>reftitle</xmlatt></dt>
+          <dt id="attr-reftitle"><xmlatt>reftitle</xmlatt></dt>
           <dd>The title of the document or topic that is quoted.</dd>
         </dlentry>
         <dlentry id="type">
-          <dt><xmlatt>type</xmlatt></dt>
+          <dt id="attr-type"><xmlatt>type</xmlatt></dt>
           <dd>Indicates the location of the source of the quote. <ph
               conkeyref="reuse-attributes/nonstandard-type"/> See <xref keyref="attributes-type"/>
             for detailed information on the usual supported values and processing implications. </dd>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -34,7 +34,7 @@
           ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
           <dl>
             <dlentry>
-              <dt><xmlatt>href</xmlatt></dt>
+              <dt id="attr-href"><xmlatt>href</xmlatt></dt>
           <dd>Specifies the referenced resource. See <xref keyref="attributes-href"/> for detailed
             information on supported values and processing implications.
             <!--References to DITA content cannot be below the topic level: that is, you cannot reference individual elements inside a topic. -->References
@@ -42,7 +42,7 @@
             kind of resource.</dd>
             </dlentry>
             <dlentry>
-              <dt><xmlatt>processing-role</xmlatt></dt>
+              <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt></dt>
           <dd>Specifies the role that the resource plays in processing. By default, this is set to
               <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <xref
               keyref="attributes-common/commonmapatts"/>.</dd>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -39,7 +39,7 @@
         defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>mapref</xmlatt></dt>
+          <dt id="attr-mapref"><xmlatt>mapref</xmlatt></dt>
           <dd>Specifies the URI of the map file or non-DITA resource to be referenced. It might
             reference a DITA map or a resource that is appropriate for a target help system. <ph
               otherprops="examples">For example, it could reference an XML TOC file for use with

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -36,7 +36,7 @@
                 attributes defined below.</p>
             <dl>
                 <dlentry id="archive">
-                    <dt><xmlatt>archive</xmlatt></dt>
+                    <dt id="attr-archive"><xmlatt>archive</xmlatt></dt>
                     <dd>Specifies a space-separated list of URIs indicating resources needed by the
                         object. These resources might include those URIs specified by the
                             <xmlatt>classid</xmlatt> and <xmlatt>data</xmlatt> attributes.
@@ -45,7 +45,7 @@
                             <xmlatt>codebase</xmlatt> attribute.</dd>
                 </dlentry>
                 <dlentry id="archivekeyrefs">
-                    <dt><xmlatt>archivekeyrefs</xmlatt></dt>
+                    <dt id="attr-archivekeyrefs"><xmlatt>archivekeyrefs</xmlatt></dt>
                     <dd>Key references to one or more archives, as for <xmlatt>archive</xmlatt>. The
                         value is a space-separated list of key names. Each resolvable key reference
                         is treated as a URI as though it had been specified on the
@@ -55,14 +55,14 @@
                         key names can be resolved to a URI. </dd>
                 </dlentry>
                 <dlentry id="classid">
-                    <dt><xmlatt>classid</xmlatt></dt>
+                    <dt id="attr-classid"><xmlatt>classid</xmlatt></dt>
                     <dd>Contains a URI that specifies the location of an object&apos;s
                         implementation. It can be used together with the <xmlatt>data</xmlatt>
                         attribute which is specified relative to the value of the
                             <xmlatt>codebase</xmlatt> attribute. </dd>
                 </dlentry>
                 <dlentry id="classidkeyref">
-                    <dt><xmlatt>classidkeyref</xmlatt></dt>
+                    <dt id="attr-classidkeyref"><xmlatt>classidkeyref</xmlatt></dt>
                     <dd>Key reference to the URI that specifies the location of an object's
                         implementation, as for <xmlatt>classid</xmlatt>. When specified, and the key
                         is resolvable, the key-provided class ID URI is used. If
@@ -70,14 +70,14 @@
                         key cannot be resolved to a URI. </dd>
                 </dlentry>
                 <dlentry id="codebase">
-                    <dt><xmlatt>codebase</xmlatt></dt>
+                    <dt id="attr-codebase"><xmlatt>codebase</xmlatt></dt>
                     <dd>Specifies the base URI used for resolving the relative URI values given for
                             <xmlatt>classid</xmlatt>, <xmlatt>data</xmlatt>, and
                             <xmlatt>archive</xmlatt> attributes. If <xmlatt>codebase</xmlatt> is not
                         set, the default is the base URI of the current element.</dd>
                 </dlentry>
                 <dlentry id="codebasekeyref">
-                    <dt><xmlatt>codebasekeyref</xmlatt></dt>
+                    <dt id="attr-codebasekeyref"><xmlatt>codebasekeyref</xmlatt></dt>
                     <dd>Key reference to the base URI used for resolving other attributes, as for
                             <xmlatt>codebase</xmlatt>. When specified, and the key is resolvable,
                         the key-provided code base URI is used. If <xmlatt>codebase</xmlatt> is
@@ -87,7 +87,7 @@
                         of the current element.</dd>
                 </dlentry>
                 <dlentry id="data">
-                    <dt><xmlatt>data</xmlatt></dt>
+                    <dt id="attr-data"><xmlatt>data</xmlatt></dt>
                     <dd>Contains a reference to the location of an object&apos;s data. If this
                         attribute is a relative URL, it is specified relative to the value of the
                             <xmlatt>codebase</xmlatt> attribute. If this attribute is set, the
@@ -95,7 +95,7 @@
                 </dlentry>
                 <dlentry id="datakeyref">
                     <!-- KJE: Modified to be parallel to the desciption of  @datakeyref in the audio and video topics-->
-                    <dt><xmlatt>datakeyref</xmlatt></dt>
+                    <dt id="attr-datakeyref"><xmlatt>datakeyref</xmlatt></dt>
                     <dd>Provides a key reference to the object. When specified and the key is
                         resolvable, the key-provided URI is used. A key that has no associated
                         resource, only link text, is considered to be unresolved. If
@@ -103,14 +103,14 @@
                         key cannot be resolved to a resource.</dd>
                 </dlentry>
                 <dlentry id="declare">
-                    <dt><xmlatt>declare</xmlatt></dt>
+                    <dt id="attr-declare"><xmlatt>declare</xmlatt></dt>
                     <dd>When this attribute is set to "declare", the current object definition is a
                         declaration only. The object must be instantiated by a later nested object
                         definition referring to this declaration. The only allowable value is
                         "declare".</dd>
                 </dlentry>
                 <dlentry id="type">
-                    <dt><xmlatt>type</xmlatt></dt>
+                    <dt id="attr-type"><xmlatt>type</xmlatt></dt>
                     <dd>Indicates the content type (MIME type) for the data specified by the
                             <xmlatt>data</xmlatt>
                         <ph>or <xmlatt>datakeyref</xmlatt>
@@ -123,7 +123,7 @@
                             the this attribute's value.</ph></dd>
                 </dlentry>
                 <dlentry id="standby">
-                    <dt><xmlatt>standby</xmlatt></dt>
+                    <dt id="attr-standby"><xmlatt>standby</xmlatt></dt>
                     <dd>Contains a message to be displayed while an object is loading.</dd>
                 </dlentry>
                 <dlentry conkeyref="reuse-attributes/image-height">
@@ -135,18 +135,18 @@
                     <dd/>
                 </dlentry>
                 <dlentry id="usemap">
-                    <dt><xmlatt>usemap</xmlatt></dt>
+                    <dt id="attr-usemap"><xmlatt>usemap</xmlatt></dt>
                     <dd>Indicates that a client-side image map is to be used. An image map specifies
                         active geometric regions of an included object and assigns a link to each
                         region. When a link is selected, a document <ph>might</ph> be retrieved or a
                         program <ph>might</ph> run on the server.</dd>
                 </dlentry>
                 <dlentry id="name">
-                    <dt><xmlatt>name</xmlatt></dt>
+                    <dt id="attr-name"><xmlatt>name</xmlatt></dt>
                     <dd>Defines a unique name for the object.</dd>
                 </dlentry>
                 <dlentry id="tabindex">
-                    <dt><xmlatt>tabindex</xmlatt></dt>
+                    <dt id="attr-tabindex"><xmlatt>tabindex</xmlatt></dt>
                     <dd>Position the object in tabbing order.</dd>
                 </dlentry>
             </dl>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -26,17 +26,17 @@
      keyref="attributes-universal"/> and the attributes defined below.</p>
    <dl>
     <dlentry id="name">
-     <dt><xmlatt>name</xmlatt>
+     <dt id="attr-name"><xmlatt>name</xmlatt>
       <ph conkeyref="reuse-attributes/required-attr"/></dt>
      <dd>Specifies the name of the metadata property. </dd>
     </dlentry>
     <dlentry id="content">
-     <dt><xmlatt>content</xmlatt>
+     <dt id="attr-content"><xmlatt>content</xmlatt>
       <ph conkeyref="reuse-attributes/required-attr"/></dt>
      <dd>Specifies the value for the property named in the <xmlatt>name</xmlatt> attribute. </dd>
     </dlentry>
     <dlentry id="translate-content">
-     <dt><xmlatt>translate-content</xmlatt></dt>
+     <dt id="attr-translate-content"><xmlatt>translate-content</xmlatt></dt>
      <dd>Indicates whether the <xmlatt>content</xmlatt> attribute of the defined metadata property
       should be translated or not. Allowable values are <keyword>yes</keyword>,
        <keyword>no</keyword>, and <xref keyref="attributes-useconreftarget"

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -27,17 +27,17 @@
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt>
+          <dt id="attr-name"><xmlatt>name</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The name of the parameter.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>value</xmlatt></dt>
+          <dt id="attr-value"><xmlatt>value</xmlatt></dt>
           <dd>Specifies the value of a run-time parameter that is specified by the
               <xmlatt>name</xmlatt> attribute.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>valuetype</xmlatt></dt>
+          <dt id="attr-valuetype"><xmlatt>valuetype</xmlatt></dt>
           <dd>Specifies the type of the <xmlatt>value</xmlatt> attribute. Allowed values are: <dl>
               <dlentry>
                 <dt>data </dt>
@@ -63,7 +63,7 @@
             </dl></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>type</xmlatt></dt>
+          <dt id="attr-type"><xmlatt>type</xmlatt></dt>
           <dd>This attribute specifies for a user agent the type of values that will be found at the
             URI designated by <xmlatt>value</xmlatt>. <ph
               conkeyref="reuse-attributes/nonstandard-type"/>
@@ -80,7 +80,7 @@
             </ol></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>keyref</xmlatt></dt>
+          <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
           <dd>Key reference to the thing the parameter references. If <xmlatt>valuetype</xmlatt> is
             specified but is not set to "ref", this attribute is ignored. When
               <xmlatt>valuetype</xmlatt> is not specified and <xmlatt>keyref</xmlatt> is specified,

--- a/specification/langRef/base/permissions.dita
+++ b/specification/langRef/base/permissions.dita
@@ -23,7 +23,7 @@
           keyref="attributes-universal"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="view">
-          <dt><xmlatt>view</xmlatt></dt>
+          <dt id="attr-view"><xmlatt>view</xmlatt></dt>
           <dd>Specifies the classifications of viewers allowed to view the document. <ph
               otherprops="examples">For example, possible values enumerated in earlier versions of
               DITA included <keyword>internal</keyword>, <keyword>classified</keyword>,

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -62,7 +62,7 @@
           <dd/>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>title</xmlatt></dt>
+          <dt id="attr-title"><xmlatt>title</xmlatt></dt>
           <dd>An identifying title for this element.</dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -43,13 +43,13 @@
           <xmlatt>translate</xmlatt>, given below), and the attributes
         defined below.<dl>
 <dlentry>
-<dt><xmlatt>remap</xmlatt></dt>
+<dt id="attr-remap"><xmlatt>remap</xmlatt></dt>
 <dd>Specifies information about the origins of the content of the
                 <xmlelement>required-cleanup</xmlelement> element. This provides authors with
               context for determining how migrated content was originally encoded.</dd>
 </dlentry>
           <dlentry>
-            <dt><xmlatt>translate</xmlatt></dt>
+            <dt id="attr-translate"><xmlatt>translate</xmlatt></dt>
             <dd>Specifies whether the content of the element should be translated or not. The
               default value for this element is "no"; setting to "yes" will override the default.
               The <xref keyref="attributes-useconreftarget">-dita-use-conref-target</xref> value is

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -32,23 +32,23 @@
         /> and the attributes defined below.</p>
       <dl>
         <dlentry id="appname">
-          <dt><xmlatt>appname</xmlatt></dt>
+          <dt id="attr-appname"><xmlatt>appname</xmlatt></dt>
           <dd><ph>Specifies a name for the external application that references the topic.</ph>
           </dd>
         </dlentry>
         <dlentry id="appid">
-          <dt><xmlatt>appid</xmlatt></dt>
+          <dt id="attr-appid"><xmlatt>appid</xmlatt></dt>
           <dd>Specifies an ID used by an application to identify the topic. </dd>
         </dlentry>
       </dl>
       <dl>
         <dlentry>
-          <dt><xmlatt>ux-context-string</xmlatt></dt>
+          <dt id="attr-ux-context-string"><xmlatt>ux-context-string</xmlatt></dt>
           <dd>Specifies the value of a user-assistance context-string that is used to identify the
             topic.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>ux-source-priority</xmlatt></dt>
+          <dt id="attr-ux-source-priority"><xmlatt>ux-source-priority</xmlatt></dt>
           <dd>
             <p>Specifies precedence for handling <xmlelement>resourceid</xmlelement> definitions
               that exist in both a map and a topic. This attribute only is valid when used within a
@@ -81,7 +81,7 @@
           </dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>ux-windowref</xmlatt></dt>
+          <dt id="attr-ux-windowref"><xmlatt>ux-windowref</xmlatt></dt>
           <dd>References the <xmlatt>name</xmlatt> attribute on the
               <xmlelement>ux-window</xmlelement> element that is used to display the topic when
             called from a help API.</dd>

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -19,7 +19,7 @@
           keyref="attributes-common/dateatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="modified">
-          <dt><xmlatt>modified</xmlatt>
+          <dt id="attr-modified"><xmlatt>modified</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>The last modification date, entered as YYYY-MM-DD, where YYYY is the year, MM is the
             month from 01 to 12, and DD is the day from 01-31.</dd>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -36,7 +36,7 @@
             <dd/>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>type</xmlatt></dt>
+            <dt id="attr-type"><xmlatt>type</xmlatt></dt>
             <dd>Describes the target of a reference. For the <xmlelement>schemeref</xmlelement>
               element, this value defaults to "scheme", because the element is expected to point to
               another subject scheme.</dd>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -95,14 +95,14 @@
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt></dt>
+          <dt id="attr-name"><xmlatt>name</xmlatt></dt>
           <dd>Specifies the metadata item that the element represents. The default value is
             "sort-as". Specializations of <xmlelement>sort-as</xmlelement> can set the default value
             of the <xmlatt>name</xmlatt> attribute to reflect the tag name of the specialized
             element.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>value</xmlatt></dt>
+          <dt id="attr-value"><xmlatt>value</xmlatt></dt>
           <dd>Specifies the value of the metadata item. When the <xmlelement>sort-as</xmlelement>
             element has content and the <xmlatt>value</xmlatt> attribute is specified, the
               <xmlatt>value</xmlatt> attribute takes precedence. If the <xmlatt>value</xmlatt>

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -34,7 +34,7 @@
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>
         <dlentry id="href">
-          <dt><xmlatt>href</xmlatt></dt>
+          <dt id="attr-href"><xmlatt>href</xmlatt></dt>
           <dd>Provides a reference to a resource from which the present resource is derived. See
               <xref keyref="attributes-href"/> for detailed information on
             supported values and processing implications. </dd>

--- a/specification/langRef/base/state.dita
+++ b/specification/langRef/base/state.dita
@@ -15,12 +15,12 @@
         defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>name</xmlatt>
+          <dt id="attr-name"><xmlatt>name</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the name of the property whose state is being described.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>value</xmlatt>
+          <dt id="attr-value"><xmlatt>value</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the state of the property identified by the <xmlatt>name</xmlatt>
             attribute.</dd>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -43,7 +43,7 @@
           <dd/>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>toc</xmlatt></dt>
+          <dt id="attr-toc"><xmlatt>toc</xmlatt></dt>
           <dd>For this element, the default value for <xmlatt>toc</xmlatt> is "no". Otherwise, the
             definition matches the one found in <xref keyref="attributes-common/commonmapatts"
             />.</dd>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -41,7 +41,7 @@
         values are legal)?</draft-comment>
       <dl>
         <dlentry id="orient">
-          <dt><xmlatt>orient</xmlatt></dt>
+          <dt id="attr-orient"><xmlatt>orient</xmlatt></dt>
           <dd>Specifies the orientation of the table in page-based outputs. This attribute is
             primarily useful for print-oriented display. Allowable values are:<dl>
               <dlentry>
@@ -61,7 +61,7 @@
                 <xmlatt>orient</xmlatt> attribute can be ignored.</p></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>pgwide</xmlatt></dt>
+          <dt id="attr-pgwide"><xmlatt>pgwide</xmlatt></dt>
           <dd>Specifies the horizontal placement of the element. Supported values are 1 and 0,
             although these are not mandated by the DTD or RNG grammar files.<p>For print-oriented
               display, the value &quot;1&quot; places the element on the left page margin;

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -21,7 +21,7 @@
           <xmlatt>align</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>cols</xmlatt>
+          <dt id="attr-cols"><xmlatt>cols</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Indicates the number of columns in a <xmlelement>tgroup</xmlelement>.</dd>
         </dlentry>

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -13,7 +13,7 @@
         </metadata>
     </prolog>
     <refbody>
-        <section id="section_c2t_k5k_nnb">
+        <section id="usage-information">
             <title>Usage Information</title>
             <p>Alternative titles can be used in topics and in maps. When used directly beneath a
                 root <xmlelement>map</xmlelement> element, the alternative title applies to the map
@@ -32,7 +32,7 @@
                 <xmlelement>topicmeta</xmlelement>, since the element is not part of a publication's
                 navigational structure. Such alternate titles should be ignored by processors.</p>
         </section>
-        <section id="section_awx_mvk_nnb">
+        <section id="processing-expectations">
             <title>Processing expectations</title>
             <p>The processing of an alternative title depends on its roles. Processors are required
                 to support the following role tokens.</p>
@@ -87,7 +87,7 @@
             <p>Alternative titles bearing roles that are not recognized by the processor <keyword
                     outputclass="RFC-2119">MUST</keyword> be ignored and not appear in output.</p>
         </section>
-        <section id="section_pwf_1xk_nnb">
+        <section id="attributes">
             <title>Attributes</title>
             <p platform="lwdita">The following attributes are available on this element: <xref
                     keyref="attributes-universal"/>, <xref keyref="attributes-universal/class"
@@ -96,7 +96,7 @@
                 and the attributes listed below.</p>
             <dl>
                 <dlentry>
-                    <dt><xmlatt>title-role</xmlatt></dt>
+                    <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
                     <dd>Specifies the role or roles fulfilled by the alternative title. Multiple
                         roles are separated by white space.</dd>
                 </dlentry>

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -14,7 +14,7 @@
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>tmtype</xmlatt>
+          <dt id="attr-tmtype"><xmlatt>tmtype</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the trademark type. Allowable values are: <dl>
               <dlentry>
@@ -36,15 +36,15 @@
             </dl></dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>trademark</xmlatt></dt>
+          <dt id="attr-trademark"><xmlatt>trademark</xmlatt></dt>
           <dd>Specifies the trademarked term.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>tmowner</xmlatt></dt>
+          <dt id="attr-tmowner"><xmlatt>tmowner</xmlatt></dt>
           <dd>Specifies the trademark owner, for example &quot;OASIS&quot;.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>tmclass</xmlatt></dt>
+          <dt id="attr-tmclass"><xmlatt>tmclass</xmlatt></dt>
           <dd>Specifies the classification of the trademark. This can be used to differentiate
             different groupings of trademarks.</dd>
         </dlentry>

--- a/specification/langRef/base/vrm.dita
+++ b/specification/langRef/base/vrm.dita
@@ -18,7 +18,7 @@
                 below.</p>
             <dl>
                 <dlentry id="version">
-                    <dt><xmlatt>version</xmlatt>
+                    <dt id="attr-version"><xmlatt>version</xmlatt>
                         <ph
                             conkeyref="reuse-attributes/required-attr"
                         /></dt>
@@ -26,11 +26,11 @@
                         describes.</dd>
                 </dlentry>
                 <dlentry id="release">
-                    <dt><xmlatt>release</xmlatt></dt>
+                    <dt id="attr-release"><xmlatt>release</xmlatt></dt>
                     <dd>Specifies the product release identifier.</dd>
                 </dlentry>
                 <dlentry id="modification">
-                    <dt><xmlatt>modification</xmlatt></dt>
+                    <dt id="attr-modification"><xmlatt>modification</xmlatt></dt>
                     <dd>Specifies the modification level of the current version and release.</dd>
                 </dlentry>
             </dl>

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -52,7 +52,7 @@
       <p>The following attributes are available on this element:</p>
       <dl>
         <dlentry>
-          <dt><xmlatt>att</xmlatt></dt>
+          <dt id="attr-att"><xmlatt>att</xmlatt></dt>
           <dd>Specifies the attribute to be acted upon. If using a literal attribute name, it is
               <xmlatt>props</xmlatt> or a specialization of <xmlatt>props</xmlatt> (such as
               <xmlatt>audience</xmlatt>, <xmlatt>deliveryTarget</xmlatt>, <xmlatt>platform</xmlatt>,
@@ -63,13 +63,13 @@
             processing attribute.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>val</xmlatt></dt>
+          <dt id="attr-val"><xmlatt>val</xmlatt></dt>
           <dd>Specifies the attribute value to be acted upon. If the <xmlatt>val</xmlatt> attribute
             is absent, then the <xmlelement>prop</xmlelement> element declares a default behavior
             for any value in the specified attribute.</dd>
         </dlentry>
         <dlentry>
-          <dt><xmlatt>action</xmlatt>
+          <dt id="attr-action"><xmlatt>action</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the action to be taken. Allowable values are:<dl>
               <dlentry>

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -40,14 +40,14 @@
 <section id="attributes"><title>Attributes</title>
             <p>The following attributes are available on this element:<dl>
                     <dlentry>
-                        <dt><xmlatt>val</xmlatt></dt>
+                        <dt id="attr-val"><xmlatt>val</xmlatt></dt>
                         <dd>Specifies the revision value to be acted upon. If the
                                 <xmlatt>val</xmlatt> attribute is absent, then the
                                 <xmlelement>revprop</xmlelement> element declares a default behavior
                             for any value in the <xmlatt>rev</xmlatt> attribute.</dd>
                     </dlentry>
                     <dlentry>
-                        <dt><xmlatt>action</xmlatt>
+                        <dt id="attr-action"><xmlatt>action</xmlatt>
                             <ph conkeyref="reuse-attributes/required-attr"/></dt>
                         <dd>Specifies the action to be taken. Allowable values are:<dl>
                                 <dlentry>
@@ -75,7 +75,7 @@
                             </dl></dd>
                     </dlentry>
                     <dlentry>
-                        <dt><xmlatt>changebar</xmlatt></dt>
+                        <dt id="attr-changebar"><xmlatt>changebar</xmlatt></dt>
                         <dd>When flag has been set, specify a changebar color, style, or character,
                             according to the changebar support of the target output format. If the
                                 <xmlatt>action</xmlatt> attribute is not set to "flag", this

--- a/specification/langRef/ditaval/ditaval-style-conflict.dita
+++ b/specification/langRef/ditaval/ditaval-style-conflict.dita
@@ -63,12 +63,12 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <dl>
           <dlentry>
-            <dt><xmlatt>foreground-conflict-color</xmlatt></dt>
+            <dt id="attr-foreground-conflict-color"><xmlatt>foreground-conflict-color</xmlatt></dt>
             <dd>Specifies the color to be used when more than one flagging color applies to a single
               content element.</dd>
           </dlentry>
           <dlentry>
-            <dt><xmlatt>background-conflict-color</xmlatt></dt>
+            <dt id="attr-background-conflict-color"><xmlatt>background-conflict-color</xmlatt></dt>
             <dd>Specifies the color to be used when more than one flagging background color applies
               to a single content element.</dd>
           </dlentry>


### PR DESCRIPTION
* Fix broken relationship table key references around attributes
* Add IDs to definition terms that define attributes, as prep for automation around attribute links
* Normalize IDs in `titlealts` topic that used generate IDs instead of the standard ones