### PR TITLE
Move remaining "complex atts" topics to arch spec

### DIFF
--- a/specification/archSpec/base/key-based-addressing.ditamap
+++ b/specification/archSpec/base/key-based-addressing.ditamap
@@ -5,8 +5,9 @@
     <topicref href="key-based-addressing.dita">
         <topicref href="keys-core-concepts.dita"/>
         <topicref keys="attributes-keys" href="thekeysattribute.dita"/>
-        <topicref href="keyScopes.dita"/>
+        <topicref href="thekeyrefattribute.dita" keys="attributes-keyref"/>
         <topicref href="using-keys-for-addressing.dita"/>
+        <topicref href="keyScopes.dita"/>
         <topicref href="using-keys-to-address-keys-across-scopes.dita"/>
         <topicref href="links-between-maps.dita"/>
         <topicref href="processing-key-references-general.dita"/>

--- a/specification/archSpec/base/key-based-addressing.ditamap
+++ b/specification/archSpec/base/key-based-addressing.ditamap
@@ -4,6 +4,7 @@
     <title>Key-based addressing</title>
     <topicref href="key-based-addressing.dita">
         <topicref href="keys-core-concepts.dita"/>
+        <topicref keys="attributes-keys" href="thekeysattribute.dita"/>
         <topicref href="keyScopes.dita"/>
         <topicref href="using-keys-for-addressing.dita"/>
         <topicref href="using-keys-to-address-keys-across-scopes.dita"/>

--- a/specification/archSpec/base/key-based-addressing.ditamap
+++ b/specification/archSpec/base/key-based-addressing.ditamap
@@ -8,6 +8,10 @@
         <topicref href="thekeyrefattribute.dita" keys="attributes-keyref"/>
         <topicref href="using-keys-for-addressing.dita"/>
         <topicref href="keyScopes.dita"/>
+        <!-- TODO: merge the content from the key scope topics above and below this.
+            Ensure the result has a key to be referenced from the langRef topics, currently
+            "attributes-keyscope" -->
+        <topicref href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
         <topicref href="using-keys-to-address-keys-across-scopes.dita"/>
         <topicref href="links-between-maps.dita"/>
         <topicref href="processing-key-references-general.dita"/>

--- a/specification/archSpec/base/the-key-scope-attribute.dita
+++ b/specification/archSpec/base/the-key-scope-attribute.dita
@@ -14,12 +14,17 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>attributes, complex<indexterm><xmlatt>keyscope</xmlatt></indexterm></indexterm>
+        <indexterm>key reference
+          attributes<indexterm><xmlatt>keyscope</xmlatt></indexterm></indexterm>
       </keywords>
     </metadata>
   </prolog>
   <refbody>
     <section id="duplicate-scope">
+      <draft-comment author="robander" time="19 May 2021">This topic contains a lot of processor /
+        implementation rules and was moved from the langref to the archspec seciton about keys. Need
+        to merge with existing key scope rules to ensure no duplication / no conflicting
+        content.</draft-comment>
       <p>All key scopes are contiguous and non-intersecting. Within a root map, two distinct key
         scopes with the same name have no relationship with each other aside from that implied by
         their relative locations in the key scope hierarchy. They do not, for example, share key

--- a/specification/archSpec/base/thekeyrefattribute.dita
+++ b/specification/archSpec/base/thekeyrefattribute.dita
@@ -11,12 +11,18 @@
  <prolog>
   <metadata>
    <keywords>
-    <indexterm>attributes, complex<indexterm><xmlatt>keyref</xmlatt></indexterm></indexterm>
+    <indexterm>key reference attributes<indexterm><xmlatt>keyref</xmlatt></indexterm></indexterm>
    </keywords>
   </metadata>
  </prolog>
  <refbody>
   <section id="section-1">
+   <draft-comment author="robander">This topic moved from the arch spec section. It needs editing
+     for<ul id="ul_fln_ssb_rpb">
+     <li>Overlap with existing content - likely needs to merge, definitely remove duplication</li>
+     <li>This topic uses a key and the langRef links to it from the definition for @keyref, so if
+      this topic goes away, be sure to update that keyref</li>
+    </ul></draft-comment>
    <p>For elements that only refer to topics or non-DITA resources, the value of the
      <xmlatt>keyref</xmlatt> attribute is a key name. For elements that <ph 
      >can</ph> refer to elements within maps or topics, the value of the <xmlatt>keyref</xmlatt>

