### PR TITLE
Fix typo in image attrs, add draft comment

### DIFF
--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -14,7 +14,12 @@
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref keyref="attributes-keyref"
-          ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
+          ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.<draft-comment
+          author="rodaande">This uses format/href/scope (but not type) from the linking group. Can
+          we list and link to those here rather than redefining them below? Is there any real
+          benefit to saying that the href on &lt;image> is a reference to an image, when it is
+          otherwise just a normal href? Not sure if this would impact the lwdita section
+          though.</draft-comment></p>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
@@ -51,7 +56,7 @@
           <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
           <dd>Indicates whether an image is displayed inline or on a separate line. The default
             value is inline. Allowable values are <keyword>inline</keyword>,
-              <keyword>break</keyword>, or and <xref keyref="attributes-useconreftarget"
+              <keyword>break</keyword>, and <xref keyref="attributes-useconreftarget"
               >"-dita-use-conref-target"</xref>.</dd>
         </dlentry>
         <dlentry platform="dita">


### PR DESCRIPTION
Fixes a typo, also adds a draft comment to remind us to sync up the attribute definitions with format/href/scope. Not actually making that change yet in case of impact on lwdita section of this reuse topic.