### PR TITLE
Cleaning up attribute sections

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -545,13 +545,13 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dlentry id="image-placement">
                                         <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
                                         <dd>Specifies whether an image is displayed inline or on a
-                                                separate line. The default value is inline.
-                                                Allowable values are: <keyword>inline</keyword>,
-                                                  <keyword>break</keyword>, or and <xref
+                                                separate line. The default value is
+                                                  <keyword>inline</keyword>. Allowable values are:
+                                                  <keyword>inline</keyword>,
+                                                  <keyword>break</keyword>, and <xref
                                                   keyref="attributes-useconreftarget"
                                                   >-dita-use-conref-target</xref>.</dd>
                                 </dlentry>
-                                <!--<dlentry id="image-longdescref"><dt><xmlatt>longdescref</xmlatt> <ph conref="#conref-attribute/deprecated-attr"/></dt><dd>A reference to a textual description of the graphic or object. This attribute supports creating accessible content. See <xref keyref="attributes-href"/> for detailed information on supported values and processing implications. <ph>For examples of how this attribute is used in output, see this topic on <xref format="html" href="http://www.w3.org/TR/WCAG10-HTML-TECHS/#long-descriptions" scope="external">long descriptions</xref>.</ph> NOTE: This attribute is deprecated in favor of the <xref href="../langRef/base/longdescref.dita"/> subelement to this element.</dd></dlentry>-->
                         </dl>
                 </section>
                         <section id="section-4"><title>Attributes used on the <xmlelement>map</xmlelement> element</title><sectiondiv

--- a/specification/langRef/base/ditavalmeta.dita
+++ b/specification/langRef/base/ditavalmeta.dita
@@ -23,8 +23,9 @@
         not intended for rendering.</p></section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>ditavalmeta</xmlelement> element is specialized from <xref
-          keyref="elements-topicmeta"/>. It is defined in the DITAVAL-reference domain module.</p>
+      <p>The <xmlelement>ditavalmeta</xmlelement> element is specialized from
+          <xmlelement>topicmeta</xmlelement>. It is defined in the DITAVAL-reference domain
+        module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -32,8 +32,8 @@
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>dvrKeyscopePrefix</xmlelement> element is specialized from <xref
-          keyref="elements-data"/>. It is defined in the DITAVAL-reference domain module.</p>
+      <p>The <xmlelement>dvrKeyscopePrefix</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -32,8 +32,8 @@
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>dvrKeyscopeSuffix</xmlelement> element is specialized from <xref
-          keyref="elements-data"/>. It is defined in the DITAVAL-reference domain module.</p>
+      <p>The <xmlelement>dvrKeyscopeSuffix</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -33,8 +33,8 @@
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>dvrResourcePrefix</xmlelement> element is specialized from <xref
-          keyref="elements-data"/>. It is defined in the DITAVAL-reference domain module.</p>
+      <p>The <xmlelement>dvrResourcePrefix</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -37,8 +37,8 @@
     </section>
     <section id="specialization-hierachy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>dvrResourceSuffix</xmlelement> element is specialized from <xref
-          keyref="elements-data"/>. It is defined in the DITAVAL-reference domain module.</p>
+      <p>The <xmlelement>dvrResourceSuffix</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -25,11 +25,11 @@
       <sectiondiv>
         <p>The following attributes are available on this element: <xref
             keyref="attributes-universal"/> and <xref keyref="attributes-common/spectitle"
-          />, and the attributes defined below.</p>
+              ><xmlatt>spectitle</xmlatt></xref>, and the attribute defined below.</p>
         <dl>
           <dlentry id="type">
             <dt id="attr-type"><xmlatt>type</xmlatt></dt>
-            <dd>Indicates the level of hazard. The values correspond to the signal words defined by
+            <dd>Specifies the level of hazard. The values correspond to the signal words defined by
               the ANSI Z535.6 standard:<dl>
                 <dlentry>
                   <dt><keyword>caution</keyword></dt>
@@ -52,9 +52,9 @@
                   <dd>Indicates a hazardous situation that, if not avoided, could result in death or
                     serious injury.</dd>
                 </dlentry>
-                <dlentry>
-                  <dt><keyword>-dita-use-conref-target </keyword></dt>
-                  <dd>See <xref keyref="attributes-useconreftarget"/> for more information. </dd>
+                <dlentry conkeyref="reuse-attributes/ditauseconref">
+                  <dt/>
+                  <dd/>
                 </dlentry>
               </dl></dd>
           </dlentry>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -31,22 +31,14 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
     <section id="attributes">
       <title>Attributes</title>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
-        attributes defined below.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+        />, <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
+        defined below.</p>
       <dl>
-        <dlentry id="format">
-          <dt id="attr-format"><xmlatt>format</xmlatt></dt>
-          <dd><!--TODO: In 2.0 make this common with version in link attribute group.-->Identifies
-            the format of the resource that is referenced. See <xref keyref="attributes-format"/>
-            for details on supported values.</dd>
-        </dlentry>
         <dlentry conkeyref="reuse-attributes/image-href">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-scope">
           <dt/>
           <dd/>
         </dlentry>


### PR DESCRIPTION
* Cleanup in attribute sections
* Markup consistency for attribute values on `@placement`
* Remove links from specialization ancestry section in ditavalref domain