--- a/specification/archSpec/base/thekeysattribute.dita
+++ b/specification/archSpec/base/thekeysattribute.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
  "reference.dtd">
 <reference id="thekeysattribute" xml:lang="en-us">
- <title>The <xmlatt>keys</xmlatt> attribute</title>
+ <title>Setting key names with the <xmlatt>keys</xmlatt> attribute</title>
  <shortdesc>A <xmlatt>keys</xmlatt> attribute consists of one or more space-separated keys. Map
   authors define keys using a <xmlelement>topicref</xmlelement> or <xmlelement>topicref</xmlelement>
   specialization that contains the <xmlatt>keys</xmlatt> attribute. Each key definition introduces
@@ -13,12 +13,17 @@
  <prolog>
   <metadata>
    <keywords>
-    <indexterm>attributes, complex<indexterm><xmlatt>keys</xmlatt></indexterm></indexterm>
+    <indexterm>key reference attributes<indexterm><xmlatt>keys</xmlatt></indexterm></indexterm>
    </keywords>
   </metadata>
  </prolog>
  <refbody>
   <section id="section-1">
+   <draft-comment author="robander" time="19 May 2021">This topic was moved from the langref; it
+    needs to be here as it defines normative rules about the syntax of a key attribute. The
+    following paragraph comes from reuse-general but in the base spec this is the only use, so
+    should probably be taken out of the reuse file. Need to go over this section more closely now
+    that attribute content has moved here.</draft-comment>
    <p conkeyref="reuse-general/keys-attribute-syntax"/>
    <p>A key <ph >cannot</ph> resolve to sub-topic elements, although a
      <xmlatt>keyref</xmlatt> attribute <ph >can</ph> do so by combining a key

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -139,7 +139,7 @@
                                 element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph
                                         conkeyref="reuse-attributes/ref-linkatts"/>, <ph
                                         conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
-                                        keyref="attributes-keyref"
+                                        keyref="attributes-common/attr-keyref"
                                 ><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass">The following attributes are available on this element: <ph
                                         conkeyref="reuse-attributes/ref-dataatts"/>, <ph
                                         conkeyref="reuse-attributes/ref-linkatts"/>, and <ph
@@ -148,7 +148,7 @@
                                         conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
                                         keyref="attributes-common/name"/>.</p><p id="universal-keyref">The following attributes are available on this element: <ph
                                         conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-                                        keyref="attributes-keyref"
+                                        keyref="attributes-common/attr-keyref"
                                 ><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-specentry" platform="dita">The following attributes are available on this element:
                                         <ph conkeyref="reuse-attributes/ref-universalatts"/> and
                                         <xref keyref="attributes-common/specentry"/>.</p><p id="universal-spectitle" platform="dita">The following attributes are available on this element:
@@ -199,7 +199,7 @@
                                                 ><xmlatt>spectitle</xmlatt></xref>.</p><p id="xref-attributes">The following attributes are available on this element: <ph
                                         conkeyref="reuse-attributes/ref-universalatts"/>, <ph
                                         conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-                                        keyref="attributes-keyref"
+                                        keyref="attributes-common/attr-keyref"
                                 ><xmlatt>keyref</xmlatt></xref>.</p><sectiondiv id="fn-attributes">
 <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/> and
@@ -227,7 +227,7 @@ element. The default value is the empty string "".</dd>
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>
                                         (with a narrowed definition for <xmlatt>type</xmlatt>, given
-                                        below), and <xref keyref="attributes-keyref"
+                                        below), and <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="type">
@@ -247,7 +247,7 @@ element. The default value is the empty string "".</dd>
                                                 conkeyref="reuse-attributes/ref-commonmapatts"/>,
                                                 <xref keyref="attributes-common/attr-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                keyref="attributes-keyref"
+                                                keyref="attributes-common/attr-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="bookmap-booklist-attributes" platform="dita">
                                 <p>The following attributes are available on this element: <ph
@@ -255,7 +255,7 @@ element. The default value is the empty string "".</dd>
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>
                                         (with a narrowed definition of <xmlatt>href</xmlatt>, given
                                         below), <ph conkeyref="reuse-attributes/ref-commonmapatts"
-                                        />, and <xref keyref="attributes-keyref"
+                                        />, and <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry id="href-for-booklist">
@@ -282,13 +282,13 @@ element. The default value is the empty string "".</dd>
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
                                                 conkeyref="reuse-attributes/ref-commonmapatts"/>,
