### PR TITLE
Cleanup and editing in element reference topics

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -323,26 +323,6 @@ of map.-->
                                                 <dd/>
                                         </dlentry>
                                 </dl>
-                        </sectiondiv><sectiondiv id="learningdomain-basic-topicref" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/> (with a
-                                        narrowed definition of <xmlatt>href</xmlatt>, given below),
-                                                <xref keyref="attributes-common/commonmapatts"/>, <xref
-                                                keyref="attributes-common/topicrefatts"/>, <xref
-                                                keyref="attributes-keys"
-                                                ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                keyref="attributes-keyref"
-                                                ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <dl>
-                                        <dlentry conref="#conref-attribute/href-on-topicref">
-                                                <dt/>
-                                                <dd/>
-                                        </dlentry>
-                                </dl>
-                        </sectiondiv><sectiondiv id="standard-topicmeta-attributes">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>.</p>
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>-->
                                 <p>The following attributes are available on this element: <xref

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -66,10 +66,13 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-s
                                         <xref keyref="attributes-universal"/> and <xref
                                         keyref="attributes-common/specentry"/>.</p><p id="universal-spectitle" platform="dita">The following attributes are available on this element:
                                         <xref keyref="attributes-universal"/> and <xref
-                                        keyref="attributes-common/spectitle"/>.</p><p id="universal-spectitle-compact" platform="dita">The following attributes are available on this
+                                        keyref="attributes-common/spectitle"
+                                                ><xmlatt>spectitle</xmlatt></xref>.</p><p id="universal-spectitle-compact" platform="dita">The following attributes are available on this
                                 element: <xref keyref="attributes-universal"/>, <xref
-                                        keyref="attributes-common/compact"/>, and <xref
-                                        keyref="attributes-common/spectitle"/>.</p><!--Used in <topic>, <concept>, etc.-->
+                                        keyref="attributes-common/compact"
+                                        ><xmlatt>compact</xmlatt></xref>, and <xref
+                                        keyref="attributes-common/spectitle"
+                                                ><xmlatt>spectitle</xmlatt></xref>.</p><!--Used in <topic>, <concept>, etc.-->
                         <sectiondiv id="topic-attributes">
                                 <p>The following attributes are available on this element: <xref
                                                 keyref="attributes-universal"/> (with a narrowed
@@ -146,28 +149,12 @@ element. The default value is the empty string "".</dd>
                         </sectiondiv><sectiondiv id="standard-topicref-attributes" platform="dita">
                                 <p>The following attributes are available on this element: <xref
                                                 keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/> (with a
-                                        narrowed definition of <xmlatt>href</xmlatt>, given below),
-                                                <xref keyref="attributes-common/commonmapatts"/>, <xref
-                                                keyref="attributes-common/topicrefatts"/>, <xref
+                                                keyref="attributes-common/linkatts"/>, <xref
+                                                keyref="attributes-common/commonmapatts"/>, <xref
                                                 keyref="attributes-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                                 keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <dl>
-                                        <dlentry id="href-on-topicref">
-                                                <dt id="attr-href-topicref"
-                                                  ><xmlatt>href</xmlatt></dt>
-                                                <dd>Specifies the referenced resource. See <xref
-                                                  keyref="attributes-href"/> for detailed
-                                                  information on supported values and processing
-                                                  implications.
-                                                  <!--References to DITA content cannot be below the topic level: that is, you cannot reference individual elements inside a topic. -->References
-                                                  to non-DITA content need to use the
-                                                  <xmlatt>format</xmlatt> attribute to identify the
-                                                  kind of resource.</dd>
-                                        </dlentry>
-                                </dl>
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes" platform="dita">
                                 <p>The following attributes are available on this element: <xref
                                                 keyref="attributes-universal"/>, <xref
@@ -652,7 +639,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                 <dlentry id="tablescope">
                                         <dt id="attr-scope-simpletable"><xmlatt>scope</xmlatt></dt>
                                         <dd>Specifies that the current entry is a header for other
-                                                table entries. Allowable values are:<dl>
+                                                table entries. The following values are valid:<dl>
                                                   <dlentry>
                                                   <dt><keyword>row</keyword></dt>
                                                   <dd>The current entry is a header for all cells in

--- a/specification/common/reuse-w-lwdita/reuse-desc.dita
+++ b/specification/common/reuse-w-lwdita/reuse-desc.dita
@@ -42,14 +42,15 @@
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
       <div platform="dita">
-        <p>When used in conjunction with <xmlelement>fig</xmlelement>  or
+        <p>When used in conjunction with <xmlelement>fig</xmlelement> or
             <xmlelement>table</xmlelement> elements, processors <term outputclass="RFC-2119"
             >SHOULD</term> consider the content of <xmlelement>desc</xmlelement> elements to be part
           of the content flow.</p>
+      </div>
+      <div platform="dita">
         <p>When used in conjunction with <xmlelement>xref</xmlelement> or
-            <xmlelement>link</xmlelement> elements, processors <term outputclass="RFC-2119"
-            >MAY</term> choose to render the content of <xmlelement>desc</xmlelement> elements as
-          hover help.</p>
+            <xmlelement>link</xmlelement> elements, processors often render the content of
+            <xmlelement>desc</xmlelement> elements as hover help or other form of link preview.</p>
       </div>
       <div platform="lwdita">
         <p>When used in conjunction with figures, processors <term outputclass="RFC-2119"

--- a/specification/common/reuse-w-lwdita/reuse-example.dita
+++ b/specification/common/reuse-w-lwdita/reuse-example.dita
@@ -2,8 +2,8 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="example" xml:lang="en-us">
 <title><xmlelement>example</xmlelement></title>
-  <shortdesc id="shortdesc">An example helps to illustrate the subject of the topic or a portion of
-    the topic.</shortdesc>
+  <shortdesc id="shortdesc">An example illustrates the subject of the topic or a portion of the
+    topic.</shortdesc>
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
@@ -11,6 +11,7 @@
         similar artifacts) and the discussion that illustrates the sample. For example, a topic
         about programming code could use the <xmlelement>example</xmlelement> element to contain
         both the sample code and the text that describes the code.</p>
+      <!--next para should probably be "Use the example" or "Use an example" rather than "Use example"?-->
       <p platform="lwdita">Use example component to contain both sample code (or similar artifacts)
         and the discussion that illustrates the sample. For example, a topic about programming code
         could use the example component to contain both the sample code and the text that describes

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -13,30 +13,24 @@
     <section id="attributes">
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-keyref"
-          ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.<draft-comment
-          author="rodaande">This uses format/href/scope (but not type) from the linking group. Can
-          we list and link to those here rather than redefining them below? Is there any real
-          benefit to saying that the href on &lt;image> is a reference to an image, when it is
-          otherwise just a normal href? Not sure if this would impact the lwdita section
-          though.</draft-comment></p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
-            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
-          ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
-            ><xmlatt>outputclass</xmlatt></xref>.</p>
+          keyref="attributes-universal"/>, <xref keyref="attributes-common/attr-href"/>, <xref
+          keyref="attributes-common/attr-format"/>, <xref keyref="attributes-common/attr-scope"/>,
+          <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
+        defined below.</p>
+      <p platform="lwdita"><draft-comment author="robander">href, format, and scope were moved from
+          the DL (marked for both lwdita and dita) into the paragraph above for full DITA; not sure
+          if they apply to lwdita, if so, the three should be listed here as
+        well.</draft-comment>The following attributes are available on this element: <xref
+          keyref="attributes-universal/localizationatts"/>, <xref
+          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       <dl>
         <dlentry platform="dita">
           <dt id="attr-align"><xmlatt>align</xmlatt></dt>
           <dd>Controls the horizontal alignment of an image when <xmlatt>placement</xmlatt> is
             specified as <keyword>break</keyword>. Common values include <keyword>left</keyword>,
               <keyword>right</keyword>, and <keyword>center</keyword>.</dd>
-        </dlentry>
-        <dlentry id="format">
-          <dt id="attr-format"><xmlatt>format</xmlatt></dt>
-          <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->Identifies
-            the format of the resource that is referenced. See <xref keyref="attributes-format"/>
-            for details on supported values.</dd>
         </dlentry>
         <dlentry>
           <dt id="attr-height"><xmlatt>height</xmlatt></dt>
@@ -46,11 +40,6 @@
             centimeters, millimeters, and ems respectively). The default unit is px (pixels).
             Example values include <keyword>5</keyword>, <keyword>5in</keyword>, and
               <keyword>10.5cm</keyword>. </dd>
-        </dlentry>
-        <dlentry>
-          <dt id="attr-href"><xmlatt>href</xmlatt></dt>
-          <dd>Provides a reference to the image. See <xref keyref="attributes-href"/> for detailed
-            information on supported values and processing implications.</dd>
         </dlentry>
         <dlentry platform="dita">
           <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
@@ -90,14 +79,6 @@
               but if feasible, it is suggested to be the page (or table cell) height or some other
               reasonable value. </p>
           </dd>
