### PR TITLE
Create reusable phrase for links to attr groups

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -8,6 +8,93 @@
                         language reference topics, a few phrases are used within those sections and
                         within other content.</shortdesc>
                 <conbody>
+                <section id="section_dwh_rbm_qpb">
+                        <title>Control how links to attribute groups appear in attribute
+                                sections</title>
+                        <p><ph id="ref-universalatts"><xref keyref="attributes-universal">universal
+                                                  attributes<desc>Universal attributes include:
+                                                  <xmlatt>audience</xmlatt>, <xmlatt>base</xmlatt>,
+                                                  <xmlatt>class</xmlatt>,
+                                                  <xmlatt>conaction</xmlatt>,
+                                                  <xmlatt>conkeyref</xmlatt>,
+                                                  <xmlatt>conref</xmlatt>,
+                                                  <xmlatt>conrefend</xmlatt>,
+                                                  <xmlatt>deliveryTarget</xmlatt>,
+                                                  <xmlatt>dir</xmlatt>, <xmlatt>id</xmlatt>,
+                                                  <xmlatt>importance</xmlatt>,
+                                                  <xmlatt>otherprops</xmlatt>,
+                                                  <xmlatt>outputclass</xmlatt>,
+                                                  <xmlatt>platform</xmlatt>,
+                                                  <xmlatt>product</xmlatt>, <xmlatt>props</xmlatt>,
+                                                  <xmlatt>rev</xmlatt>, <xmlatt>status</xmlatt>,
+                                                  <xmlatt>translate</xmlatt>, and
+                                                  <xmlatt>xml:lang</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-idandconrefatts"><xref keyref="attributes-universal/idatts">ID
+                                                and conref attributes<desc>ID and conref attributes
+                                                  include: <xmlatt>conaction</xmlatt>,
+                                                  <xmlatt>conkeyref</xmlatt>,
+                                                  <xmlatt>conref</xmlatt>,
+                                                  <xmlatt>conrefend</xmlatt>, and
+                                                  <xmlatt>id</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-localizationatts"><xref keyref="attributes-universal/localizationatts"
+                                                >localization
+                                                  attributes<desc>Localization attributes include:
+                                                  <xmlatt>dir</xmlatt>, <xmlatt>translate</xmlatt>,
+                                                  and
+                                <xmlatt>xml:lang</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-metadataatts"><xref keyref="attributes-universal/metadataatts"
+                                                >metadata attributes<desc>Metadata attributes
+                                                  include: <xmlatt>audience</xmlatt>,
+                                                  <xmlatt>base</xmlatt>,
+                                                  <xmlatt>deliveryTarget</xmlatt>,
+                                                  <xmlatt>importance</xmlatt>,
+                                                  <xmlatt>otherprops</xmlatt>,
+                                                  <xmlatt>platform</xmlatt>,
+                                                  <xmlatt>product</xmlatt>, <xmlatt>props</xmlatt>,
+                                                  <xmlatt>rev</xmlatt>, and
+                                                  <xmlatt>status</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-architecturalatts"><xref keyref="attributes-common/architecturalatts"
+                                               >architectural
+                                                  attributes<desc>Architectural attributes include:
+                                                  <xmlatt>DITAArchVersion</xmlatt>,
+                                                  <xmlatt>specializations</xmlatt>, and
+                                                  <xmlatt>xmlns:ditaarch</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-commonmapatts"><xref keyref="attributes-common/commonmapatts"
+                                                >common map attributes<desc>Common map attributes
+                                                  include: <xmlatt>cascade</xmlatt>,
+                                                  <xmlatt>chunk</xmlatt>,
+                                                  <xmlatt>collection-type</xmlatt>,
+                                                  <xmlatt>keyscope</xmlatt>,
+                                                  <xmlatt>linking</xmlatt>,
+                                                  <xmlatt>processing-role</xmlatt>,
+                                                  <xmlatt>search</xmlatt>, and
+                                                  <xmlatt>toc</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-dataatts"><xref keyref="attributes-common/dataatts">data-element
+                                                  attributes<desc>Data-element attributes include:
+                                                  <xmlatt>datatype</xmlatt>, <xmlatt>name</xmlatt>,
+                                                  and <xmlatt>value</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-dateatts"><xref keyref="attributes-common/dateatts">date
+                                                  attributes<desc>Date attributes include:
+                                                  <xmlatt>expiry</xmlatt> and
+                                                  <xmlatt>golive</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-displayatts"><xref keyref="attributes-common/displayatts">display
+                                                  attributes<desc>Display attributes include:
+                                                  <xmlatt>expanse</xmlatt>, <xmlatt>frame</xmlatt>,
+                                                  and <xmlatt>scale</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-inclusionatts"><xref keyref="attributes-common/inclusionatts"
+                                                >inclusion attributes<desc>Inclusion attributes
+                                                  include: <xmlatt>encoding</xmlatt> and
+                                                  <xmlatt>parse</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-linkatts"><xref keyref="attributes-common/linkatts"
+                                                >link-relationship attributes<desc>Link relationship
+                                                  attributes include: <xmlatt>format</xmlatt>,
+                                                  <xmlatt>href</xmlatt>, <xmlatt>type</xmlatt>, and
+                                                  <xmlatt>scope</xmlatt></desc></xref></ph></p>
+                        <p><ph id="ref-simpletableatts"><xref keyref="attributes-common/simpletableatts"
+                                                >simpletable attributes<desc>Simpletable attributes
+                                                  include: <xmlatt>keycol</xmlatt> and
+                                                  <xmlatt>relcolwidth</xmlatt></desc></xref></ph></p>
+                </section>
                         <section id="section-1"><title>Reused text from attribute
                                 descriptions</title><p>Common <xmlelement>dlentry</xmlelement> for <keyword>-dita-use-conref-target</keyword>:</p><dl>
                                 <dlentry id="ditauseconref">
@@ -49,35 +136,25 @@
                                                 outputclass="RFC-2119">MAY</term> ignore one of the
                                         two values when they are unable to scale to each direction
                                         using different factors.</ph></p><p id="data-link-universal-keyref-outputclass">The following attributes are available on this