-                                        and <xref keyref="attributes-keyref"
+                                        and <xref keyref="attributes-common/attr-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="bookmap-frontbackmatter" platform="dita">
                                 <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,
                                                 <ph conkeyref="reuse-attributes/ref-commonmapatts"
-                                        />, and <xref keyref="attributes-keyref"
+                                        />, and <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>. This element also
                                         uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and
                                                 <xmlatt>type</xmlatt> from <ph
@@ -392,13 +392,13 @@ of map.-->
                                                   ><xmlatt>processing-role</xmlatt></xref>, <xref
                                                           keyref="attributes-common/attr-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                keyref="attributes-keyref"
+                                                keyref="attributes-common/attr-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                         </sectiondiv><sectiondiv id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>-->
                                 <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/> and
-                                                <xref keyref="attributes-keyref"
+                                                <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <p id="attr-exception">For this element, the
                                                 <xmlatt>translate</xmlatt> attribute has a default
@@ -447,7 +447,7 @@ of map.-->
                         </dl></section>
                 <section id="section-2"><title>Reusable groups for syntax diagram elements</title><p>These tend to
                                 be similar, with tweaks in <xmlatt>importance</xmlatt>, or adding/removing <xref
-                                        keyref="attributes-keyref"
+                                        keyref="attributes-common/attr-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p><p><keyword>optreq-sectiondiv</keyword> is used by <xmlelement>delim</xmlelement>,
                                         <xmlelement>repsep</xmlelement>. The
                                         <xmlatt>importance</xmlatt> definition inside is also used
@@ -522,7 +522,7 @@ of map.-->
                                 <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/>
                                         (with a narrowed definition of <xmlatt>importance</xmlatt>,
-                                        given below) and <xref keyref="attributes-keyref"
+                                        given below) and <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
                                 <dl>
                                         <dlentry>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -245,7 +245,7 @@ element. The default value is the empty string "".</dd>
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
                                                 conkeyref="reuse-attributes/ref-commonmapatts"/>,
-                                                <xref keyref="attributes-keys"
+                                                <xref keyref="attributes-common/attr-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                                 keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
@@ -390,7 +390,7 @@ of map.-->
                                                 <xref
                                                 keyref="attributes-common/attr-processing-role"
                                                   ><xmlatt>processing-role</xmlatt></xref>, <xref
-                                                keyref="attributes-keys"
+                                                          keyref="attributes-common/attr-keys"
                                                 ><xmlatt>keys</xmlatt></xref>, and <xref
                                                 keyref="attributes-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-alt.dita
+++ b/specification/common/reuse-w-lwdita/reuse-alt.dita
@@ -14,7 +14,7 @@
                                         <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
                                         keyref="attributes-universal/class"
                                         ><xmlatt>class</xmlatt></xref>, <xref
-                                        keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>,
+                                        keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>,
                                 and <xref keyref="attributes-universal/outputclass"
                                                 ><xmlatt>outputclass</xmlatt></xref>.</p>
         </section>

--- a/specification/common/reuse-w-lwdita/reuse-b.dita
+++ b/specification/common/reuse-w-lwdita/reuse-b.dita
@@ -14,7 +14,7 @@
    <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
   </section>

--- a/specification/common/reuse-w-lwdita/reuse-data.dita
+++ b/specification/common/reuse-w-lwdita/reuse-data.dita
@@ -53,9 +53,9 @@
       <p platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"
-        />, and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+        />, and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+            ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
             ><xmlatt>outputclass</xmlatt></xref>.</p>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-i.dita
+++ b/specification/common/reuse-w-lwdita/reuse-i.dita
@@ -15,7 +15,7 @@
             <title>Attributes</title>
             <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
             <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"
                 ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -14,14 +14,14 @@
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-href"/>, <xref
           keyref="attributes-common/attr-format"/>, <xref keyref="attributes-common/attr-scope"/>,
-          <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
+          <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
         defined below.</p>
       <p platform="lwdita"><draft-comment author="robander">href, format, and scope were moved from
           the DL (marked for both lwdita and dita) into the paragraph above for full DITA; not sure
           if they apply to lwdita, if so, the three should be listed here as
         well.</draft-comment>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       <dl>
         <dlentry platform="dita">

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -27,7 +27,7 @@
         <p platform="dita">The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <ph
             conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keyref"
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-common/attr-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
         <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition of
             <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/class"

