### PR TITLE
Grammar changes for #33 remove copy-to

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -427,9 +427,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                keys
                           CDATA
                                     #IMPLIED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >

--- a/doctypes/dtd/base/mapGroup.mod
+++ b/doctypes/dtd/base/mapGroup.mod
@@ -65,9 +65,6 @@
               "keys
                           CDATA
                                     #IMPLIED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >
@@ -108,9 +105,6 @@
                           CDATA
                                     #IMPLIED
                keyscope
-                          CDATA
-                                    #IMPLIED
-               copy-to
                           CDATA
                                     #IMPLIED
                collection-type
@@ -181,9 +175,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                format
                           CDATA
                                     'ditamap'
@@ -212,9 +203,6 @@
                           CDATA
                                     #REQUIRED
                keyscope
-                          CDATA
-                                    #IMPLIED
-               copy-to
                           CDATA
                                     #IMPLIED
                collection-type

--- a/doctypes/dtd/base/metaDecl.mod
+++ b/doctypes/dtd/base/metaDecl.mod
@@ -452,6 +452,9 @@
                appid
                           CDATA
                                     #IMPLIED
+               appid-role
+                           CDATA
+                                     'context-sensitive-help'
                ux-context-string
                           CDATA
                                     #IMPLIED

--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -448,9 +448,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                collection-type
                           (choice |
                            family |
@@ -648,9 +645,6 @@
                           CDATA
                                     #IMPLIED
                keys
-                          CDATA
-                                    #IMPLIED
-               copy-to
                           CDATA
                                     #IMPLIED
                type

--- a/doctypes/rng/base/mapGroupDomain.rng
+++ b/doctypes/rng/base/mapGroupDomain.rng
@@ -114,9 +114,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
         <optional>
           <attribute name="keys"/>
         </optional>
-        <optional>
-          <attribute name="copy-to"/>
-        </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
       </define>
@@ -190,9 +187,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
         </optional>
         <optional>
           <attribute name="keyscope"/>
-        </optional>
-        <optional>
-          <attribute name="copy-to"/>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -301,9 +295,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
           <attribute name="keys"/>
         </optional>
         <optional>
-          <attribute name="copy-to"/>
-        </optional>
-        <optional>
           <attribute name="format" a:defaultValue="ditamap"/>
         </optional>
         <ref name="topicref-atts-without-format"/>
@@ -348,9 +339,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
         <attribute name="keys"/>
         <optional>
           <attribute name="keyscope"/>
-        </optional>
-        <optional>
-          <attribute name="copy-to"/>
         </optional>
         <optional>
           <attribute name="collection-type">

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -586,9 +586,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <optional>
           <attribute name="keys"/>
         </optional>
-        <optional>
-          <attribute name="copy-to"/>
-        </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
       </define>

--- a/doctypes/rng/base/metaDeclMod.rng
+++ b/doctypes/rng/base/metaDeclMod.rng
@@ -805,12 +805,16 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
           <attribute name="appid"/>
         </optional>
         <optional>
+          <attribute name="appid-role"
+            a:defaultValue="context-sensitive-help"
+            dita:since="2.0"/>
+        </optional>
+        <optional>
           <attribute name="ux-context-string"/>
         </optional>
         <optional>
           <attribute name="ux-source-priority"
-                     a:defaultValue="topic-and-map"
-            >
+                     a:defaultValue="topic-and-map">
             <choice>
               <value>topic-and-map</value>
               <value>topic-only</value>
@@ -828,8 +832,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       <define name="resourceid.element">
         <element name="resourceid" dita:longName="Resource Identifier">
           <a:documentation>The &lt;resourceid> element provides an identifier for applications that require them in a particular format, when the normal id attribute of the topic can't be used. Each
-            resourceid entry should be unique. It is one of the metadata elements that can be included within the prolog of a topic, along with document tracking and product information, etc. The
-            element has no content, but takes an id attribute, an appname attribute, and an appid attribute. Category: Prolog elements</a:documentation>
+            resourceid entry should be unique. It is one of the metadata elements that can be included within the prolog of a topic, along with document tracking and product information, etc.</a:documentation>
           <ref name="resourceid.attlist"/>
           <ref name="resourceid.content"/>
         </element>

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -687,9 +687,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
           <attribute name="keys"/>
         </optional>
         <optional>
-          <attribute name="copy-to"/>
-        </optional>
-        <optional>
           <attribute name="collection-type">
             <choice>
               <value>choice</value>
@@ -1020,9 +1017,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
         </optional>
         <optional>
           <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="copy-to"/>
         </optional>
         <optional>
           <attribute name="type"/>


### PR DESCRIPTION
Implements the DTD and RNG changes for #33, remove `@copy-to`