-        </dlentry>
-        <dlentry>
-          <dt id="attr-scope"><xmlatt>scope</xmlatt></dt>
-          <dd>Identifies the closeness of the relationship between the current document and the
-            target resource. Allowable values are <keyword>local</keyword>, <keyword>peer</keyword>,
-              <keyword>external</keyword>, and <xref keyref="attributes-useconreftarget"
-              >"-dita-use-conref-target"</xref>. See <xref keyref="attributes-scope"/> for more
-            information on values.</dd>
         </dlentry>
         <dlentry>
           <dt id="attr-width"><xmlatt>width</xmlatt></dt>

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -28,8 +28,7 @@
             keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
           narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
             keyref="attributes-common/commonmapatts"/> (with a narrowed definition of
-            <xmlatt>processing-role</xmlatt>, given below), <xref
-            keyref="attributes-common/topicrefatts"/>, <xref keyref="attributes-keyref"
+            <xmlatt>processing-role</xmlatt>, given below), <xref keyref="attributes-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
         <p platform="lwdita">The following attributes are available on this element: <xref
             keyref="attributes-common/linkatts"/> (with a narrowed definition of

--- a/specification/common/reuse-w-lwdita/reuse-linktext.dita
+++ b/specification/common/reuse-w-lwdita/reuse-linktext.dita
@@ -6,16 +6,17 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <!--<draft-comment author="robander" audience="spec-editors" time="2018"><p>This usage information needs to be entirely reworked. It currently contains processing information, tutorial information, and also ignores the fact that link text is now often used for text within a key definition (that does not actually specify a link).</p><p>Additionally: it says to use this ONLY when (x, y, or z); implying that it is incorrect to use link text for links to local topics.</p></draft-comment>-->
-      <!--<p>For links to local DITA topics, the text of a link typically can be resolved during processing. Use the <xmlelement>linktext</xmlelement> element only when the target cannot be reached, such as when it is a peer or external link, or when the target is local but not in DITA format. When used inside of a <xmlelement>link</xmlelement> element inside a topic, <xmlelement>linktext</xmlelement> is used as the text for the specified link; when used within a map, <xmlelement>linktext</xmlelement> is used as the text for generated links that refer to the specified topic.</p>-->
-      <p>The <xmlelement>linktext</xmlelement> element can provide descriptive text for a link when
-        the target cannot be resolved during processing, for example, as when the link is to a peer,
-        external, or non-DITA resource. When used in conjunction with a local DITA resource, the
-        content of the <xmlelement>linktext</xmlelement> is used as a label for the generated
-        link.</p>
-      <draft-comment author="Kristen J Eberlein" time="31 October 2020">
-        <p>Is the above correct and adequately resolves your draft comment from 2018?</p>
-      </draft-comment>
+      <p>The <xmlelement>linktext</xmlelement> element provides descriptive text for a link. It is
+        most commonly used when the target cannot be resolved during processing or when a title for
+        the reference cannot be determined by a processor. For example, link text might be required
+        when the link is to a peer, external, or non-DITA resource.</p>
+    </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <draft-comment author="robander" time="14 May 2021">Pulled this from the "usage" section to
+        have a clearer rendering statement, but it needs editing.</draft-comment>
+      <p>For processors that can automatically retrieve link text from a target, a specified
+          <xmlelement>linktext</xmlelement> element is used instead of the retrieved link text.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/common/reuse-w-lwdita/reuse-map.dita
+++ b/specification/common/reuse-w-lwdita/reuse-map.dita
@@ -53,13 +53,16 @@
       <title>Attributes</title>
       <sectiondiv>
         <p platform="dita">The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> (with a narrowed definition of <xmlatt>id</xmlatt>,
-          given below), <xref keyref="attributes-common/commonmapatts"/>, <xref
-            keyref="attributes-common/architecturalatts"/>, and the attributes defined below. This element also
-          uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt> from <xref
-            keyref="attributes-common/linkatts"/>.</p>
+            keyref="attributes-universal"/>, <xref keyref="attributes-common/commonmapatts"/>, <xref
+            keyref="attributes-common/architecturalatts"/>, <xref
+            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, and the attribute
+          defined below.</p>
         <p platform="lwdita">The following attributes are available on this element: <xref
-            keyref="attributes-common/architecturalatts"/>, <xref keyref="attributes-universal/localizationatts"/>, <xref
+            keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <xref
+            keyref="attributes-common/architecturalatts"/>, <xref
+            keyref="attributes-universal/localizationatts"/>, <xref
             keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
             keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
           attribute defined below.</p>
@@ -72,12 +75,6 @@
               the map with <xmlatt>anchorref</xmlatt> to be pulled into the location of the anchor
               point "a1" inside <filepath>map1.ditamap</filepath> when
                 <filepath>map1.ditamap</filepath> is rendered for delivery.</dd>
-          </dlentry>
-          <dlentry id="map-attribute-id">
-            <dt id="attr-id"><xmlatt>id</xmlatt></dt>
-            <dd>Allows an ID to be specified for the map. Note that maps do not require IDs (unlike
-              topics), and the map ID is not included in references to elements within a map. This
-              attribute is defined with the XML Data Type ID.</dd>
           </dlentry>
         </dl>
       </sectiondiv>

--- a/specification/common/reuse-w-lwdita/reuse-shortdesc.dita
+++ b/specification/common/reuse-w-lwdita/reuse-shortdesc.dita
@@ -8,11 +8,11 @@
     <section id="usage-information">
       <title>Usage information</title>
 
-      <p>When present in topics, the short description is the first paragraph of the topic. It also
-        is used for link previews and search results.</p>
+      <p platform="lwdita">When present in topics, the short description is the first paragraph of
+        the topic. It can also be used for link previews and search results.</p>
       <div platform="dita">
-        <p>When present in topics, the short description is the first paragraph of the topic. It
-          also is used for link previews and search results.</p>
+        <p>When present in topics, the short description is the first paragraph of the topic. It can
+          also be used for link previews and search results.</p>
         <p>When present in maps, the <xmlelement>shortdesc</xmlelement> element is associated with
             <xmlelement>topicref</xmlelement> elements. This enables map authors to accomplish the
           following goals:</p>
@@ -24,8 +24,6 @@
         <p>When a <xmlelement>shortdesc</xmlelement> element applies to an entire DITA map, it
           serves as description only.</p>
       </div>
-      <p platform="lwdita">When present in topics, the short description is the first paragraph of
-        the topic. It also is used for link previews and search results.</p>
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>

--- a/specification/common/reuse-w-lwdita/reuse-simpletable.dita
+++ b/specification/common/reuse-w-lwdita/reuse-simpletable.dita
@@ -29,7 +29,7 @@
       <p platform="dita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref keyref="attributes-common/displayatts"/>, <xref
           keyref="attributes-common/simpletableatts"/>, and <xref
-          keyref="attributes-common/spectitle"/>.</p>
+          keyref="attributes-common/spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-stentry.dita
+++ b/specification/common/reuse-w-lwdita/reuse-stentry.dita
@@ -8,8 +8,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"/>, and
-        the attributes defined below.</p>
+          keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+            ><xmlatt>specentry</xmlatt></xref>, and the attributes defined below.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/> and the attributes defined below.</p>
       <dl>

--- a/specification/common/reuse-w-lwdita/reuse-topic.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topic.dita
@@ -7,24 +7,15 @@
   <section id="attributes">
    <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (with a narrowed definition of <xmlatt>id</xmlatt>, given
-        below) and <xref keyref="attributes-common/architecturalatts"/>.</p>
+          keyref="attributes-universal"/> and <xref keyref="attributes-common/architecturalatts"
+        />.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-common/architecturalatts"/>, <xref keyref="attributes-universal/localizationatts"/>, <xref
+          keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <xref
+          keyref="attributes-common/architecturalatts"/>, <xref
+          keyref="attributes-universal/localizationatts"/>, and <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
-        attribute defined below.</p>
-      <dl>
-        <dlentry id="topic-id">
-          <dt id="attr-id"><xmlatt>id</xmlatt>
-            <ph>(REQUIRED)</ph></dt>
-          <dd>Provides an anchor point. This ID is usually required as part of the
-              <xmlatt>href</xmlatt> or <xmlatt>conref</xmlatt> syntax when cross referencing or
-            reusing content within the topic; it also enables <xmlelement>topicref</xmlelement>
-            elements in DITA maps to optionally reference a specific topic within a DITA document.
-              <ph>This attribute is defined with the XML Data Type ID.</ph></dd>
-        </dlentry>
-      </dl>
+          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
+      <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required.</p>
   </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -12,9 +12,9 @@
       <p platform="dita">The following attributes are available on this element: <xref
           keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
         narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-          keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-common/topicrefatts"/>, <xref
-          keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-keys"
+            ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-keyref"
+            ><xmlatt>keyref</xmlatt></xref>.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
           keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-universal/idatts"/>, <xref keyref="attributes-common/linkatts"/>
         (with a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
@@ -23,6 +23,10 @@
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
+      <draft-comment author="robander" time="15 May 2021">Would like to convert this into an
+        attribute-exception paragraph, reminding that topicref is meant to refer to topic-level
+        elements, but before doing that, need to make sure the href topic is updated with the same
+        info in arch spec.</draft-comment>
       <dl>
         <dlentry id="href-on-topicref">
           <dt id="attr-href"><xmlatt>href</xmlatt></dt>

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -24,9 +24,6 @@
 <refbody>
 		<section id="usage-information">
 			<title>Usage information</title>
-			<p>The <xmlelement>abstract</xmlelement> element cannot be overridden by maps, but its
-				contained <xmlelement>shortdesc</xmlelement> elements can be, for the purpose of
-				creating link summaries or previews.</p>
 			<p>Use the <xmlelement>abstract</xmlelement> element when the initial paragraph of a
 				topic is unsuitable for use as a link preview or for summaries, because, for
 				example, it contains lists or tables, or because only a portion of the paragraph is
@@ -41,6 +38,9 @@
 		</section>
 		<section id="processing-expectations">
 			<title>Processing expectations</title>
+			<draft-comment author="robander" time="13 May 2021">Should discuss how to describe link
+				previews; they are not a given (they depend entirely on output format, and the spec
+				cannot / should not madate that even in HTML you must use them.</draft-comment>
 			<p>When the contained <xmlelement>shortdesc</xmlelement> occurs within phrase-level
 				content, it is treated as phrase-level content and should not create a separate
 				paragraph on output of the topic. When the contained

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -35,27 +35,27 @@
 				portions of the <xmlelement>abstract</xmlelement> content as useful for previews or
 				summaries by embedding the <xmlelement>shortdesc</xmlelement> element within
 					<xmlelement>abstract</xmlelement>.</p>
-		</section>
-		<section id="processing-expectations">
-			<title>Processing expectations</title>
-			<draft-comment author="robander" time="13 May 2021">Should discuss how to describe link
-				previews; they are not a given (they depend entirely on output format, and the spec
-				cannot / should not madate that even in HTML you must use them.</draft-comment>
-			<p>When the contained <xmlelement>shortdesc</xmlelement> occurs within phrase-level
+			<p>When a contained <xmlelement>shortdesc</xmlelement> occurs within phrase-level
 				content, it is treated as phrase-level content and should not create a separate
 				paragraph on output of the topic. When the contained
 					<xmlelement>shortdesc</xmlelement> occurs as a peer to paragraph-level content,
 				it is treated as block-level content and should create a separate paragraph on
 				output of the topic. When multiple <xmlelement>shortdesc</xmlelement> elements are
-				included in an <xmlelement>abstract</xmlelement>, they are concatenated in output of
-				link previews or summaries (separated by spaces).</p>
+				included in an <xmlelement>abstract</xmlelement>, they are meant to be concatenated
+				when used for link previews or or link summaries (separated by spaces).</p>
+		</section>
+		<section id="processing-expectations">
+			<title>Processing expectations</title>
+			<draft-comment author="robander" time="14 May 2021">It feels like the following
+				paragraph does not belong here, it is entirely about how to process shortdesc rather
+				than abstract</draft-comment>
 			<p id="1.2.1">When a <xmlelement>shortdesc</xmlelement> element occurs in a DITA map, it
 				overrides the short description provided in the topic for the purpose of generating
-				link previews, but does not replace the <xmlelement>shortdesc</xmlelement> in the
-				rendered topic itself. This means that generated links to this topic will use the
-				short description from the map for purposes any link previews provided with the
-				link, while the rendered topic continues to use the short description inside the
-				topic.</p>
+				map-based link previews. It does not replace the <xmlelement>shortdesc</xmlelement>
+				in the rendered topic itself. This means that generated map-based links to this
+				topic will use the short description from the map for purposes any link previews
+				provided with the link, while the rendered topic continues to use the short
+				description inside the topic.</p>
 		</section>
 		<section id="attributes">
 			<title>Attributes</title>

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -4,8 +4,7 @@
 <reference id="anchor" xml:lang="en-us">
 <title><xmlelement>anchor</xmlelement></title>
 <shortdesc>An anchor within a map is an integration point that another map can reference in order to
-    insert its navigation into the referenced map's navigation
-    tree.<!--For those familiar with Eclipse help systems, this serves the same purpose as the <xmlelement>anchor</xmlelement> element in that system.--></shortdesc>
+    insert its navigation into the referenced map's navigation tree.</shortdesc>
 <prolog><metadata>
 <keywords><indexterm>elements<indexterm>basic map<indexterm><xmlelement>anchor</xmlelement></indexterm></indexterm></indexterm>
 </keywords>
@@ -26,19 +25,11 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (with a narrowed definition of
-          <xmlatt>id</xmlatt>, given below).</p>
-      <dl>
-        <dlentry>
-          <dt id="attr-id"><xmlatt>id</xmlatt>
-            <ph conkeyref="reuse-attributes/required-attr"/></dt>
-          <dd>Provides an integration point that another map <ph>can</ph> reference in order to
-            insert its navigation into the current navigation tree. The <xmlatt>anchorref</xmlatt>
-            attribute on a map <ph>can</ph> be used to reference this attribute. See <xref
-              href="../../archSpec/base/id.dita"/> for more details.</dd>
-        </dlentry>
-      </dl>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />.</p>
+      <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required. It is
+        referenced by <xmlelement>anchorref</xmlelement> or by the <xmlatt>anchorref</xmlatt>
+        attribute on <xmlelement>map</xmlelement> elements.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p id="anchor_ex">The following code sample shows how a map creates an

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -32,8 +32,8 @@
         <section id="rendering-expectations">
             <title>Rendering expectations</title>
             <p>When possible, the content of the <xmlelement>anchorref</xmlelement> element is
-                rendered when  the map with <xmlelement>anchor</xmlelement> element is displayed in
-                an authoring tool.</p>
+                rendered at the referenced anchor when the map with that
+                    <xmlelement>anchor</xmlelement> element is displayed in an authoring tool.</p>
         </section>
         <section id="processing-expectations">
             <title>Processing expectations</title>
@@ -63,31 +63,18 @@
             <sectiondiv id="standard-topicref-attributes">
                 <p>The following attributes are available on this element: <xref
                         keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"
-                    /> (with narrowed definitions of <xmlatt>href</xmlatt>, <xmlatt>type</xmlatt>,
-                    and <xmlatt>format</xmlatt>, all given below), <xref
-                        keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-common/topicrefatts"
-                    />, <xref keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+                    />, <xref keyref="attributes-common/commonmapatts"/>, <xref
+                        keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
-                <dl>
-                    <dlentry>
-                        <dt id="attr-href"><xmlatt>href</xmlatt></dt>
-                        <dd>Specifies an <xmlelement>anchor</xmlelement> element in this or another
-                            DITA map. When rendered, the contents of the current element are copied
-                            to the location of the <xmlelement>anchor</xmlelement> element. See
-                                <xref keyref="attributes-href"/> for the syntax to use when
-                            referencing a map element.</dd>
-                    </dlentry>
-                    <dlentry>
-                        <dt id="attr-type"><xmlatt>type</xmlatt></dt>
-                        <dd>Specifies the type of the referenced resource. By default, this is set
-                            to <keyword>anchor</keyword>.</dd>
-                    </dlentry>
-                    <dlentry>
-                        <dt id="attr-format"><xmlatt>format</xmlatt></dt>
-                        <dd>Specifies the format of the referenced resource. By default, this is set
-                            to <keyword>ditamap</keyword>.</dd>
-                    </dlentry>
-                </dl>
+                <p id="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
+                        <li>The <xmlatt>href</xmlatt> attribute refers to an
+                                <xmlelement>ancho</xmlelement> element in this or another DITA
+                            map.</li>
+                        <li>The <xmlatt>format</xmlatt> attribute has a default value of
+                                <keyword>ditamap</keyword>.</li>
+                        <li>The <xmlatt>type</xmlatt> attribute has a default value of
+                                <keyword>anchor</keyword>.</li>
+                    </ul></p>
             </sectiondiv>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -25,19 +25,12 @@
                     keyref="attributes-universal/outputclass"/>, <xref
                     keyref="attributes-universal/class"/>, and the
                 attributes defined below.</p>
-            <dl>
-                <dlentry>
-                    <dt id="attr-name"><xmlatt>name</xmlatt>
-                        <ph
-                            conkeyref="reuse-attributes/required-attr"
-                        /></dt>
-                    <dd>Specifies the attribute that is bound to a set of enumerated values</dd>
-                </dlentry>
-                <dlentry conkeyref="reuse-attributes/translate-NO">
-                    <dt/>
-                    <dd/>
-                </dlentry>
-            </dl>
+            <p id="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
+                    <li>The <xmlatt>name</xmlatt> attribute is required, and specifies the name of
+                        an attribute that will take a set of enumerated values.</li>
+                    <li>The <xmlatt>translate</xmlatt> attribute has a default value of
+                            <keyword>no</keyword>.</li>
+                </ul></p>
         </section>
 <example id="example" otherprops="examples"><title>Example</title>
             <p>In the following code sample, the enumeration definition for the

--- a/specification/langRef/base/audio.dita
+++ b/specification/langRef/base/audio.dita
@@ -11,10 +11,7 @@
       </keywords>
     </metadata>
   </prolog>
-  <refbody><section id="attr-href">add href id</section><section id="attr-keyref">
-    <title>add keyref id</title>
-    <p></p>
-  </section>
+  <refbody>
     <section conkeyref="reuse-audio/usage-information" id="usage-information"><title/><p/></section>
     <section conkeyref="reuse-audio/rendering-expectations" id="rendering-expectations"
       ><title/><p/></section>

--- a/specification/langRef/base/bodydiv.dita
+++ b/specification/langRef/base/bodydiv.dita
@@ -18,13 +18,12 @@
       <title>Usage information</title>
       <p>The <xmlelement>bodydiv</xmlelement> element cannot contain a title. If a title is
         required, use nested topics.</p>
-      <p>The <xmlelement>bodydiv</xmlelement> element can nest itself, so it can be used as a
-        specialization base. Another common use case for the <xmlelement>bodydiv</xmlelement>
-        element is to group a sequence of related elements for reuse, so that another topic can
-        reference the entire set with a single <xmlatt>conref</xmlatt> or <xmlatt>conkeyref</xmlatt>
-        attribute.</p>
-      <p>Because the <xmlelement>bodydiv</xmlelement> element allows
-          <xmlelement>section</xmlelement>, it cannot be used within
+      <p>The <xmlelement>bodydiv</xmlelement> element is often used to group a sequence of related
+        elements for reuse, so that another topic can reference the entire set with a single
+          <xmlatt>conref</xmlatt> or <xmlatt>conkeyref</xmlatt> attribute.</p>
+      <p>The <xmlelement>bodydiv</xmlelement> element can nest itself, which makes it a good
+        specialization base for general topic content. Because the <xmlelement>bodydiv</xmlelement>
+        element allows <xmlelement>section</xmlelement>, it cannot be used within
           <xmlelement>section</xmlelement> elements. Use the <xmlelement>div</xmlelement> element to
         group content that might occur in both topic bodies and sections.</p>
     </section>

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="cite" xml:lang="en-us">
 <title><xmlelement>cite</xmlelement></title>
-<shortdesc>A citation indicates the title of a bibliographic resource. </shortdesc>
+<shortdesc>A citation is the name or the title of a bibliographic resource. </shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>citations</indexterm><indexterm>elements<indexterm>body<indexterm><xmlelement>cite</xmlelement></indexterm></indexterm></indexterm>

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -15,16 +15,19 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (without the Metadata attribute group),
-          <xmlatt>base</xmlatt> from the <xref keyref="attributes-universal/metadataatts"/>, and the attributes
-        defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
-          <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"
+            ><xmlatt>base</xmlatt></xref>, <xref keyref="attributes-common/attr-align"
+            ><xmlatt>align</xmlatt></xref>, <xref keyref="attributes-common/attr-char"
+            ><xmlatt>char</xmlatt></xref>, <xref keyref="attributes-common/attr-charoff"
+            ><xmlatt>charoff</xmlatt></xref>, <xref keyref="attributes-common/attr-colsep"
+            ><xmlatt>colsep</xmlatt></xref>, <xref keyref="attributes-common/attr-rowsep"
+            ><xmlatt>rowsep</xmlatt></xref>, <xref keyref="attributes-common/attr-rowheader"
+            ><xmlatt>rowheader</xmlatt></xref> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-colnum"><xmlatt>colnum</xmlatt></dt>
-          <dd>Indicates the number of a column in the table, counting from the first logical column
+          <dd>Specifies the number of a column in the table, counting from the first logical column
             to the last column.</dd>
         </dlentry>
         <dlentry>
@@ -35,7 +38,7 @@
         </dlentry>
         <dlentry>
           <dt id="attr-colwidth"><xmlatt>colwidth</xmlatt></dt>
-          <dd>Describes the column width.</dd>
+          <dd>Specifies the column width.</dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -7,16 +7,16 @@
       <p>This topic should be removed from the base spec and added to the tech comm spec. It should
         include info about use cases (and maybe when to use ditabase, and when to NOT use
         ditabase.)</p>
-    </draft-comment><draft-comment author="robander" time="13 May 2021">I believe this cannot be
-      moved to tech comm because it is a base element; otherwise a set of specializations would end
-      up defining a wrapper element that is not valid DITA (not a base element and not a
+    </draft-comment><draft-comment author="robander" time="13 May 2021">This cannot be moved to tech
+      comm because it is a base element; otherwise a set of specializations would end up defining a
+      wrapper element that is not valid DITA (not a base element and not a
       specialization).</draft-comment></shortdesc>
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The <xmlelement>dita</xmlelement> element can contain any sequence of topics, and the
-        ditabase document type enables these topic types to nest.</p>
-      <p>The <xmlelement>dita</xmlelement> element cannot be specialized.</p>
+      <p>The <xmlelement>dita</xmlelement> element cannot be specialized. It is provided as a
+        container that can manage any sequence any type of topic. Topic nesting rules can be
+        configured in the document type shell.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/div.dita
+++ b/specification/langRef/base/div.dita
@@ -16,8 +16,8 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The <xmlelement>div</xmlelement> element is useful primarily as a specialization base and
-        for reuse.</p>
+      <p>The <xmlelement>div</xmlelement> element often is useful for reuse or as a specialization
+        base.</p>
       <!--<p>The <xmlelement>div</xmlelement> element cannot contain a title. This avoids enabling the creation of deeply-nested content that would otherwise be written as separate topics. If the content requires a title, use a <xmlelement>section</xmlelement> element, a nested <xmlelement>topic</xmlelement>, or possibly a <xmlelement>fig</xmlelement> element.</p>-->
     </section>
     <section id="attributes">

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -23,10 +23,10 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (with a narrowed definition for
-          <xmlatt>translate</xmlatt>, given below) and the attributes
-        defined below.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> and the attributes defined below.</p>
+      <p id="attr-exception">For this element, the <xmlatt>translate</xmlatt> attribute has a
+        default value of <keyword>no</keyword>.</p>
       <dl>
         <dlentry id="author">
           <dt id="attr-author"><xmlatt>author</xmlatt></dt>
@@ -39,11 +39,6 @@
         <dlentry id="time">
           <dt id="attr-time"><xmlatt>time</xmlatt></dt>
           <dd>Specifies when the draft comment was created.</dd>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/translate-NO"
-          id="translate">
-          <dt/>
-          <dd/>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -17,22 +17,19 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal/idatts"/>, <xmlatt>status</xmlatt> and
-          <xmlatt>base</xmlatt> from <xref keyref="attributes-universal/metadataatts"
-          />, <xref keyref="attributes-universal/outputclass"/>, <xref
-          keyref="attributes-universal/class"/>, and the attributes
-        defined below.</p>
-      <dl>
-        <dlentry>
-          <dt id="attr-name"><xmlatt>name</xmlatt>
-            <ph conkeyref="reuse-attributes/required-attr"/></dt>
-          <dd>Specifies the element to which the set of controlled values are bound </dd>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/translate-NO">
-          <dt/>
-          <dd/>
-        </dlentry>
-      </dl>
+          keyref="attributes-universal/idatts"/>, <xref keyref="attributes-universal/attr-status"
+            ><xmlatt>status</xmlatt></xref>, <xref keyref="attributes-universal/attr-base"
+            ><xmlatt>base</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
+            ><xmlatt>outputclass</xmlatt></xref>, <xref keyref="attributes-universal/attr-translate"
+            ><xmlatt>translate</xmlatt></xref>, <xref keyref="attributes-universal/class"
+            ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-common/attr-name"
+            ><xmlatt>name</xmlatt></xref>.</p>
+      <p id="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
+          <li>The <xmlatt>name</xmlatt> attribute is required, and specifies the name of an element
+            to which controlled attribute values are bound.</li>
+          <li>The <xmlatt>translate</xmlatt> attribute has a default value of
+            <keyword>no</keyword>.</li>
+        </ul></p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In this example, the <xmlatt>type</xmlatt> attribute for the <xmlelement>note</xmlelement>
         element is bound to the specified set of values. Processors should limit the values for the

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -14,18 +14,15 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (without the Metadata attribute group),
-          <xmlatt>base</xmlatt> and <xmlatt>rev</xmlatt> from the <xref
-          keyref="attributes-universal/metadataatts"/>, and the attributes
-        defined below. This element also uses <xmlatt>align</xmlatt>, <xmlatt>char</xmlatt>,
-          <xmlatt>charoff</xmlatt>, <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>valign</xmlatt> from the <xref keyref="attributes-common/complextableatts"
-        />.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      /> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>,
+        <xref keyref="attributes-universal/attr-rev"><xmlatt>rev</xmlatt></xref>, <xref keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref>, <xref keyref="attributes-common/attr-char"><xmlatt>char</xmlatt></xref>,
+        <xref keyref="attributes-common/attr-charoff"><xmlatt>charoff</xmlatt></xref>, <xref keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>,
+        <xref keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, and <xref keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>, and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-rotate"><xmlatt>rotate</xmlatt></dt>
-          <dd>Specifies whether the contents of the entry is rotated. Supported values are:<dl>
+          <dd>Specifies whether the contents of the entry is rotated. The following values are valid:<dl>
               <dlentry>
                 <dt>1</dt>
                 <dd>The contents of the cell are rotated 90 degrees counterclockwise.</dd>
@@ -44,24 +41,20 @@
         </dlentry>
         <dlentry>
           <dt id="attr-colname"><xmlatt>colname</xmlatt></dt>
-          <dd>Specifies the column name in which an entry is found. <ph>The value is a reference to
-              the <xmlatt>colname</xmlatt> attribute on the <xmlelement>colspec</xmlelement>
-              element.</ph>
-          </dd>
+          <dd>Specifies the column name in which an entry is found. The value is a reference to the
+              <xmlatt>colname</xmlatt> attribute on the <xmlelement>colspec</xmlelement> element. </dd>
         </dlentry>
         <dlentry>
           <dt id="attr-namest"><xmlatt>namest</xmlatt></dt>
-          <dd>Specifies the first logical column that is included in a horizontal span. <ph>The
-              value is a reference to the <xmlatt>colname</xmlatt> attribute on the
-                <xmlelement>colspec</xmlelement> element.</ph>
-          </dd>
+          <dd>Specifies the first logical column that is included in a horizontal span. The value is
+            a reference to the <xmlatt>colname</xmlatt> attribute on the
+              <xmlelement>colspec</xmlelement> element. </dd>
         </dlentry>
         <dlentry>
           <dt id="attr-nameend"><xmlatt>nameend</xmlatt></dt>
-          <dd>Specifies the last logical column that is included in a horizontal span. <ph>The value
-              is a reference to the <xmlatt>colname</xmlatt> attribute on the
-                <xmlelement>colspec</xmlelement> element.</ph>
-          </dd>
+          <dd>Specifies the last logical column that is included in a horizontal span. The value is
+            a reference to the <xmlatt>colname</xmlatt> attribute on the
+              <xmlelement>colspec</xmlelement> element. </dd>
         </dlentry>
         <dlentry>
           <dt id="attr-morerows"><xmlatt>morerows</xmlatt></dt>

--- a/specification/langRef/base/fallback.dita
+++ b/specification/langRef/base/fallback.dita
@@ -15,7 +15,7 @@
     <section id="processing-expectations">
       <title>Processing expectations</title>
       <p>The contents of this element are displayed only when the media that is referenced by the
-        containing element cannot be displayed.</p>
+        containing element cannot be displayed or viewed.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/figgroup.dita
+++ b/specification/langRef/base/figgroup.dita
@@ -2,11 +2,7 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="figgroup" xml:lang="en-us">
 <title><xmlelement>figgroup</xmlelement></title>
-<shortdesc>A figure group organizes segments within a figure.<draft-comment
-      author="Kristen J Eberlein" time="09 September 2020">
-      <p>Should this topic be located here in "Body elements," or should it be relocated to
-        "Specialization elements?</p>
-    </draft-comment></shortdesc>
+<shortdesc>A figure group organizes segments within a figure.</shortdesc>
 <prolog><metadata>
 <keywords><indexterm>elements<indexterm>body<indexterm><xmlelement>figgroup</xmlelement></indexterm></indexterm></indexterm>
         <indexterm>grouping

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -2,14 +2,10 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="include">
     <title><xmlelement>include</xmlelement></title>
-    <shortdesc>The <xmlelement>include</xmlelement> element specifies that non-DITA content from a
-        resource outside the current document should be placed at that location. The resource is
-        specified using either a URI or a key reference. Processing expectations for the referenced
-        data can also be specified.<draft-comment author="Kristen J Eberlein"
-            time="09 September 2020">
-            <p>Should this topic be located here in "Body elements," or should it be relocated to
-                "Specialization elements?</p>
-        </draft-comment></shortdesc>
+    <shortdesc>Included content is a reference to non-DITA content outside the current document that
+        will be rendered at the location of the reference. The resource is specified using either a
+        URI or a key reference. Processing expectations for the referenced data can also be
+        specified.</shortdesc>
     <prolog>
         <metadata>
             <keywords>
@@ -35,11 +31,9 @@
                 <li>The transclusion of plain-text prose within DITA elements using
                         <codeph>parse="text"</codeph></li>
             </ul>
-            <draft-comment author="Kristen J Eberlein" time="29 April 2019" audience="spec-editors">
-                <p>Do we want to mention that <xmlelement>include</xmlelement> is the specialization
-                    base for <xmlelement>coderef</xmlelement>, <xmlelement>svgref</xmlelement>, and
-                        <xmlelement>mathmlref</xmlelement>?</p>
-            </draft-comment>
+            <p otherprops="examples">For example, the <xmlelement>include</xmlelement> element can
+                be specialized to an element such as <xmlelement>coderef</xmlelement> as a way to
+                include preformatted sample programming code.</p>
             <p>It is an error when the <xmlelement>include</xmlelement> element is used to reference
                 DITA content. Authors should use <xmlatt>conref</xmlatt> or
                     <xmlatt>conkeyref</xmlatt> to reuse DITA content.</p>
@@ -104,18 +98,17 @@ attribute.</p>
             </fig>
             <fig>
                 <title>Inclusion of README text into a DITA topic, with fallback</title>
-                <p>
-                    <draft-comment author="Kristen J Eberlein" time="29 April 2019"
-                        audience="spec-editors">
-                        <p>I can't imagine including a readme file into a short description ...</p>
-                    </draft-comment>
-                </p>
-                <codeblock>
-&lt;shortdesc>
-  &lt;include href="../src/README.txt" parse="text" encoding="UTF-8">
-    &lt;fallback>This topic describes XYZ.&lt;/fallback>
-  &lt;/include>
-&lt;/shortdesc></codeblock>
+                <p>In the following sample, a README text file is referenced in order to reuse a
+                    list of changes to a set of source code.</p>
+                <codeblock>&lt;topic id="readme">
+  &lt;title>Summary of changes&lt;/title>
+  &lt;shortdesc>This topic describes changes in the project source code.&lt;/shortdesc>
+  &lt;body>
+    &lt;include href="../src/README.txt" parse="text" encoding="UTF-8">
+      &lt;fallback>See README.txt in the source package for a list of changes.&lt;/fallback>
+    &lt;/include>
+  &lt;/body>
+&lt;/topic></codeblock>
             </fig>
             <fig>
                 <title>Inclusion of preformatted text</title>

--- a/specification/langRef/base/keytext.dita
+++ b/specification/langRef/base/keytext.dita
@@ -3,7 +3,10 @@
 <reference id="keytext">
     <title><xmlelement>keytext</xmlelement></title>
     <shortdesc>A <xmlelement>keytext</xmlelement> element specifies variable or link text; it also
-        specifies alternate text for images that are referenced by keys.</shortdesc>
+        specifies alternate text for images that are referenced by keys.<draft-comment
+            author="robander">to use natural language, maybe: "Key text is variable or link text
+            used when resolving key references. It also specifies alternate text for images that are
+            referenced by keys."</draft-comment></shortdesc>
     <prolog>
         <metadata>
             <keywords>
@@ -22,6 +25,9 @@
             <draft-comment author="Kristen J Eberlein" time="31 October 2020">
                 <p>Should this be a related link instead of a cross reference?</p>
             </draft-comment>
+            <draft-comment author="robander">I like having it here, because a tool implementor
+                scanning for elements that have specific processing concerns is certain to find
+                it.</draft-comment>
         </section>
         <section id="attributes">
             <title>Attributes</title>

--- a/specification/langRef/base/keyword.dita
+++ b/specification/langRef/base/keyword.dita
@@ -17,7 +17,7 @@
          <p>When used within the <xmlelement>keywords</xmlelement> element, the content of a
                <xmlelement>keyword</xmlelement> element is considered to be metadata and should be
             processed as appropriate for the given output medium.</p>
-         <p>Elements that are specialized from the <xmlelement>keyword</xmlelement>element might
+         <p>Elements that are specialized from the <xmlelement>keyword</xmlelement> element might
             have extended processing, such as specific formatting or automatic indexing. </p>
       </section>
       <section id="attributes">

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -2,8 +2,9 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="lines" xml:lang="en-us">
 <title><xmlelement>lines</xmlelement></title>
-<shortdesc>Lines are lines of text where white space is significant. It can be used to represent
-dialogs, poetry, or other text fragments where line breaks are significant.</shortdesc>
+<shortdesc>Lines are lines of text where white space is significant. The
+            <xmlelement>lines</xmlelement> element can be used to represent dialogs, poetry, or
+        other text fragments where line breaks are significant.</shortdesc>
 <prolog><metadata>
 <keywords><indexterm>elements<indexterm>body<indexterm><xmlelement>lines</xmlelement></indexterm></indexterm></indexterm>
 </keywords>

--- a/specification/langRef/base/linkinfo.dita
+++ b/specification/langRef/base/linkinfo.dita
@@ -12,15 +12,10 @@
           elements<indexterm><xmlelement>linkinfo</xmlelement></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="processing-expectations">
-      <title>Processing expectations</title>
-      <draft-comment author="Kristen J Eberlein" time="01 June 2018" audience="tc-reviewers">
-        <p>What processing expectations do we have for this element? I'm assuming that we expect
-          processors to render the content somewhere and probably in a paragraph format, based on
-          the short description.</p>
-      </draft-comment>
-      <draft-comment author="robander" time="13 May 2021">Yes, I think that's correct, but I'm not
-        sure anything needs to be stated; </draft-comment>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The <xmlelement>linkinfo</xmlelement> element is considered part of the content flow and
+        commonly rendered as a paragraph.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -20,11 +20,10 @@
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
       <p>The order in which links in a <xmlelement>linkpool</xmlelement> element are rendered is
-        processor-specific. A processor might order links based on role or type. A processor might
+        processor-specific. A processor might sort links based on role or type. A processor might
         move or remove links based on the context; for example, prerequisite links might be rendered
         at the beginning of a Web page, or links to the next topic might be removed if the two
-        topics are rendered on the same page in a PDF. Processors might automatically sort some
-        links, while others are left ordered as authored.</p>
+        topics are rendered on the same page in a PDF.</p>
     </section>
 <section id="attributes"><title>Attributes</title>
    <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>,

--- a/specification/langRef/base/linktext.dita
+++ b/specification/langRef/base/linktext.dita
@@ -14,6 +14,8 @@
 <refbody>
     <section conkeyref="reuse-linktext/usage-information" id="usage-information"
       ><title/><p/></section>
+  <section conkeyref="reuse-linktext/rendering-expectations" id="rendering-expectations"
+    ><title/><p/></section>
     <section conkeyref="reuse-linktext/attributes" id="attributes"/>
 <example id="example" otherprops="examples"><title>Examples</title>
       <p>This section contains examples of how the <xmlelement>linktext</xmlelement> element can be

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -28,23 +28,16 @@
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-            <draft-comment author="Kristen J Eberlein" time="05 August 2018" audience="tc-reviewers">
-                <p>When trying to craft a new example for this element, I realized I don't
-                    understand what value it provides that is not already available in
-                        <xmlelement>lq</xmlelement>.</p>
-            </draft-comment>
             <p>In the following code sample, the <xmlelement>longdescref</xmlelement> element
                 references an online version of <cite>As You Like It</cite>.</p>
             <codeblock>&lt;p>The following is one of the most frequently used quotations from a Shakespearean play:
   &lt;lq>All the world's a stage, and all the men and women merely players. They have 
       their exits and their entrances; And one man in his time plays many parts.’
-    &lt;longquoteref href="http://www.example.org/shakespeare/as-you-like-it" scope="external"/>
+    &lt;longquoteref href="http://www.example.org/shakespeare/as-you-like-it" format="html"
+       scope="external">As you like it&lt;/longquoteref>
   &lt;/lq>
 &lt;/p>
-  </codeblock>
-            <!--<codeblock>&lt;p>A great person once said the following thing.
-&lt;lq>Examples are the key to any
-specification.&lt;longquoteref href="http://www.example.org/quotes" scope="external"/>&lt;/lq>&lt;/p></codeblock>--></example>
+  </codeblock></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -14,22 +14,17 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/linkatts"/> (with a narrowed definition for
-          <xmlatt>type</xmlatt>, given below), and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
-        attributes defined below.</p>
+      <draft-comment author="robander" time="14 May 2021"><xmlelement>longquoteref</xmlelement> was
+        added to help with translation, moving translatable titles out of @reftitle. Not sure why we
+        still have reftitle and all the linking attributes on lq itself, when that's what
+        longquoteref is for?</draft-comment>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-keyref"
+            ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
       <dl>
         <dlentry id="reftitle">
           <dt id="attr-reftitle"><xmlatt>reftitle</xmlatt></dt>
           <dd>The title of the document or topic that is quoted.</dd>
-        </dlentry>
-        <dlentry id="type">
-          <dt id="attr-type"><xmlatt>type</xmlatt></dt>
-          <dd>Indicates the location of the source of the quote. <ph
-              conkeyref="reuse-attributes/nonstandard-type"/> See <xref keyref="attributes-type"/>
-            for detailed information on the usual supported values and processing implications. </dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -47,19 +47,13 @@
       <title>Attributes</title>
       <sectiondiv id="mapref-attributes">
         <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref
-            keyref="attributes-common/linkatts"/> (with narrowed definitions of
-            <xmlatt>href</xmlatt> and <xmlatt>format</xmlatt>, given below), <xref
-            keyref="attributes-common/commonmapatts"/>, <xref
-            keyref="attributes-common/topicrefatts"/>, <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
-            keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>.</p>
+            keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
+          narrowed definition of  <xmlatt>format</xmlatt>, given below), <xref
+            keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-keyref"
+              ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-keys"
+              ><xmlatt>keys</xmlatt></xref>.</p>
         <dl>
           <dlentry conkeyref="reuse-attributes/format-mapref">
-            <dt/>
-            <dd/>
-          </dlentry>
-          <dlentry conkeyref="reuse-attributes/href-on-topicref">
             <dt/>
             <dd/>
           </dlentry>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -24,7 +24,6 @@
         help system where the referenced navigation is published independently (or may not be
         avilable at all). If available, the referenced navigation can then be resolved at render
         time within a help system.</p>
-      <!--<p>For example, if a map is converted to the Eclipse help system format, the DITA element <codeph>&lt;navref mapref="other.ditamap"/&gt;</codeph> <ph>is</ph> converted to the Eclipse element <codeph>&lt;link toc="other.xml"/&gt;</codeph>. When Eclipse loads the referencing map, it will replace this link element with the contents of the file <filepath>other.xml</filepath>, provided that the file <filepath>other.xml</filepath> is available.</p>-->
       <p>In order to include another map directly without depending on the output format or help
         system, use a <xmlelement>topicref</xmlelement> element with the <xmlatt>format</xmlatt>
         attribute set to <codeph>ditamap</codeph>. The effect is similar to using a

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -16,7 +16,7 @@
       <title>Usage information</title>
       <p>Any number of <xmlelement>param</xmlelement> elements might appear in the content of an
           <xmlelement>object</xmlelement> in any order, but must be placed at the start of the
-        content of the enclosing object. This element is comparable to the XHMTL
+        content of the enclosing object. This element is comparable to the HMTL
           <xmlelement>param</xmlelement> element, and its attributes' semantics derive from their
         HTML definitions. For example, the <xmlatt>type</xmlatt> attribute differs from the
           <xmlatt>type</xmlatt> attribute on many other DITA elements.</p>

--- a/specification/langRef/base/permissions.dita
+++ b/specification/langRef/base/permissions.dita
@@ -4,8 +4,7 @@
  "reference.dtd">
 <reference id="permissions" xml:lang="en-us">
 <title><xmlelement>permissions</xmlelement></title>
-<shortdesc>A <xmlelement>permissions</xmlelement> element specifies the level of entitlement needed
-    to access content.</shortdesc>
+<shortdesc>Permissions are the level of entitlement needed to access content.</shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>elements<indexterm>prolog<indexterm><xmlelement>permissions</xmlelement></indexterm></indexterm></indexterm><indexterm>prolog elements<indexterm><xmlelement>permissions</xmlelement></indexterm></indexterm>
@@ -14,8 +13,8 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The <xmlelement>permissions</xmlelement> element indicates any preferred controls for
-        access to content.</p>
+      <p>The <xmlelement>permissions</xmlelement> element specifies any preferred controls for
+                access to content.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -2,8 +2,8 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="related-links" xml:lang="en-us">
 <title><xmlelement>related-links</xmlelement></title>
-<shortdesc>Related links refer to other topics or external information related to the current
-    topic.</shortdesc>
+<shortdesc>Related links are a group of references to other topics or external information related
+    to the current topic.</shortdesc>
 <prolog><metadata>
 <keywords>
         <indexterm>processing expectations<indexterm>related links</indexterm></indexterm>
@@ -16,25 +16,9 @@
       <p>Related links usually are displayed at the end of the topic, although some Web-based help
         systems might display them in a separate navigation frame.</p>
       <p>Links specified within the <xmlelement>related-links</xmlelement> element typically are
-        displayed together with the links that are generated based on the map context.</p>
-    </section>
-    <section id="processing-expectations">
-      <title>Processing expectations</title>
-      <draft-comment author="robander" time="13 May 2021">These both feel like rendering
-        expectations rather than processing. The first one also feels like rendering expectations
-        for linklist rather than for this element - linklist currently has a MUST statement that
-        says links are displayed in order.</draft-comment>
-      <p>The following list contains processing expectations for the
-          <xmlelement>related-links</xmlelement> element:</p>
-      <ol>
-        <li>Links within a <xmlelement>linklist</xmlelement> element appear in the order defined,
-          while those outside of a <xmlelement>linklist</xmlelement> might be sorted and displayed
-          in a different order or location (based upon their role, target, importance, or other
-          qualifiers).</li>
-        <li>PDF or print-oriented output typically ignores hierarchical links such as those with
-          roles of ancestor, parent, child, descendant, next, previous, or sibling, although this
-          behavior is not required.</li>
-      </ol>
+        displayed together with any links that are generated based on the map context.</p>
+      <p>PDF or print-oriented output commonly ignores hierarchical links such as those with roles
+        of ancestor, parent, child, descendant, next, previous, or sibling.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
@@ -46,7 +30,8 @@
           keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample show how the <xmlelement>related-link</xmlelement> element is used to
-        specify links to Web sites that always will be relevant to the topic:</p><codeblock>&lt;related-links scope="external" format="html">
+        specify links to external information that always will be relevant to the topic:</p><codeblock>&lt;related-links 
+    scope="external" format="html">
   &lt;link href="http://www.example.org">
     &lt;linktext>Example 1&lt;/linktext>
   &lt;/link>

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -20,12 +20,11 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref
-          keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt>).
-        This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-          <xmlatt>format</xmlatt> from <xref keyref="attributes-common/linkatts"
-        />.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> and <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt>),
+          <xref keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref
 keyref="elements-reltable"/>.</p></example>

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -69,12 +69,12 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref
-          keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt>). This element also
-        uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and <xmlatt>format</xmlatt> from <xref
-          keyref="attributes-common/linkatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> and <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt>
+        or <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-type"
+            ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
+            ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
+            ><xmlatt>format</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following section shows how a simple relationship table uses column specifications to

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -37,9 +37,16 @@
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>
+      <draft-comment author="robander">Couple comments:<ol id="ol_rnd_3tq_ppb">
+          <li>"Not output for TOC purposes" I think can be worded better, maybe "are not rendered in
+            a table of contents"</li>
+          <li>"Within a map tree..." I think means "Within a root map, the effective relationship
+            table is the union of all relationship tables in the (map hierarchy? scope of the root
+            map?)</li>
+        </ol></draft-comment>
       <p>By default, the contents of a <xmlelement>reltable</xmlelement> element are not output for
