### PR TITLE
Clean up IDs and attribute lists in alt title elements

### DIFF
--- a/specification/common/reuse-w-lwdita/reuse-navtitle.dita
+++ b/specification/common/reuse-w-lwdita/reuse-navtitle.dita
@@ -22,11 +22,17 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-universal/class"
-            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
-            ><xmlatt>outputclass</xmlatt></xref>, and the <xmlatt>title-role</xmlatt> attribute set
-        to <codeph>navigation</codeph>.</p>
+      <div platform="dita">
+        <p>The following attributes are available on this element: <xref
+            keyref="attributes-universal"/> and the attribute listed below.</p>
+        <dl id="dl_w2g_qvq_lpb">
+          <dlentry>
+            <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+            <dd>Specifies the role or roles fulfilled by the alternative title. On this element the
+              value has a default value of <codeph>navigation</codeph>.</dd>
+          </dlentry>
+        </dl>
+      </div>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"

--- a/specification/langRef/base/linktitle.dita
+++ b/specification/langRef/base/linktitle.dita
@@ -12,7 +12,7 @@
       </keywords>
     </metadata></prolog>
 <refbody>
-    <section id="section_fpd_43h_rnb">
+    <section id="usage-information">
       <title>Usage information</title>
       <p>Link titles are alternative titles for use in cases where a hyperlink or cross-reference to
         a resource is generated based on relationships described by a DITA map. This includes, but
@@ -26,7 +26,7 @@
       </ul>
       <p>Processors may use this title for other custom linking scenarios.</p>
     </section>
-    <section id="section_jhh_njh_rnb">
+    <section id="processing-expectations">
       <title>Processing expectations</title>
       <p>The <xmlelement>linktitle</xmlelement> element is a specialization of
           <xmlelement>titlealt</xmlelement> with the <xmlatt>title-role</xmlatt> set to
@@ -42,9 +42,14 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
-          <xmlatt>title-role</xmlatt> attribute set to <codeph>linking</codeph>.</p>
+        /> and the attribute listed below.</p>
+      <dl id="dl_w2g_qvq_lpb">
+        <dlentry>
+          <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+          <dd>Specifies the role or roles fulfilled by the alternative title. On this element the
+            value has a default value of <codeph>linking</codeph>.</dd>
+        </dlentry>
+      </dl>
     </section>
 <example id="example" otherprops="examples"><title>Examples</title>
       <p>This section contains examples of how the <xmlelement>linktitle</xmlelement> element can be

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -36,9 +36,14 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
-          <xmlatt>title-role</xmlatt> attribute set to <codeph>navigation</codeph>.</p>
+        /> and the attribute listed below.</p>
+      <dl id="dl_w2g_qvq_lpb">
+        <dlentry>
+          <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+          <dd>Specifies the role or roles fulfilled by the alternative title. On this element the
+            value has a default value of <codeph>search</codeph>.</dd>
+        </dlentry>
+      </dl>
     </section>
 <example id="example" otherprops="examples"><title>Examples</title>
       <p>This section contains examples of how the <xmlelement>searchtitle</xmlelement> element can

--- a/specification/langRef/base/subtitle.dita
+++ b/specification/langRef/base/subtitle.dita
@@ -13,16 +13,16 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="section_fpd_43h_rnb">
+    <section id="usage-information">
       <title>Usage information</title>
       <p>Subtitles specify a subordinate title to be displayed alongside the title in certain
         display contexts.</p>
     </section>
-    <section id="section_jhh_njh_rnb">
+    <section id="processing-expectations">
       <title>Processing expectations</title>
       <p>The <xmlelement>subtitle</xmlelement> element is a specialization of
           <xmlelement>titlealt</xmlelement> with the <xmlatt>title-role</xmlatt> set to
-          <codeph>linking</codeph>. Processing is dictated by the rules for
+          <codeph>subtitle</codeph>. Processing is dictated by the rules for
           <xmlelement>titlealt</xmlelement>.</p>
     </section>
     <section id="specialization-hierachy">
@@ -34,9 +34,14 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
-          <xmlatt>title-role</xmlatt> attribute set to <codeph>subtitle</codeph>.</p>
+        /> and the attribute listed below.</p>
+      <dl id="dl_w2g_qvq_lpb">
+        <dlentry>
+          <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+          <dd>Specifies the role or roles fulfilled by the alternative title. On this element the
+            value has a default value of <codeph>subtitle</codeph>.</dd>
+        </dlentry>
+      </dl>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -89,11 +89,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-universal/class"
-                        ><xmlatt>class</xmlatt></xref>, <xref
-                    keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>,
-                and the attributes listed below.</p>
+            <p>The following attributes are available on this element: <xref
+                    keyref="attributes-universal"/> and the attribute listed below.</p>
             <dl>
                 <dlentry>
                     <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/titlehint.dita
+++ b/specification/langRef/base/titlehint.dita
@@ -13,13 +13,13 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="section_fpd_43h_rnb">
+    <section id="usage-information">
       <title>Usage information</title>
       <p>Title hints are intended to provide the title of referenced resources to map authors when
         the title may not be immediately accessible. It is not rendered as part of the
         publication.</p>
     </section>
-    <section id="section_jhh_njh_rnb">
+    <section id="processing-expectations">
       <title>Processing expectations</title>
       <p>The <xmlelement>titlehint</xmlelement> element is a specialization of
           <xmlelement>titlealt</xmlelement> with the <xmlatt>title-role</xmlatt> set to
@@ -35,9 +35,14 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
-          <xmlatt>title-role</xmlatt> attribute set to <codeph>hint</codeph>.</p>
+        /> and the attribute listed below.</p>
+      <dl id="dl_w2g_qvq_lpb">
+        <dlentry>
+          <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+          <dd>Specifies the role or roles fulfilled by the alternative title. On this element the
+            value has a default value of <codeph>hint</codeph>.</dd>
+        </dlentry>
+      </dl>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>


### PR DESCRIPTION
* Fixes default values in the spec for some of the elements
* Cleans up attribute section to drop `class` and `outputclass` which are part of universal attributes
* Uses standard IDs for standard sections