-                                        element: <xref keyref="attributes-common/dataatts"/>, <xref
-keyref="attributes-common/linkatts"/>, <xref
-keyref="attributes-universal"/>, and <xref
+                                        element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element:
-<xref keyref="attributes-common/dataatts"/>, <xref
-keyref="attributes-common/linkatts"/>, and <xref
-keyref="attributes-universal"/>.</p><p id="only-universal">The following attributes are available
-                                on this element: <xref
-                                        keyref="attributes-universal"
-                                />.</p><p id="universal-outputclass-name">The following attributes are available on this element: <xref
-keyref="attributes-universal"/>, and <xref
-keyref="attributes-common/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <xref
-keyref="attributes-universal"/> and <xref
+<ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="only-universal">The following attributes are available
+                                on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="universal-outputclass-name">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+keyref="attributes-common/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry" platform="dita">The following attributes are available on this element:
-                                        <xref keyref="attributes-universal"/> and <xref
+                                        <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
                                         keyref="attributes-common/specentry"/>.</p><p id="universal-spectitle" platform="dita">The following attributes are available on this element:
-                                        <xref keyref="attributes-universal"/> and <xref
+                                        <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
                                         keyref="attributes-common/spectitle"
                                                 ><xmlatt>spectitle</xmlatt></xref>.</p><p id="universal-spectitle-compact" platform="dita">The following attributes are available on this
-                                element: <xref keyref="attributes-universal"/>, <xref
+                                element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
                                         keyref="attributes-common/compact"
                                         ><xmlatt>compact</xmlatt></xref>, and <xref
                                         keyref="attributes-common/spectitle"
                                                 ><xmlatt>spectitle</xmlatt></xref>.</p><!--Used in <topic>, <concept>, etc.-->
                         <sectiondiv id="topic-attributes">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/> (with a narrowed
-                                        definition of <xmlatt>id</xmlatt>, given below) and <xref
-                                                keyref="attributes-common/architecturalatts"/>.</p>
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed
+                                        definition of <xmlatt>id</xmlatt>, given below) and <ph conkeyref="reuse-attributes/ref-architecturalatts"/>.</p>
                                 <dl>
                                         <dlentry id="topic-id">
                                                 <dt id="attr-id"><xmlatt>id</xmlatt>
@@ -93,21 +170,13 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-s
                                                   conref="#conref-attribute/define-ID"/></dd>
                                         </dlentry>
                                 </dl>
-                        </sectiondiv><p id="topic-body">The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (without the Metadata attribute group) and
-<xmlatt>base</xmlatt> from the <xref keyref="attributes-universal/metadataatts"/>.</p><p id="fig-attributes" platform="dita">The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/>, <xref
-                                        keyref="attributes-common/displayatts"/>, and <xref
-                                        keyref="attributes-common/spectitle"/>.</p><p id="pre-attributes" platform="dita">The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/>, <xref
-                                        keyref="attributes-common/displayatts"/>, <xref
+                        </sectiondiv><p id="topic-body">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (without the metadata attribute group) and
+                                <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>.</p><p id="fig-attributes" platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>, and <xref
+                                        keyref="attributes-common/spectitle"/>.</p><p id="pre-attributes" platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>, <xref
                                         keyref="attributes-common/xmlspace"/>, and <xref
-                                        keyref="attributes-common/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <xref
-keyref="attributes-universal"/>, <xref
-keyref="attributes-common/linkatts"/>, and <xref
+                                        keyref="attributes-common/spectitle"/>.</p><p id="xref-attributes">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
-<p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> and the attribute defined below.</p>
+<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
 <dl>
 <dlentry id="callout">
 <dt id="attr-callout"><xmlatt>callout</xmlatt></dt>
@@ -127,11 +196,7 @@ element. The default value is the empty string "".</dd>
 </dlentry>
 </dl>
 </sectiondiv><sectiondiv id="author-attributes">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"
-                                        />, <xref
-                                                keyref="attributes-common/linkatts"
-                                        /> (with a narrowed definition for <xmlatt>type</xmlatt>,
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition for <xmlatt>type</xmlatt>,
                                         given below), and <xref
                                                 keyref="attributes-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
@@ -147,20 +212,15 @@ element. The default value is the empty string "".</dd>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="standard-topicref-attributes" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/>, <xref
-                                                keyref="attributes-common/commonmapatts"/>, <xref
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
                                                 keyref="attributes-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                                 keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/> (with a
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
                                         narrowed definition of <xmlatt>href</xmlatt>, given below),
-                                                <xref keyref="attributes-common/commonmapatts"/>,
+                                                <ph conkeyref="reuse-attributes/ref-commonmapatts"/>,
                                         and <xref keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -183,21 +243,15 @@ element. The default value is the empty string "".</dd>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="bookmap-topicrefs" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/>, <xref
-                                                keyref="attributes-common/commonmapatts"/>, and
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, and
                                                 <xref keyref="attributes-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="bookmap-frontbackmatter" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/commonmapatts"/>, and
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, and
                                                 <xref keyref="attributes-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>. This element also
                                         uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and
-                                                <xmlatt>type</xmlatt> from <xref
-                                                keyref="attributes-common/linkatts"/>.</p>
+                                                <xmlatt>type</xmlatt> from <ph conkeyref="reuse-attributes/ref-linkatts"/>.</p>
                         </sectiondiv><sectiondiv>
                                 <p>Define the <keyword>href</keyword> value common to map
                                         references.</p>
@@ -208,8 +262,7 @@ element. The default value is the empty string "".</dd>
                                                 <dd>Specifies the format of the resource. By
                                                   default, it is set to <keyword>ditamap</keyword>.
                                                   Otherwise, the attribute is the same as described
-                                                  in <xref keyref="attributes-common/linkatts"
-                                                  />.</dd>
+                                                  in <ph conkeyref="reuse-attributes/ref-linkatts"/>.</dd>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv>
@@ -223,8 +276,7 @@ element. The default value is the empty string "".</dd>
                                                   specified locally, but is specified on an
                                                   ancestor, the value cascades from the closest
                                                   containing element. By default, the value for
-                                                  <xmlatt>toc</xmlatt> is set to "no". See <xref
-                                                  keyref="attributes-common/commonmapatts"/> for a complete
+                                                  <xmlatt>toc</xmlatt> is set to "no". See <ph conkeyref="reuse-attributes/ref-commonmapatts"/> for a complete
                                                   definition of <xmlatt>toc</xmlatt>.</dd>
                                         </dlentry>
                                 </dl>