-        navigation or TOC purposes; they are used only to define relationships that can be expressed
-        as topic-to-topic links. The <xmlelement>relcell</xmlelement> elements can contain
+        TOC purposes; they are used only to define relationships that can be expressed as
+        topic-to-topic links. The <xmlelement>relcell</xmlelement> elements can contain
           <xmlelement>topicref</xmlelement> elements, which are then related to other
           <xmlelement>topicref</xmlelement> elements in the same row (although not necessarily in
         the same cell).</p>
@@ -48,19 +55,15 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt>, and with a narrowed definition of
-          <xmlatt>toc</xmlatt>, given below), and the attributes
-        defined below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-          <xmlatt>format</xmlatt> from <xref keyref="attributes-common/linkatts"
-        />.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
+          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-type"
+            ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
+            ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
+            ><xmlatt>format</xmlatt></xref>, and the attributes defined below.</p>
+      <p id="attr-exception">For this element, the <xmlatt>toc</xmlatt> attribute has a default
+        value of <keyword>no</keyword>.</p>
       <dl>
-        <dlentry conkeyref="reuse-attributes/toc-default-no">
-          <dt/>
-          <dd/>
-        </dlentry>
         <dlentry>
           <dt id="attr-title"><xmlatt>title</xmlatt></dt>
           <dd>An identifying title for this element.</dd>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -4,8 +4,7 @@
     Model.</shortdesc><prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>row</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, along with
