### PR TITLE
Fixing a typo

### DIFF
--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -77,7 +77,7 @@
         <dlentry platform="dita">
           <dt id="attr-scalefit"><xmlatt>scalefit</xmlatt></dt>
           <dd>Allows an image to be scaled up or down to fit within available space. Allowable
-            values are<keyword> yes</keyword>, <keyword>no</keyword>, and <xref
+            values are <keyword>yes</keyword>, <keyword>no</keyword>, and <xref
               keyref="attributes-useconreftarget">"-dita-use-conref-target"</xref>. If
               <xmlatt>height</xmlatt>, <xmlatt>width</xmlatt>, or <xmlatt>scale</xmlatt> is
             specified, those attributes determine the graphic size, and the
@@ -85,10 +85,10 @@
             specified and <codeph>scalefit="yes"</codeph>, then the image is scaled (the same factor
             in both dimensions) so that the graphic will just fit within the available height or
             width (whichever is more constraining). <p>The available width would be the prevailing
-              column (or table cell) width—that is, the width a paragraph of text would have if
-              the graphic were a paragraph instead. The available height is implementation
-              dependent, but if feasible, it is suggested to be the page (or table cell) height or
-              some other reasonable value. </p>
+              column (or table cell) width—that is, the width a paragraph of text would have if the
+              graphic were a paragraph instead. The available height is implementation dependent,
+              but if feasible, it is suggested to be the page (or table cell) height or some other
+              reasonable value. </p>
           </dd>
         </dlentry>
         <dlentry>


### PR DESCRIPTION
A space inside the `<keyword>` rather than outside resulted in some broken styling