### PR TITLE
Remove duplicate map entry for anchor element

### DIFF
--- a/specification/langRef/basic-map-elements.ditamap
+++ b/specification/langRef/basic-map-elements.ditamap
@@ -13,7 +13,6 @@
   <topicref keyref="elements-relcell" />
   <topicref keyref="elements-relheader" />
   <topicref keyref="elements-relcolspec" />
-  <topicref keyref="elements-anchor" />
   <topicref keyref="elements-keytext" />
  </topicref>
 </map>


### PR DESCRIPTION
The `<anchor>` element is listed twice in the element reference map, but should only be in there once. Removing the second instance.