-        <xmlatt>rowsep</xmlatt> and <xmlatt>valign</xmlatt> from <xref
-          keyref="attributes-common/complextableatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref> and <xref
+          keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/sectiondiv.dita
+++ b/specification/langRef/base/sectiondiv.dita
@@ -15,6 +15,11 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
+      <draft-comment author="robander" audience="spec-editors">Impertinent question: did we ever
+        stop to consider whether DITA 2.0 should remove this element, now that we have &lt;div>? It
+        was originally added as a way to get divisions into sections, without allowing a global
+        generic &lt;div>, but now that the generic &lt;div> is allowed within sections...? They do
+        have the same content model...</draft-comment>
       <p>The <xmlelement>sectiondiv</xmlelement> element cannot contain a title. If a title is
         required, use nested topics.</p>
       <p>The <xmlelement>sectiondiv</xmlelement> element can nest itself, so it can be used as a

--- a/specification/langRef/base/subjectHeadMeta.dita
+++ b/specification/langRef/base/subjectHeadMeta.dita
@@ -17,8 +17,7 @@ description to be associated with a subject heading. </shortdesc>
     </section>
   <section id="attributes">
    <title>Attributes</title>
-   <sectiondiv
-    conkeyref="reuse-attributes/standard-topicmeta-attributes"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
   </section>
 <example conkeyref="reuse-examples/example-subjectHead" id="example" otherprops="examples"/>
 </refbody>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -14,15 +14,15 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The DITA table is based on the OASIS Exchange Table Model, augmented with DITA attributes