--- a/specification/common/reuse-w-lwdita/reuse-ph.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ph.dita
@@ -27,11 +27,11 @@
             </section>
             <section id="attributes">
                   <title>Attributes</title>
-                  <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-keyref"
+                  <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"
                                     ><xmlatt>keyref</xmlatt></xref>.</p>
                   <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
                               keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>,
-                              <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and
+                              <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and
                               <xref keyref="attributes-universal/outputclass"
                                     ><xmlatt>outputclass</xmlatt></xref>.</p>
             </section>

--- a/specification/common/reuse-w-lwdita/reuse-sub.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sub.dita
@@ -15,7 +15,7 @@
             <title>Attributes</title>
             <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
             <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"
                 ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-sup.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sup.dita
@@ -15,7 +15,7 @@
             <title>Attributes</title>
             <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
             <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+                        ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"
                 ><xmlatt>outputclass</xmlatt></xref>.</p>

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -9,16 +9,22 @@
 <refbody>
   <section id="attributes">
    <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/> (with a
-        narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keys"
-            ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-keyref"
-            ><xmlatt>keyref</xmlatt></xref>.</p>
-      <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>
-        (with a narrowed definition of <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref
+      <p platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition of
+          <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-commonmapatts"/>,
+          <xref keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p platform="lwdita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
+          conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition of
+          <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"
+        />, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
-            ><xmlatt>keys</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
-            ><xmlatt>outputclass</xmlatt></xref>.</p>
+          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       <draft-comment author="robander" time="15 May 2021">Would like to convert this into an
         attribute-exception paragraph, reminding that topicref is meant to refer to topic-level
         elements, but before doing that, need to make sure the href topic is updated with the same

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -22,7 +22,7 @@
           <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"
         />, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
           keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       <draft-comment author="robander" time="15 May 2021">Would like to convert this into an

--- a/specification/common/reuse-w-lwdita/reuse-u.dita
+++ b/specification/common/reuse-w-lwdita/reuse-u.dita
@@ -14,7 +14,7 @@
          <title>Attributes</title>
          <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
          <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"
-                  ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-keyref"
+                  ><xmlatt>class</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
                   ><xmlatt>keyref</xmlatt></xref>, and <xref
                keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
       </section>

--- a/specification/common/reuse-w-lwdita/reuse-xref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-xref.dita
@@ -9,9 +9,9 @@
         <section id="attributes">
             <title>Attributes</title>
             <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>,
-                and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+                and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
             <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-                    keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+                    keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
                     keyref="attributes-universal/outputclass"
                 ><xmlatt>outputclass</xmlatt></xref>.</p>
         </section>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -383,7 +383,9 @@
           <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
           <dd><ph id="keyrefDescription"><xmlatt>keyref</xmlatt> provides a redirectable reference
               based on a key defined within a map. See <xref keyref="attributes-keyref"/> for
-              information on using this attribute. </ph></dd>
+              information on using this attribute. </ph><draft-comment author="robander">The
+              definiton above for @keyref should be synchronized with the definition in the linked
+              section on keys.</draft-comment></dd>
         </dlentry>
         <dlentry>
           <dt id="attr-keys"><xmlatt>keys</xmlatt></dt>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -385,6 +385,11 @@
               based on a key defined within a map. See <xref keyref="attributes-keyref"/> for
               information on using this attribute. </ph></dd>
         </dlentry>
+        <dlentry>
+          <dt id="attr-keys"><xmlatt>keys</xmlatt></dt>
+          <dd>Specifies one or more names for a resource. See <xref keyref="attributes-keys"/> for
+            information on using this attribute.</dd>
+        </dlentry>
         <dlentry id="keyscope" platform="dita">
           <dt id="attr-keyscope"><xmlatt>keyscope</xmlatt> (common map attributes)</dt>
           <dd>Specifies that the element marks the boundaries of a key scope. See <xref

--- a/specification/langRef/attributes/complexattributedefinitions.dita
+++ b/specification/langRef/attributes/complexattributedefinitions.dita
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
-<reference id="complexattributedefinitions" xml:lang="en-us">
-<title>Complex attribute definitions</title>
-<shortdesc>Several DITA attributes require more explanation. Those attributes are collected
-  here.</shortdesc>
-</reference>

--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -7,7 +7,6 @@
   <topicref keyref="attributes-common"/>
   <topicref keyref="attributes-complex-attributes-container">
    <topicref keyref="attributes-keyref"/>
-   <topicref keyref="attributes-keys"/>
    <topicref keyref="attributes-keyscope" platform="dita"/>
   </topicref>
  </topicref>

--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -5,8 +5,5 @@
  <topicref keyref="attributes-container-topic">
   <topicref keyref="attributes-universal"/>
   <topicref keyref="attributes-common"/>
-  <topicref keyref="attributes-complex-attributes-container">
-   <topicref keyref="attributes-keyscope" platform="dita"/>
-  </topicref>
  </topicref>
 </map>

--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -6,7 +6,6 @@
   <topicref keyref="attributes-universal"/>
   <topicref keyref="attributes-common"/>
   <topicref keyref="attributes-complex-attributes-container">
-   <topicref keyref="attributes-keyref"/>
    <topicref keyref="attributes-keyscope" platform="dita"/>
   </topicref>
  </topicref>

--- a/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
@@ -6,5 +6,4 @@
  <keydef href="universalAttributes.dita" keys="attributes-universal"/>
  <keydef href="commonAttributes.dita" keys="attributes-common"/>
  <keydef href="complexattributedefinitions.dita" keys="attributes-complex-attributes-container"/>
- <keydef href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
 </map>

--- a/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
@@ -7,6 +7,5 @@
  <keydef href="commonAttributes.dita" keys="attributes-common"/>
  <keydef href="complexattributedefinitions.dita" keys="attributes-complex-attributes-container"/>
  <keydef href="thekeyrefattribute.dita" keys="attributes-keyref"/>
- <keydef href="thekeysattribute.dita" keys="attributes-keys"/>
  <keydef href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
 </map>

--- a/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
@@ -5,5 +5,4 @@
  <keydef href="attributes.dita" keys="attributes-container-topic"/>
  <keydef href="universalAttributes.dita" keys="attributes-universal"/>
  <keydef href="commonAttributes.dita" keys="attributes-common"/>
- <keydef href="complexattributedefinitions.dita" keys="attributes-complex-attributes-container"/>
 </map>

--- a/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap
@@ -6,6 +6,5 @@
  <keydef href="universalAttributes.dita" keys="attributes-universal"/>
  <keydef href="commonAttributes.dita" keys="attributes-common"/>
  <keydef href="complexattributedefinitions.dita" keys="attributes-complex-attributes-container"/>
- <keydef href="thekeyrefattribute.dita" keys="attributes-keyref"/>
  <keydef href="the-key-scope-attribute.dita" keys="attributes-keyscope"/>
 </map>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -66,7 +66,7 @@
                         conkeyref="reuse-attributes/ref-linkatts"/>, <ph
                         conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
                         keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-                        keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
+                        keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
                 <p id="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
                         <li>The <xmlatt>href</xmlatt> attribute refers to an
                                 <xmlelement>anchor</xmlelement> element in this or another DITA

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -61,8 +61,11 @@
         <section id="attributes">
             <title>Attributes</title>
             <sectiondiv id="standard-topicref-attributes">
-                <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
-                        keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+                <p>The following attributes are available on this element: <ph
+                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+                        conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+                        conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
+                        keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
                 <p id="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
                         <li>The <xmlatt>href</xmlatt> attribute refers to an

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -12,7 +12,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>In the following code sample, the <xmlelement>cite</xmlelement> element is used to mark up

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -17,7 +17,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keys"
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, and <xref keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -20,7 +20,7 @@
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keys"
-            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, and <xref keyref="attributes-common/attr-toc"
             ><xmlatt>toc</xmlatt></xref>.</p>

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -22,7 +22,7 @@
             conkeyref="reuse-attributes/ref-linkatts"/>, <xref
             keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
             <xref keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </sectiondiv>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/hasRelated.dita
+++ b/specification/langRef/base/hasRelated.dita
@@ -17,9 +17,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="scheme-HAS-elements">
-        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
+        <p>The following attributes are available on this element: <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-linkatts"/>, <xref
             keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
-            <xref keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+            <xref keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
             keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </sectiondiv>
     </section>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -31,7 +31,7 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
     <section id="attributes">
       <title>Attributes</title>
       <!--Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of glossSymbol.-->
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -68,7 +68,7 @@ attribute.</p>
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-                    keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">
             <title>Examples</title>

--- a/specification/langRef/base/index-see-also.dita
+++ b/specification/langRef/base/index-see-also.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">
 <title>Examples</title>

--- a/specification/langRef/base/index-see.dita
+++ b/specification/langRef/base/index-see.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -72,7 +72,7 @@ index entry would be sorted.</shortdesc>
                 <section id="attributes">
                         <title>Attributes</title>
                         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-                                        keyref="attributes-keyref"
+                                        keyref="attributes-common/attr-keyref"
                                                 ><xmlatt>keyref</xmlatt></xref>.</p>
                 </section>
 <example id="example" otherprops="examples"><p>This is an example of an index entry for <codeph>&lt;data&gt;</codeph> that will be sorted as

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -23,7 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry id="start">

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-role"
             ><xmlatt>role</xmlatt></xref>, and <xref keyref="attributes-common/attr-otherrole"
             ><xmlatt>otherrole</xmlatt></xref>.</p>

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -14,7 +14,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/longquoteref.dita
+++ b/specification/langRef/base/longquoteref.dita
@@ -23,7 +23,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
             <p>In the following code sample, the <xmlelement>longdescref</xmlelement> element

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -18,7 +18,7 @@
         added to help with translation, moving translatable titles out of @reftitle. Not sure why we
         still have reftitle and all the linking attributes on lq itself, when that's what
         longquoteref is for?</draft-comment>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-keyref"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
       <dl>
         <dlentry id="reftitle">

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -49,7 +49,7 @@
         <p>The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <ph
             conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keyref"
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-common/attr-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-common/attr-keys"
               ><xmlatt>keys</xmlatt></xref>.</p>
         <p id="attr-exception">For this element, the <xmlatt>format</xmlatt> attribute has a default

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -50,7 +50,7 @@
             conkeyref="reuse-attributes/ref-universalatts"/>, <ph
             conkeyref="reuse-attributes/ref-linkatts"/>, <ph
             conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-keyref"
-              ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-keys"
+              ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-common/attr-keys"
               ><xmlatt>keys</xmlatt></xref>.</p>
         <p id="attr-exception">For this element, the <xmlatt>format</xmlatt> attribute has a default
           value of <keyword>ditamap</keyword>.</p>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -28,8 +28,8 @@
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, <ph
           conkeyref="reuse-attributes/ref-commonmapatts"/> (excluding <xmlatt>chunk</xmlatt> and
-          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-keys"
-          ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
+          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-keys"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
       <p id="attr-exception">For this element, the <xmlatt>processing-role</xmlatt> attribute has a
         default value of <keyword>resource-only</keyword>.</p>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -29,7 +29,7 @@
           conkeyref="reuse-attributes/ref-linkatts"/>, <ph
           conkeyref="reuse-attributes/ref-commonmapatts"/> (excluding <xmlatt>chunk</xmlatt> and
           <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-keys"
-            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
       <p id="attr-exception">For this element, the <xmlatt>processing-role</xmlatt> attribute has a
         default value of <keyword>resource-only</keyword>.</p>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -20,7 +20,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-                    keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -48,7 +48,7 @@
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keys"
-            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, <xref
           keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -45,9 +45,11 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keys"
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-keyref"
-          ><xmlatt>keyref</xmlatt></xref>,  <xref keyref="attributes-common/attr-processing-role"
+          ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref>, <xref
           keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
         and <xref keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>.</p>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -24,7 +24,7 @@
                         conkeyref="reuse-attributes/ref-universalatts"/>, <ph
                         conkeyref="reuse-attributes/ref-linkatts"/>, <xref
                         keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-                        keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+                        keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <p id="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
             <li>The <xmlatt>format</xmlatt> attribute has a default value of
                 <keyword>ditamap</keyword>.</li>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -20,9 +20,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv id="standard-topicref-attributes">
-        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
-            keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+        <p>The following attributes are available on this element: <ph
+                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+                        conkeyref="reuse-attributes/ref-linkatts"/>, <xref
+                        keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+                        keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         <p id="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
             <li>The <xmlatt>format</xmlatt> attribute has a default value of
                 <keyword>ditamap</keyword>.</li>

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -29,7 +29,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-keyref"
+          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>.</p>
       <p id="attr-exception">For this element, <xmlatt>href</xmlatt> provides a reference to a
         resource from which the topic is derived.</p>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -35,7 +35,7 @@
                                         conkeyref="reuse-attributes/ref-linkatts"/>, <xref
                                         keyref="attributes-common/attr-keys"
                                         ><xmlatt>keys</xmlatt></xref>, <xref
-                                        keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>,
+                                        keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>,
                                         <xref keyref="attributes-common/attr-processing-role"
                                                 ><xmlatt>processing-role</xmlatt></xref>, <xref
                                         keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -30,8 +30,11 @@
                 </section>
                 <section id="attributes">
                         <title>Attributes</title>
-                        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref
-                                        keyref="attributes-keys"><xmlatt>keys</xmlatt></xref>, <xref
+                        <p>The following attributes are available on this element: <ph
+                                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+                                        conkeyref="reuse-attributes/ref-linkatts"/>, <xref
+                                        keyref="attributes-common/attr-keys"
+                                        ><xmlatt>keys</xmlatt></xref>, <xref
                                         keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>,
                                         <xref keyref="attributes-common/attr-processing-role"
                                                 ><xmlatt>processing-role</xmlatt></xref>, <xref

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -20,7 +20,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                    conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+                    conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
                         ><xmlatt>keys</xmlatt></xref>, <xref
                     keyref="attributes-common/attr-collection-type"

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -18,13 +18,17 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
-          ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
-            ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"
-            ><xmlatt>linking</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
-            ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"
-            ><xmlatt>toc</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+                        ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
+                        ><xmlatt>keys</xmlatt></xref>, <xref
+                    keyref="attributes-common/attr-collection-type"
+                    ><xmlatt>collection-type</xmlatt></xref>, <xref
+                    keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>, <xref
+                    keyref="attributes-common/attr-processing-role"
+                    ><xmlatt>processing-role</xmlatt></xref> and <xref
+                    keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>.</p>
       <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default value of
               <keyword>resource-only</keyword>.</li>

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -25,7 +25,7 @@ can identify a single subject. Additional subjects can be specified by nested
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -23,9 +23,11 @@ can identify a single subject. Additional subjects can be specified by nested
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
-          ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"
             ><xmlatt>linking</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -31,7 +31,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -29,9 +29,11 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-keys"
-          ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-keyref"
+            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-keys"
+            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"
             ><xmlatt>toc</xmlatt></xref>.</p>
       <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -43,7 +43,7 @@
                 <sli><xref keyref="attributes-universal/importance"/></sli>
                 <sli><xref keyref="attributes-common/keycol"/></sli>
                 <sli><xref keyref="attributes-common/keyref"/></sli>
-                <sli><xref keyref="attributes-keyref"/></sli>
+                <sli><xref keyref="attributes-common/attr-keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keys"/></sli>
                 <sli><xref keyref="attributes-common/keyscope"/></sli>
                 <sli><xref keyref="attributes-keyscope"/></sli>

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -44,7 +44,7 @@
                 <sli><xref keyref="attributes-common/keycol"/></sli>
                 <sli><xref keyref="attributes-common/keyref"/></sli>
                 <sli><xref keyref="attributes-keyref"/></sli>
-                <sli><xref keyref="attributes-keys"/></sli>
+                <sli><xref keyref="attributes-common/attr-keys"/></sli>
                 <sli><xref keyref="attributes-common/keyscope"/></sli>
                 <sli><xref keyref="attributes-keyscope"/></sli>
                 <sli><xref keyref="attributes-common/linking"/></sli>

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -45,8 +45,7 @@
                 <sli><xref keyref="attributes-common/keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keys"/></sli>
-                <sli><xref keyref="attributes-common/keyscope"/></sli>
-                <sli><xref keyref="attributes-keyscope"/></sli>
+                <sli><xref keyref="attributes-common/attr-keyscope"/></sli>
                 <sli><xref keyref="attributes-common/linking"/></sli>
                 <sli><xref keyref="attributes-common/name"/></sli>
                 <sli><xref keyref="attributes-universal/otherprops"/></sli>


### PR DESCRIPTION
The topics in the langref on keys, keyref, and keyscope overlap quite a lot with the arch spec, and specify additional rules that are missing from the arch spec.

This update moves those topics into the arch spec, adjusts keyrefs as needed, and removes the now-obsolete container topic for "complex attribute definitions".

Next step is a full editing pass over the keys topics to merge rules / remove duplicate info.