@@ -282,14 +334,11 @@ of map.-->
                                                 <dd>Specifies the role that the resource plays in
                                                   processing. By default, this is set to
                                                   <keyword>resource-only</keyword>. Otherwise, the
-                                                  definition matches the one in <xref
-                                                  keyref="attributes-common/commonmapatts"/>.</dd>
+                                                  definition matches the one in <ph conkeyref="reuse-attributes/ref-commonmapatts"/>.</dd>
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="scheme-HAS-elements" platform="dita">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/linkatts"/>, <xref
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
                                                 keyref="attributes-common/attr-processing-role"
                                                   ><xmlatt>processing-role</xmlatt></xref>, <xref
                                                 keyref="attributes-keys"
@@ -298,16 +347,14 @@ of map.-->
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>-->
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/> and <xref
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
                                                 keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <p id="attr-exception">For this element, the
                                                 <xmlatt>translate</xmlatt> attribute has a default
                                         value of <keyword>no</keyword>.</p>
                         </sectiondiv><sectiondiv id="universal-outputclass-required-id">
-                                <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (with a narrowed definition of
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed definition of
 <xmlatt>id</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
@@ -354,8 +401,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                         <xmlatt>importance</xmlatt> definition inside is also used
                                 by <xmlelement>fragref</xmlelement>.</p><sectiondiv
                                 id="syntaxelement-optreq">
-                                <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (with a narrowed definition of
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry id="importance-optreq">
@@ -383,8 +429,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance">
-                                <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (with a narrowed definition of
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>
@@ -418,8 +463,7 @@ keyref="attributes-universal"/> (with a narrowed definition of
                                         </dlentry>
                                 </dl>
                         </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">
-                                <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (with a narrowed definition of
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below) and <xref
 keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
@@ -557,13 +601,10 @@ keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                         <section id="section-4"><title>Attributes used on the <xmlelement>map</xmlelement> element</title><sectiondiv
                                         id="all-map-attributes">
                                         <p id="map-attributes-common">The following attributes are
-available on this element: <xref keyref="attributes-universal"/> (with a
-narrowed definition of <xmlatt>id</xmlatt>, given below), <xref
-keyref="attributes-common/commonmapatts"/>, <xref
-keyref="attributes-common/architecturalatts"/>, and the attributes defined
+available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a
+narrowed definition of <xmlatt>id</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, and the attributes defined
 below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
-<xmlatt>format</xmlatt> from <xref keyref="attributes-common/linkatts"
-/>.</p>
+<xmlatt>format</xmlatt> from <ph conkeyref="reuse-attributes/ref-linkatts"/>.</p>
                                         <dl>
                                                 <dlentry id="map-attribute-id">
                                                   <dt id="attr-id-map"><xmlatt>id</xmlatt></dt>
@@ -594,9 +635,9 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                         <title>Common for <xmlelement>simpletable</xmlelement> and at least one
                                 specialization</title>
                         <p id="simpletable-attributes" platform="dita">The following attributes are
-                                available on this element: <xref keyref="attributes-universal"/>,
-                                        <xref keyref="attributes-common/displayatts"/>, <xref
-                                        keyref="attributes-common/simpletableatts"/>, and <xref
+                                available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
+                                        <ph conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+                                        conkeyref="reuse-attributes/ref-simpletableatts"/>, and <xref
                                         keyref="attributes-common/spectitle"/>.</p>
                 </section>
                 <section id="section_tbf_vhy_jlb">
@@ -656,9 +697,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                 </section>
                 <section id="section-6"><title>Attributes for specialized relationship tables (drop <xmlatt>title</xmlatt> from base
                                         <xmlelement>reltable</xmlelement>)</title><sectiondiv id="reltable-minus-title">
-                                <p>The following attributes are available on this element: <xref
-                                                keyref="attributes-universal"/>, <xref
-                                                keyref="attributes-common/commonmapatts"/>,  <xref
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>,  <xref
                                                 keyref="attributes-common/attr-type"
                                                   ><xmlatt>type</xmlatt></xref>, <xref
                                                 keyref="attributes-common/attr-scope"
@@ -669,8 +708,7 @@ below. This element also uses <xmlatt>type</xmlatt>, <xmlatt>scope</xmlatt>, and
                                         attribute has a default value of <keyword>no</keyword>.</p>
                         </sectiondiv></section>
                 <section id="section-7"><title>Common to <xmlelement>step</xmlelement> and <xmlelement>substep</xmlelement></title><p>Universal attributes, with narrowed definition of <xmlatt>importance</xmlatt>.</p><sectiondiv id="step-and-substep">
-                                <p>The following attributes are available on this element: <xref
-keyref="attributes-universal"/> (with a narrowed definition of
+                                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a narrowed definition of
 <xmlatt>importance</xmlatt>, given below).</p>
                                 <dl>
                                         <dlentry>

--- a/specification/common/reuse-strow.dita
+++ b/specification/common/reuse-strow.dita
@@ -4,6 +4,5 @@
   <shortdesc id="shortdesc">A simple table row is a single row in a simple table.</shortdesc><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section></refbody></reference>

--- a/specification/common/reuse-w-lwdita/reuse-alt.dita
+++ b/specification/common/reuse-w-lwdita/reuse-alt.dita
@@ -9,9 +9,9 @@
         <section id="attributes">
             <title>Attributes</title>
                         <p platform="dita">The following attributes are available on this element:
-                                        <xref keyref="attributes-universal"/>.</p>
+                                        <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
                         <p platform="lwdita">The following attributes are available on this element:
-                                        <xref keyref="attributes-universal/localizationatts"/>, <xref
+                                        <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
                                         keyref="attributes-universal/class"
                                         ><xmlatt>class</xmlatt></xref>, <xref
                                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>,

--- a/specification/common/reuse-w-lwdita/reuse-audio.dita
+++ b/specification/common/reuse-w-lwdita/reuse-audio.dita
@@ -37,8 +37,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and the attributes defined below.</p>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
         <dl>
           <dlentry>
             <dt id="attr-autoplay"><xmlatt>autoplay</xmlatt></dt>
@@ -109,8 +108,7 @@
           </dlentry>
         </dl>
       </div>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.<draft-comment author="rodaande">This needs to be examined
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.<draft-comment author="rodaande">This needs to be examined
           in line of the element moving into the base vocabulary; likely, some additional attributes
           are now present.</draft-comment></p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-b.dita
+++ b/specification/common/reuse-w-lwdita/reuse-b.dita
@@ -12,10 +12,8 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-body.dita
+++ b/specification/common/reuse-w-lwdita/reuse-body.dita
@@ -6,10 +6,8 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-data.dita
+++ b/specification/common/reuse-w-lwdita/reuse-data.dita
@@ -50,13 +50,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-common/dataatts"/>, <xref keyref="attributes-common/linkatts"/>, <xref
-          keyref="attributes-universal"/>, and <xref keyref="attributes-keyref"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-universalatts"/>, and <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-common/dataatts"/>, <xref keyref="attributes-common/linkatts"/>, <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-dd.dita
+++ b/specification/common/reuse-w-lwdita/reuse-dd.dita
@@ -7,8 +7,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-                />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-desc.dita
+++ b/specification/common/reuse-w-lwdita/reuse-desc.dita
@@ -62,10 +62,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/metadataatts"/>, <xref
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, and <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-dl.dita
+++ b/specification/common/reuse-w-lwdita/reuse-dl.dita
@@ -7,8 +7,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-dlentry.dita
+++ b/specification/common/reuse-w-lwdita/reuse-dlentry.dita
@@ -7,8 +7,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-dt.dita
+++ b/specification/common/reuse-w-lwdita/reuse-dt.dita
@@ -7,8 +7,7 @@
 <refbody>
     <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
         </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-fig.dita
+++ b/specification/common/reuse-w-lwdita/reuse-fig.dita
@@ -7,12 +7,10 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-common/displayatts"/>,
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>,
                 and <xref keyref="attributes-common/spectitle"
                 ><xmlatt>spectitle</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref keyref="attributes-common/displayatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-displayatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-fn.dita
+++ b/specification/common/reuse-w-lwdita/reuse-fn.dita
@@ -103,8 +103,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="callout">
           <dt id="attr-callout"><xmlatt>callout</xmlatt></dt>

--- a/specification/common/reuse-w-lwdita/reuse-i.dita
+++ b/specification/common/reuse-w-lwdita/reuse-i.dita
@@ -13,10 +13,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+            <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+            <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
                         ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -12,16 +12,14 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/attr-href"/>, <xref
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-href"/>, <xref
           keyref="attributes-common/attr-format"/>, <xref keyref="attributes-common/attr-scope"/>,
           <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
         defined below.</p>
       <p platform="lwdita"><draft-comment author="robander">href, format, and scope were moved from
           the DL (marked for both lwdita and dita) into the paragraph above for full DITA; not sure
           if they apply to lwdita, if so, the three should be listed here as
-        well.</draft-comment>The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref
+        well.</draft-comment>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -24,16 +24,12 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="keydef-attributes">
-        <p platform="dita">The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
-          narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-            keyref="attributes-common/commonmapatts"/> (with a narrowed definition of
+        <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
+          narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (with a narrowed definition of
             <xmlatt>processing-role</xmlatt>, given below), <xref keyref="attributes-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
-        <p platform="lwdita">The following attributes are available on this element: <xref
-            keyref="attributes-common/linkatts"/> (with a narrowed definition of
-            <xmlatt>href</xmlatt>, given below), <xref keyref="attributes-universal/localizationatts"/>, <xref
-            keyref="attributes-universal/metadataatts"/>, <xref keyref="attributes-universal/class"
+        <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition of
+            <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>.</p>
         <dl>
@@ -55,8 +51,7 @@
           <dlentry>
             <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt></dt>
             <dd>Specifies the role that the resource plays in processing. By default, this is set to
-                <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <xref
-                keyref="attributes-common/commonmapatts"/>.</dd>
+                <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <ph conkeyref="reuse-attributes/ref-commonmapatts"/>.</dd>
           </dlentry>
         </dl>
       </sectiondiv>

--- a/specification/common/reuse-w-lwdita/reuse-li.dita
+++ b/specification/common/reuse-w-lwdita/reuse-li.dita
@@ -7,8 +7,7 @@
 <refbody>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
         </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-linktext.dita
+++ b/specification/common/reuse-w-lwdita/reuse-linktext.dita
@@ -20,10 +20,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-map.dita
+++ b/specification/common/reuse-w-lwdita/reuse-map.dita
@@ -52,17 +52,13 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv>
-        <p platform="dita">The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref keyref="attributes-common/commonmapatts"/>, <xref
-            keyref="attributes-common/architecturalatts"/>, <xref
+        <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, <xref
             keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
             keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
             keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, and the attribute
           defined below.</p>
         <p platform="lwdita">The following attributes are available on this element: <xref
-            keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <xref
-            keyref="attributes-common/architecturalatts"/>, <xref
-            keyref="attributes-universal/localizationatts"/>, <xref
+            keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
             keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
             keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and the
           attribute defined below.</p>

--- a/specification/common/reuse-w-lwdita/reuse-media-source.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-source.dita
@@ -22,8 +22,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and the attributes defined below.</p>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
         <dl>
           <dlentry platform="dita">
             <dt id="attr-format"><xmlatt>format</xmlatt></dt>
@@ -49,8 +48,7 @@
         </dl>
       </div>
       <div platform="lwdita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>, and the attributes defined below.</p>
         <draft-comment author="Robert">Need to update these atts now that the element is part of the

--- a/specification/common/reuse-w-lwdita/reuse-media-track.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-track.dita
@@ -25,8 +25,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and the attributes defined below.</p>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
         <dl>
           <dlentry platform="dita">
             <dt id="attr-format"><xmlatt>format</xmlatt></dt>
@@ -103,8 +102,7 @@
         </dl>
       </div>
       <div platform="lwdita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>, and the attributes defined below.</p>
         <draft-comment author="Robert">Need to update these atts now that the element is part of the

--- a/specification/common/reuse-w-lwdita/reuse-navtitle.dita
+++ b/specification/common/reuse-w-lwdita/reuse-navtitle.dita
@@ -23,8 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and the attribute listed below.</p>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
         <dl id="dl_w2g_qvq_lpb">
           <dlentry>
             <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
@@ -33,8 +32,7 @@
           </dlentry>
         </dl>
       </div>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-note.dita
+++ b/specification/common/reuse-w-lwdita/reuse-note.dita
@@ -13,8 +13,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <div platform="dita">
-                <p>The following attributes are available on this element: <xref
-                        keyref="attributes-universal"/>, <xref keyref="attributes-common/spectitle"
+                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/spectitle"
                             ><xmlatt>spectitle</xmlatt></xref>, and the attributes defined
                     below.</p>
                 <dl>
@@ -43,8 +42,7 @@
                 </dl>
             </div>
             <div platform="lwdita">
-                <p>The following attributes are available on this element: <xref
-                        keyref="attributes-universal"/> and the attribute defined below.</p>
+                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
                 <p conkeyref="reuse-attributes/mdita-attributes"/>
                 <dl>
                     <dlentry>

--- a/specification/common/reuse-w-lwdita/reuse-ol.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ol.dita
@@ -7,12 +7,10 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-common/compact"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/compact"
                         ><xmlatt>compact</xmlatt></xref>, and <xref
                     keyref="attributes-common/spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-p.dita
+++ b/specification/common/reuse-w-lwdita/reuse-p.dita
@@ -7,8 +7,8 @@
 <refbody>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-                              keyref="attributes-universal"/>.</p>
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-ph.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ph.dita
@@ -27,11 +27,9 @@
             </section>
             <section id="attributes">
                   <title>Attributes</title>
-                  <p platform="dita">The following attributes are available on this element: <xref
-                              keyref="attributes-universal"/> and <xref keyref="attributes-keyref"
+                  <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-keyref"
                                     ><xmlatt>keyref</xmlatt></xref>.</p>
-                  <p platform="lwdita">The following attributes are available on this element: <xref
-                              keyref="attributes-universal/localizationatts"/>, <xref
+                  <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
                               keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>,
                               <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and
                               <xref keyref="attributes-universal/outputclass"

--- a/specification/common/reuse-w-lwdita/reuse-pre.dita
+++ b/specification/common/reuse-w-lwdita/reuse-pre.dita
@@ -15,12 +15,10 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p platform="dita">The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/displayatts"/>,
+         <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>,
                <xref keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>, and
                <xref keyref="attributes-common/spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
-         <p platform="lwdita">The following attributes are available on this element: <xref
-               keyref="attributes-universal"/> and <xref keyref="attributes-common/xmlspace"/>.</p>
+         <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/xmlspace"/>.</p>
       </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-prolog.dita
+++ b/specification/common/reuse-w-lwdita/reuse-prolog.dita
@@ -7,10 +7,8 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/metadataatts"/>, and <xref
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, and <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>.</p>
     </section>
 </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-section.dita
+++ b/specification/common/reuse-w-lwdita/reuse-section.dita
@@ -30,11 +30,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref keyref="attributes-common/spectitle"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/spectitle"
             ><xmlatt>spectitle</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-shortdesc.dita
+++ b/specification/common/reuse-w-lwdita/reuse-shortdesc.dita
@@ -43,8 +43,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
   </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-simpletable.dita
+++ b/specification/common/reuse-w-lwdita/reuse-simpletable.dita
@@ -26,12 +26,10 @@
   </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/displayatts"/>, <xref
-          keyref="attributes-common/simpletableatts"/>, and <xref
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+        conkeyref="reuse-attributes/ref-simpletableatts"/>, and <xref
           keyref="attributes-common/spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-stentry.dita
+++ b/specification/common/reuse-w-lwdita/reuse-stentry.dita
@@ -7,11 +7,9 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             ><xmlatt>specentry</xmlatt></xref>, and the attributes defined below.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attributes defined below.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/stentry-colspan">
           <dt/>

--- a/specification/common/reuse-w-lwdita/reuse-sthead.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sthead.dita
@@ -7,8 +7,7 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
   </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-strow.dita
+++ b/specification/common/reuse-w-lwdita/reuse-strow.dita
@@ -4,6 +4,5 @@
   <shortdesc id="shortdesc">A simple table row is a single row in a simple table.</shortdesc><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section></refbody></reference>

--- a/specification/common/reuse-w-lwdita/reuse-sub.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sub.dita
@@ -13,10 +13,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+            <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+            <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
                         ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"

--- a/specification/common/reuse-w-lwdita/reuse-sup.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sup.dita
@@ -13,10 +13,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+            <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+            <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
                         ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"

--- a/specification/common/reuse-w-lwdita/reuse-title.dita
+++ b/specification/common/reuse-w-lwdita/reuse-title.dita
@@ -7,12 +7,10 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (without the metadata attribute group), <xref
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (without the metadata attribute group), <xref
           keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, and <xref
           keyref="attributes-universal/attr-rev"><xmlatt>rev</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-topic.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topic.dita
@@ -6,13 +6,9 @@
 <refbody>
   <section id="attributes">
    <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref keyref="attributes-common/architecturalatts"
-        />.</p>
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-architecturalatts"/>.</p>
       <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <xref
-          keyref="attributes-common/architecturalatts"/>, <xref
-          keyref="attributes-universal/localizationatts"/>, and <xref
+          keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, and <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required.</p>

--- a/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
@@ -26,11 +26,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>.</p>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </div>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal/localizationatts"/> and <xref keyref="attributes-universal/class"
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/> and <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>.</p>
     </section>
   </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -9,16 +9,12 @@
 <refbody>
   <section id="attributes">
    <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
-        narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-          keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-keys"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
+        narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-universal/idatts"/>, <xref keyref="attributes-common/linkatts"/>
-        (with a narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-          keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/metadataatts"/>, <xref
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>
+        (with a narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"

--- a/specification/common/reuse-w-lwdita/reuse-u.dita
+++ b/specification/common/reuse-w-lwdita/reuse-u.dita
@@ -12,10 +12,8 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p platform="dita">The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>.</p>
-         <p platform="lwdita">The following attributes are available on this element: <xref
-               keyref="attributes-universal/localizationatts"/>, <xref keyref="attributes-universal/class"
+         <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+         <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
                   ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
                   ><xmlatt>keyref</xmlatt></xref>, and <xref
                keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-ul.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ul.dita
@@ -7,12 +7,10 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/compact"
+      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/compact"
             ><xmlatt>compact</xmlatt></xref>, and <xref keyref="attributes-common/spectitle"
             ><xmlatt>spectitle</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
   </refbody>
 </reference>

--- a/specification/common/reuse-w-lwdita/reuse-video.dita
+++ b/specification/common/reuse-w-lwdita/reuse-video.dita
@@ -47,8 +47,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <draft-comment author="rodaande">This list was significantly reworked when the element moved
         into the base vocabulary; need to validate that the list is still correct for
         LwDITA.</draft-comment>

--- a/specification/common/reuse-w-lwdita/reuse-xref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-xref.dita
@@ -8,12 +8,9 @@
     <refbody>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="dita">The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/>,
+            <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>,
                 and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
-            <p platform="lwdita">The following attributes are available on this element: <xref
-                    keyref="attributes-common/linkatts"/>, <xref keyref="attributes-universal/localizationatts"
-                />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+            <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
                     keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"
                 ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -25,8 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required. It is
         referenced by <xmlelement>anchorref</xmlelement> or by the <xmlatt>anchorref</xmlatt>
         attribute on <xmlelement>map</xmlelement> elements.</p>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -61,14 +61,12 @@
         <section id="attributes">
             <title>Attributes</title>
             <sectiondiv id="standard-topicref-attributes">
-                <p>The following attributes are available on this element: <xref
-                        keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"
-                    />, <xref keyref="attributes-common/commonmapatts"/>, <xref
+                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
                         keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
                 <p id="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
                         <li>The <xmlatt>href</xmlatt> attribute refers to an
-                                <xmlelement>ancho</xmlelement> element in this or another DITA
+                                <xmlelement>anchor</xmlelement> element in this or another DITA
                             map.</li>
                         <li>The <xmlatt>format</xmlatt> attribute has a default value of
                                 <keyword>ditamap</keyword>.</li>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -18,8 +18,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal/idatts"/>, <xref
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
                     keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>, <xref
                     keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
                     keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>,

--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -23,8 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry id="type">
           <dt id="attr-type"><xmlatt>type</xmlatt></dt>

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -11,8 +11,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -15,8 +15,7 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"
             ><xmlatt>base</xmlatt></xref>, <xref keyref="attributes-common/attr-align"
             ><xmlatt>align</xmlatt></xref>, <xref keyref="attributes-common/attr-char"
             ><xmlatt>char</xmlatt></xref>, <xref keyref="attributes-common/attr-charoff"

--- a/specification/langRef/base/copyright.dita
+++ b/specification/langRef/base/copyright.dita
@@ -21,8 +21,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref
-     keyref="attributes-universal"/> and the attribute defined below.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
    <dl>
     <dlentry id="type">
      <dt id="attr-type"><xmlatt>type</xmlatt></dt>

--- a/specification/langRef/base/copyryear.dita
+++ b/specification/langRef/base/copyryear.dita
@@ -14,8 +14,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="year">
           <dt id="attr-year"><xmlatt>year</xmlatt></dt>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -13,9 +13,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/dateatts"/>, and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-dateatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="date">
           <dt id="attr-date"><xmlatt>date</xmlatt>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -17,8 +17,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keys"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, and <xref keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -23,8 +23,7 @@
       <p>The following attributes are available on this element: <xref
           keyref="attributes-common/attr-xmlns-ditaarch"><xmlatt>xmlns:ditaarch</xmlatt></xref>,
           <xref keyref="attributes-common/attr-DITAArchVersion"
-          ><xmlatt>DITAArchVersion</xmlatt></xref>, and <xref
-          keyref="attributes-universal/localizationatts"/>.</p>
+          ><xmlatt>DITAArchVersion</xmlatt></xref>, and <ph conkeyref="reuse-attributes/ref-localizationatts"/>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows a ditabase document that contains multiple topics:</p><codeblock>&lt;dita&gt;

--- a/specification/langRef/base/ditavalmeta.dita
+++ b/specification/langRef/base/ditavalmeta.dita
@@ -29,8 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this
         domain).</p>
     </section>
 <example id="example" otherprops="examples" conkeyref="reuse-examples/ditavalref"/>

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -122,8 +122,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and the attributes defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -23,8 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <p id="attr-exception">For this element, the <xmlatt>translate</xmlatt> attribute has a
         default value of <keyword>no</keyword>.</p>
       <dl>

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -37,8 +37,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrKeyscopePrefix</keyword>.</p>

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -37,8 +37,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrKeyscopeSuffix</keyword>.</p>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -38,8 +38,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrResourcPrefix</keyword>.</p>

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -42,8 +42,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrResourcSuffix</keyword>.</p>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -16,8 +16,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal/idatts"/>, <xref keyref="attributes-universal/attr-status"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref keyref="attributes-universal/attr-status"
             ><xmlatt>status</xmlatt></xref>, <xref keyref="attributes-universal/attr-base"
             ><xmlatt>base</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>, <xref keyref="attributes-universal/attr-translate"

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -14,8 +14,7 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-      /> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>,
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (without the Metadata attribute group), <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>,
         <xref keyref="attributes-universal/attr-rev"><xmlatt>rev</xmlatt></xref>, <xref keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref>, <xref keyref="attributes-common/attr-char"><xmlatt>char</xmlatt></xref>,
         <xref keyref="attributes-common/attr-charoff"><xmlatt>charoff</xmlatt></xref>, <xref keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>,
         <xref keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, and <xref keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>, and the attributes defined below.</p>

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -69,8 +69,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal/idatts"/>, <xref
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
                     keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>, <xref
                     keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
                     keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>,

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -17,8 +17,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="scheme-HAS-elements">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/>, <xref
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
             keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
             <xref keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -23,8 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv>
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/> and <xref keyref="attributes-common/spectitle"
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/spectitle"
               ><xmlatt>spectitle</xmlatt></xref>, and the attribute defined below.</p>
         <dl>
           <dlentry id="type">

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -31,8 +31,7 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
     <section id="attributes">
       <title>Attributes</title>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -67,9 +67,7 @@ attribute.</p>
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-common/inclusionatts"
-                />, <xref keyref="attributes-common/linkatts"/>, and <xref
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
                     keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/base/index-see-also.dita
+++ b/specification/langRef/base/index-see-also.dita
@@ -23,8 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/index-see.dita
+++ b/specification/langRef/base/index-see.dita
@@ -26,8 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -71,8 +71,7 @@ index entry would be sorted.</shortdesc>
                 </section>
                 <section id="attributes">
                         <title>Attributes</title>
-                        <p>The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/> and <xref
+                        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
                                         keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                 </section>

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -22,8 +22,7 @@
     <!--<section id="processing-expectations"><title>Processing expectations</title><p>It is an error if an <xmlelement>indexterm</xmlelement> that contains <xmlelement>indexterm</xmlelement> children contains both an <xmlelement>index-see</xmlelement> and an <xmlelement>index-see-also</xmlelement> element. In the case of this error condition, an implementation <term outputclass="RFC-2119">MAY</term> give an error message; it <term outputclass="RFC-2119">MAY</term> recover by treating all such <xmlelement>index-see</xmlelement> elements as <xmlelement>index-see-also</xmlelement> elements.</p></section>-->
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/base/keytext.dita
+++ b/specification/langRef/base/keytext.dita
@@ -31,8 +31,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
         </section>
         <example id="example" otherprops="examples">
             <title>Examples</title>

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -17,8 +17,7 @@ space within the <xmlelement>lines</xmlelement> element.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-                />, <xref keyref="attributes-common/displayatts"/>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-displayatts"/>, <xref
                     keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>, and <xref
                     keyref="attributes-common/spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
     </section>

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -24,8 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-role"
             ><xmlatt>role</xmlatt></xref>, and <xref keyref="attributes-common/attr-otherrole"
             ><xmlatt>otherrole</xmlatt></xref>.</p>

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -28,8 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/collection-type"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/collection-type"
         ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-role"
             ><xmlatt>role</xmlatt></xref>, <xref keyref="attributes-common/attr-otherrole"
             ><xmlatt>otherrole</xmlatt></xref>, <xref keyref="attributes-common/attr-duplicates"

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -26,7 +26,7 @@
         topics are rendered on the same page in a PDF.</p>
     </section>
 <section id="attributes"><title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>,
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
           <xref keyref="attributes-common/collection-type"><xmlatt>collection-type</xmlatt></xref>,
           <xref keyref="attributes-common/attr-role"><xmlatt>role</xmlatt></xref>, <xref
           keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>, <xref

--- a/specification/langRef/base/linktitle.dita
+++ b/specification/langRef/base/linktitle.dita
@@ -41,8 +41,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attribute listed below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
       <dl id="dl_w2g_qvq_lpb">
         <dlentry>
           <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -13,9 +13,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/linkatts"/>, and <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -22,9 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/linkatts"/>, and <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -18,8 +18,7 @@
         added to help with translation, moving translatable titles out of @reftitle. Not sure why we
         still have reftitle and all the linking attributes on lq itself, when that's what
         longquoteref is for?</draft-comment>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
       <dl>
         <dlentry id="reftitle">

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -46,10 +46,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="mapref-attributes">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
-          narrowed definition of  <xmlatt>format</xmlatt>, given below), <xref
-            keyref="attributes-common/commonmapatts"/>, <xref keyref="attributes-keyref"
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
+          narrowed definition of  <xmlatt>format</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-keys"
               ><xmlatt>keys</xmlatt></xref>.</p>
         <dl>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -24,10 +24,8 @@
         </section>
         <section id="attributes">
           <title>Attributes</title>
-          <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/> (with a
-        narrowed definition of <xmlatt>href</xmlatt>, given below), <xref
-          keyref="attributes-common/commonmapatts"/> (with the exclusion of <xmlatt>chunk</xmlatt> and
+          <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
+        narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (with the exclusion of <xmlatt>chunk</xmlatt> and
           <xmlatt>collection-type</xmlatt>, and a narrowed definition of
           <xmlatt>processing-role</xmlatt>, given below), <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
@@ -44,8 +42,7 @@
             <dlentry>
               <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt></dt>
           <dd>Specifies the role that the resource plays in processing. By default, this is set to
-              <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <xref
-              keyref="attributes-common/commonmapatts"/>.</dd>
+              <keyword>resource-only</keyword>. Otherwise, the definition matches the one in <ph conkeyref="reuse-attributes/ref-commonmapatts"/>.</dd>
             </dlentry>
           </dl>
         </section>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -33,8 +33,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p id="universal-outputclass">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attribute
+      <p id="universal-outputclass">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -31,8 +31,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and the
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the
                 attributes defined below.</p>
             <dl>
                 <dlentry id="archive">

--- a/specification/langRef/base/ol.dita
+++ b/specification/langRef/base/ol.dita
@@ -9,7 +9,7 @@
 </metadata></prolog>
 <refbody>
     <section conkeyref="reuse-ol/attributes" id="attributes"><p>The following attributes are available on this
-                element: <xref keyref="attributes-universal"/>, <xref
+                element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
                     keyref="attributes-common/compact"/>, and <xref
                     keyref="attributes-common/spectitle"/>.</p></section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -22,8 +22,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref
-     keyref="attributes-universal"/> and the attributes defined below.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
    <dl>
     <dlentry id="name">
      <dt id="attr-name"><xmlatt>name</xmlatt>

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -23,8 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-name"><xmlatt>name</xmlatt>

--- a/specification/langRef/base/permissions.dita
+++ b/specification/langRef/base/permissions.dita
@@ -18,8 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
       <dl>
         <dlentry id="view">
           <dt id="attr-view"><xmlatt>view</xmlatt></dt>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -19,9 +19,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref
-                    keyref="attributes-common/linkatts"/>, and <xref
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
                     keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -22,8 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>scope</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>type</xmlatt></xref>, <xref
           keyref="attributes-common/attr-role"><xmlatt>role</xmlatt></xref>, and <xref

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -45,8 +45,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keys"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>,  <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, <xref

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -20,8 +20,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt>),
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt>),
           <xref keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -69,8 +69,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt>
         or <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-type"
             ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
             ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -55,8 +55,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
           <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-type"
             ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
             ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -38,8 +38,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> (with a modified definition of
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (with a modified definition of
           <xmlatt>translate</xmlatt>, given below), and the attributes
         defined below.<dl>
 <dlentry>

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -72,8 +72,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry id="appname">
           <dt id="attr-appname"><xmlatt>appname</xmlatt></dt>

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -14,9 +14,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/dateatts"/>, and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-dateatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="modified">
           <dt id="attr-modified"><xmlatt>modified</xmlatt>

--- a/specification/langRef/base/row.dita
+++ b/specification/langRef/base/row.dita
@@ -4,7 +4,6 @@
     Model.</shortdesc><prolog><metadata><keywords><indexterm>table elements<indexterm><xmlelement>row</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref> and <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref> and <xref
           keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>.</p>
     </section><example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -20,8 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="standard-topicref-attributes">
-        <p>The following attributes are available on this element: <xref
-            keyref="attributes-universal"/>, <xref keyref="attributes-common/linkatts"/>, <xref
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
             keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <p id="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -35,8 +35,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attribute listed below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
       <dl id="dl_w2g_qvq_lpb">
         <dlentry>
           <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/sl.dita
+++ b/specification/langRef/base/sl.dita
@@ -13,8 +13,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-                />, <xref keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>, and
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>, and
                     <xref keyref="attributes-common/spectitle"
                 ><xmlatt>spectitle</xmlatt></xref>.</p>
     </section>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -94,8 +94,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p id="only-universal">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-common/attr-name"
+      <p id="only-universal">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-name"
             ><xmlatt>name</xmlatt></xref>, and <xref keyref="attributes-common/attr-value"
             ><xmlatt>value</xmlatt></xref>.</p>
       <p id="attr-exception">For this element,<ul id="ul_g3c_412_ppb">

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -27,9 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/linkatts"/> (with a narrowed definition for
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition for
           <xmlatt>href</xmlatt>, given below), and <xref
           keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <dl>

--- a/specification/langRef/base/state.dita
+++ b/specification/langRef/base/state.dita
@@ -10,8 +10,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p id="universal-outputclass">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attributes
+      <p id="universal-outputclass">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes
         defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/subjectCell.dita
+++ b/specification/langRef/base/subjectCell.dita
@@ -21,9 +21,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/> and <xref
-                                        keyref="attributes-common/commonmapatts"/>,  <xref
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-commonmapatts"/>,  <xref
                                         keyref="attributes-common/attr-type"
                                         ><xmlatt>type</xmlatt></xref>, <xref
                                         keyref="attributes-common/attr-scope"

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -26,8 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/attr-processing-role"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-processing-role"
           ><xmlatt>processing-role</xmlatt></xref>, <xref keyref="attributes-common/attr-toc"
             ><xmlatt>toc</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, and <xref

--- a/specification/langRef/base/subjectRole.dita
+++ b/specification/langRef/base/subjectRole.dita
@@ -27,7 +27,7 @@
     </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>,
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
           <xref keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, and <xref
           keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -18,9 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/commonmapatts"/>, <xref
-          keyref="attributes-common/architecturalatts"/>, <xref keyref="attributes-common/attr-type"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, <xref keyref="attributes-common/attr-type"
             ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
             ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
             ><xmlatt>format</xmlatt></xref>, and the attribute defined below.</p>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -30,9 +30,7 @@
                 </section>
                 <section id="attributes">
                         <title>Attributes</title>
-                        <p>The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/>, <xref
-                                        keyref="attributes-common/linkatts"/>, <xref
+                        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
                                         keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, <xref
                                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>,
                                         <xref keyref="attributes-common/attr-processing-role"

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -18,8 +18,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
           ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"

--- a/specification/langRef/base/subtitle.dita
+++ b/specification/langRef/base/subtitle.dita
@@ -33,8 +33,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attribute listed below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
       <dl id="dl_w2g_qvq_lpb">
         <dlentry>
           <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/table.dita
+++ b/specification/langRef/base/table.dita
@@ -30,8 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/attr-frame"><xmlatt>frame</xmlatt></xref>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-frame"><xmlatt>frame</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scale"><xmlatt>scale</xmlatt></xref>, <xref
           keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
           keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, <xref

--- a/specification/langRef/base/tbody.dita
+++ b/specification/langRef/base/tbody.dita
@@ -8,7 +8,6 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/tgroup.dita
+++ b/specification/langRef/base/tgroup.dita
@@ -15,8 +15,7 @@
   <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
           keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, <xref
           keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref> and the attribute
         defined below.</p>

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -8,8 +8,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-                /> and <xref keyref="attributes-common/attr-valign"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-valign"
                 ><xmlatt>valign</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>See <xref keyref="elements-table"/>.</p></example></refbody></reference>

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -112,8 +112,7 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and the attribute listed below.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
             <dl>
                 <dlentry>
                     <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/titlehint.dita
+++ b/specification/langRef/base/titlehint.dita
@@ -34,8 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and the attribute listed below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attribute listed below.</p>
       <dl id="dl_w2g_qvq_lpb">
         <dlentry>
           <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -10,8 +10,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-tmtype"><xmlatt>tmtype</xmlatt>

--- a/specification/langRef/base/topicCell.dita
+++ b/specification/langRef/base/topicCell.dita
@@ -22,9 +22,9 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and <xref
-                    keyref="attributes-common/commonmapatts"/>, <xref
+            <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
                     keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
                     keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
                     keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -23,8 +23,7 @@ can identify a single subject. Additional subjects can be specified by nested
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
           ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -43,11 +43,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal"/> and <xref
-          keyref="attributes-common/commonmapatts"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-commonmapatts"/>.</p>
       <p>The <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> attributes
-        from <xref keyref="attributes-common/linkatts"/> are also available.</p>
+        from <ph conkeyref="reuse-attributes/ref-linkatts"/> are also available.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the following code sample, the <xmlelement>topicgroup</xmlelement> element specifies common
         attributes (<xmlatt>audience</xmlatt> and <xmlatt>linking</xmlatt>) that are inherited by

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -37,8 +37,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/commonmapatts"/>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, and <xref
           keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -29,8 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        />, <xref keyref="attributes-common/linkatts"/>, <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
           ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -26,9 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-          keyref="attributes-universal/idatts"/>, <xref keyref="attributes-universal/metadataatts"
-        />, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, and the
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/vrm.dita
+++ b/specification/langRef/base/vrm.dita
@@ -13,8 +13,7 @@
 <refbody>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and the attributes defined
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
                 below.</p>
             <dl>
                 <dlentry id="version">


### PR DESCRIPTION
Switches links from Attribute sections to attribute groups so that they use a common `xref` (with controlled link text and hover help) rather than relying on the same key definitions used for TOC and other links.