-        that enable it for accessibility, specialization, conref, and other DITA processing. An
-        optional <xmlelement>title</xmlelement> inside the <xmlelement>table</xmlelement> element
-        provides a caption to describe the table. In addition, the optional
-          <xmlelement>desc</xmlelement> element enables table description that is parallel with
-        figure description.</p>
+      <p>The DITA <xmlelement>table</xmlelement> element is based on the OASIS Exchange Table Model,
+        augmented with DITA attributes that enable accessibility, specialization, conref, and other
+        DITA processing. An optional <xmlelement>title</xmlelement> inside the
+          <xmlelement>table</xmlelement> element provides a caption to describe the table. In
+        addition, the optional <xmlelement>desc</xmlelement> element enables a table description
+        that is parallel with a figure description.</p>
       <p>See <xref keyref="elements-simpletable"/> for a simplified table model that is closer to
-        the HTML5 table model, and can be specialized to represent more regular relationships of
-        data.</p>
+        the HTML5 table model, and can be more easily specialized to represent regular relationships
+        of data.</p>
       <p conkeyref="reuse-general/pgwide-explain"/>
       <note>The <xmlatt>scale</xmlatt> attribute represents a stylistic markup property that is
         currently maintained in tables for legacy purposes. External stylesheets should enable less
@@ -30,20 +30,24 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xmlatt>frame</xmlatt> and <xmlatt>scale</xmlatt> from <xref
-          keyref="attributes-common/displayatts"/>, and the attributes defined below. This
-        element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>rowheader</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
-      <draft-comment author="Robert">Looking for consistency on orient, pgwide, and entry/@rotate.
-        Should they mention "not enforced by dtd / rng"? Should they say "Supported values" (seems
-        to imply "processors MUST support at least these") or "Allowed values" (implies no other
-        values are legal)?</draft-comment>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-common/attr-frame"><xmlatt>frame</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scale"><xmlatt>scale</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowheader"><xmlatt>rowheader</xmlatt></xref>, and the
+        attributes defined below.</p>
+      <draft-comment author="Robert">Looking for consistency on orient, pgwide, colsep, rowsep, and
+        entry/@rotate. We have a mix of "Supported values" (seems to imply "processors MUST support
+        at least these") or "Allowed values" (implies no other values are legal, and the wording
+        used on most other attributes)? Also, are we consistent between "Allowable" and "Allowed"
+        (allowed seems more correct for ennumerated values)?<p>Update after talking with Kris 14 May
+          2021: Better to use: "The following values are valid:"</p></draft-comment>
       <dl>
         <dlentry id="orient">
           <dt id="attr-orient"><xmlatt>orient</xmlatt></dt>
           <dd>Specifies the orientation of the table in page-based outputs. This attribute is
-            primarily useful for print-oriented display. Allowable values are:<dl>
+            primarily useful for print-oriented display. The following values are valid:<dl>
               <dlentry>
                 <dt>port</dt>
                 <dd>The same orientation as the text flow.</dd>
@@ -62,11 +66,11 @@
         </dlentry>
         <dlentry>
           <dt id="attr-pgwide"><xmlatt>pgwide</xmlatt></dt>
-          <dd>Specifies the horizontal placement of the element. Supported values are 1 and 0,
-            although these are not mandated by the DTD or RNG grammar files.<p>For print-oriented
-              display, the value &quot;1&quot; places the element on the left page margin;
-              &quot;0&quot; aligns the element with the left margin of the current text line and
-              takes indention into account. </p></dd>
+          <dd>Specifies the horizontal placement of the element. The following values are valid:
+              <keyword>1</keyword> and <keyword>0</keyword>. For print-oriented display, the value
+              <keyword>1</keyword> places the element on the left page margin; <keyword>0</keyword>
+            aligns the element with the left margin of the current text line and takes indention
+            into account. </dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -8,8 +8,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and
-          <xmlatt>valign</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        /> and <xref keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -15,15 +15,16 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attribute
-        defined below. This element also uses <xmlatt>colsep</xmlatt>, <xmlatt>rowsep</xmlatt>, and
-          <xmlatt>align</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref> and the attribute
+        defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-cols"><xmlatt>cols</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
-          <dd>Indicates the number of columns in a <xmlelement>tgroup</xmlelement>.</dd>
+          <dd>Specifies the number of columns in a <xmlelement>tgroup</xmlelement>.</dd>
         </dlentry>
       </dl>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -8,8 +8,8 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and
-          <xmlatt>valign</xmlatt> from <xref keyref="attributes-common/complextableatts"/>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+                /> and <xref keyref="attributes-common/attr-valign"
+                ><xmlatt>valign</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -15,9 +15,17 @@
     <refbody>
         <section id="usage-information">
             <title>Usage Information</title>
-            <p>Alternative titles can be used in topics and in maps. When used directly beneath a
-                root <xmlelement>map</xmlelement> element, the alternative title applies to the map
-                itself. When used inside a <xmlelement>topicref</xmlelement> or specialization of
+            <draft-comment author="robander" time="13 May 2021">Questions as I read this more
+                    closely:<ol id="ul_y12_sgk_ppb">
+                    <li>"alternative titles from the topicref are merged with those" ==> merging
+                        implies processing, so I think this needs to be reworded or moved to
+                        processing.</li>
+                    <li>It says title-role must specify at least one role, but it's not a required
+                        attribute. What does it mean if it's *not* specified?</li>
+                </ol></draft-comment>
+            <p>Alternative titles can be used in topics and in maps. When used in the
+                    <xmlelement>topicmeta</xmlelement> of a root <xmlelement>map</xmlelement>
+                element, the alternative title applies to the map itself. When used inside a
                     <xmlelement>topicref</xmlelement>, the alternative title applies to the resource
                 referenced by the <xmlelement>topicref</xmlelement>. When the referenced resource is
                 a DITA topic, the alternative titles from the <xmlelement>topicref</xmlelement> are
@@ -34,6 +42,24 @@
         </section>
         <section id="processing-expectations">
             <title>Processing expectations</title>
+            <draft-comment author="robander" time="13 May 2021">Questions as I read this more
+                    closely:<ol id="ol_aff_zgk_ppb">
+                    <li>"Processors are required to support the following role tokens" ==> this
+                        sounds like a MUST? But they might not be relevant to some processors, so
+                        MUST is difficult.</li>
+                    <li>Some of this language implies a specific type of processor, which we've had
+                        trouble with in the past; language may need to be more processor
+                        agnostic</li>
+                    <li>Also overlaps with rendering, such as stating where a subtitle generally
+                        appears</li>
+                    <li>"Content architects are encouraged to develop..." sounds more like usage
+                        than processing</li>
+                    <li>it ends saying unknown roles MUST be ignored - can we make that a SHOULD?
+                        With MUST it seems like it would be invalid even for a review tool to
+                        display those.</li>
+                </ol><p>Given the complications, the number of required samples, and the impact on
+                    processing, it feels like this deserves a page in the architectural
+                    specifciation.</p></draft-comment>
             <p>The processing of an alternative title depends on its roles. Processors are required
                 to support the following role tokens.</p>
             <dl>
@@ -71,12 +97,9 @@
                         referenced resource without needing to access the resource itself. Does not
                         have an effect on processing or output.</dd>
                 </dlentry>
-                <dlentry>
-                    <dt><codeph>-dita-use-conref-target</codeph></dt>
-                    <dd>When present, instructs processors to use the <xmlatt>title-role</xmlatt>
-                        tokens from the element referenced by <xmlatt>conref</xmlatt> or
-                            <xmlatt>conkeyref</xmlatt>. All other tokens are ignored, replaced by
-                        those on the referenced element.</dd>
+                <dlentry conkeyref="reuse-attributes/ditauseconref">
+                    <dt/>
+                    <dd/>
                 </dlentry>
             </dl>
             <p>Other roles may be defined by processors, authors, or content architects for specific
@@ -95,7 +118,11 @@
                 <dlentry>
                     <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
                     <dd>Specifies the role or roles fulfilled by the alternative title. Multiple
-                        roles are separated by white space.</dd>
+                        roles are separated by white space. Applications can define roles; the
+                        following roles are defined in the specification:
+                        <keyword>linking</keyword>, <keyword>navigation</keyword>,
+                            <keyword>search</keyword>, <keyword>subtitle</keyword>, and
+                            <keyword>hint</keyword>.</dd>
                 </dlentry>
             </dl>
         </section>

--- a/specification/langRef/base/topicmeta.dita
+++ b/specification/langRef/base/topicmeta.dita
@@ -5,19 +5,25 @@
   <shortdesc conkeyref="reuse-topicmeta/shortdesc"/>
   <prolog>
     <metadata>
-      <keywords><indexterm>elements<indexterm>basic map<indexterm><xmlelement>topicmeta</xmlelement></indexterm></indexterm></indexterm>
+      <keywords>
+        <indexterm>elements<indexterm>basic
+              map<indexterm><xmlelement>topicmeta</xmlelement></indexterm></indexterm></indexterm>
         <indexterm>examples<indexterm>maps<indexterm>audience
           definition</indexterm></indexterm></indexterm>
         <indexterm>maps<indexterm>examples<indexterm>audience
             definition</indexterm></indexterm><indexterm>metadata</indexterm></indexterm>
-        <indexterm>metadata<indexterm>maps</indexterm></indexterm></keywords>
+        <indexterm>metadata<indexterm>maps</indexterm></indexterm>
+      </keywords>
     </metadata>
   </prolog>
   <refbody>
-    <section conkeyref="reuse-topicmeta/usage-information" id="usage-information"><title/><p/></section>
+    <section conkeyref="reuse-topicmeta/usage-information" id="usage-information"
+      ><title/><p/></section>
     <section conkeyref="reuse-topicmeta/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
+      <draft-comment author="robander">Need to fix this example; audience is an empty element, so
+        this is not currently valid</draft-comment>
       <p>The following example shows how the <xmlelement>topicmeta</xmlelement> element can contain
         a metadata element:</p>
       <codeblock>&lt;map>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -2,9 +2,9 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference xml:lang="en-us" id="ux-window" >
   <title><xmlelement>ux-window</xmlelement></title>
-  <shortdesc>The <xmlelement>ux-window</xmlelement> element provides specifications for a window or
-    viewport in which a user assistance topic or web page can be displayed. The window or viewport
-    can be referenced by the <xmlelement>resourceid</xmlelement> element associated with a topic or
+  <shortdesc>A UX window specification is a collection of metadata for a window or viewport in which
+    a user assistance topic or web page can be displayed. The window or viewport can be referenced
+    by the <xmlelement>resourceid</xmlelement> element associated with a topic or
       <xmlelement>topicref</xmlelement> element.</shortdesc>
   <prolog>
     <metadata>
@@ -18,18 +18,18 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The <xmlelement>ux-window</xmlelement> element can be used anywhere within a map. If more
-        than one <xmlelement>ux-window</xmlelement> element in a map has the same
-          <xmlatt>name</xmlatt> attribute, the first window specification in document order with
-        that <xmlatt>name</xmlatt> attribute is used.</p>
+      <p>The <xmlelement>ux-window</xmlelement> element can be used in any
+          <xmlelement>topicmeta</xmlelement> element in a map. If more than one
+          <xmlelement>ux-window</xmlelement> element in a map has the same <xmlatt>name</xmlatt>
+        attribute, the first window specification in document order with that <xmlatt>name</xmlatt>
+        attribute is used.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal/idatts"/>, <xref
-          keyref="attributes-universal/metadataatts"/>, <xref
-          keyref="attributes-universal/class"/>, and the attributes
-        defined below.</p>
+          keyref="attributes-universal/idatts"/>, <xref keyref="attributes-universal/metadataatts"
+        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, and the
+        attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="uxatt-name"><xmlatt>name</xmlatt>

--- a/specification/langRef/basic-map-elements.ditamap
+++ b/specification/langRef/basic-map-elements.ditamap
@@ -14,5 +14,6 @@
   <topicref keyref="elements-relheader" />
   <topicref keyref="elements-relcolspec" />
   <topicref keyref="elements-keytext" />
+  <topicref keyref="elements-ux-window"/>
  </topicref>
 </map>

--- a/specification/langRef/containers/body-elements.dita
+++ b/specification/langRef/containers/body-elements.dita
@@ -3,9 +3,8 @@
  "reference.dtd">
 <reference id="body2" xml:lang="en-us">
 <title>Body elements</title>
-<shortdesc>The body elements support the most common types of content
-authoring for topics: paragraphs, lists, phrases, figures, and other
-common types of exhibits in a document.</shortdesc>
+<shortdesc>The body elements support the most common types of content authoring for topics:
+        paragraphs, lists, phrases, figures, and other common document components.</shortdesc>
 <prolog><metadata>
 <keywords><indexterm>body elements</indexterm>
     <indexterm>element groups<indexterm>body</indexterm></indexterm></keywords>

--- a/specification/langRef/containers/related-links-elements.dita
+++ b/specification/langRef/containers/related-links-elements.dita
@@ -2,10 +2,10 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="relatedl" xml:lang="en-us">
 <title>Related links elements</title>
-<shortdesc><!--The related-links section of DITA topics is a special structure that contains links. Links support navigation from a topic to other related topics or resources.-->Related
-        links are topic-to-topic connections or connections from DITA topics to non-DITA resources.
-        These embedded references in DITA topics establish dependencies from the topics to the
-        referenced resources.</shortdesc>
+<shortdesc>The related links elements define, group, and describe topic-to-topic connections or
+                connections from DITA topics to non-DITA resources. These embedded references in
+                DITA topics establish dependencies from the topics to the referenced
+                resources.</shortdesc>
 <prolog><metadata>
 <keywords>
                 <!--<indexterm>best practices<indexterm>links</indexterm></indexterm>-->

--- a/specification/langRef/containers/table-elements.dita
+++ b/specification/langRef/containers/table-elements.dita
@@ -3,24 +3,23 @@
  "reference.dtd">
 <reference id="table2" xml:lang="en-us">
 <title>Table elements</title>
-<shortdesc>DITA topics support two types of tables. The <xmlelement>table</xmlelement>
-element uses <!--the most common table format used in industry,-->the
-OASIS Exchange Table Model (formerly known as the CALS table model).
-The OASIS table supports the spanning of multiple rows or columns
-for special layout or organizational needs, and provides a wide variety
-of controls over the display properties of the data and even the table
-structure itself.</shortdesc>
+<shortdesc>DITA topics support two types of tables. The <xmlelement>table</xmlelement> element uses
+        the <!--industry standard--> OASIS Exchange Table Model (formerly known as the CALS table
+        model). The <xmlelement>simpletable</xmlelement> element is structurally less complex than
+        the OASIS table, and is an easier base for specialization.</shortdesc>
 <prolog><metadata>
 <keywords>
     <indexterm>element groups<indexterm>table</indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-<section id="section-1"><p>The other table structure in DITA is called <xmlelement>simpletable</xmlelement>. As the name
-                implies, it is structurally less complex than the OASIS table, and it can be used as
-                a very simple, regular table for which close control of formatting is not as
-                important. The main advantage of <xmlelement>simpletable</xmlelement> is for
-                describing lists of data with regular headings, such as telephone directory
-                listings, display adapter configuration data, or API properties. </p></section>
+<section id="section-1">
+            <p>The <xmlelement>table</xmlelement> element based on the OASIS table model provides a
+                wide variety of controls over the display properties of the data and even the table
+                structure itself.</p>
+            <p>The <xmlelement>simpletable</xmlelement> element does not provide as much control
+                over formatting. It is useful for describing lists of data with regular headings,
+                such as telephone directory listings, display adapter configuration data, or API
+                properties.</p></section>
 </refbody>
 </reference>
 


### PR DESCRIPTION
No changes to meaning, but a lot of cleanup to wording, handling (or adding) draft comments, and revising the look/feel of attribute sections.