### PR TITLE
Add outputclass for attribute exceptions

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -167,7 +167,7 @@
                                                 <ph
                                                 conkeyref="reuse-attributes/ref-architecturalatts"
                                         />.</p>
-                                <p id="attr-exception-topicid">For this element, the
+                                <p id="attr-exception-topicid" outputclass="attr-exception">For this element, the
                                                 <xmlatt>id</xmlatt> attribute is required.</p>
                         </div><p id="fig-attributes" platform="dita">The following attributes are available on this element: <ph
                                         conkeyref="reuse-attributes/ref-universalatts"/>, <ph
@@ -201,7 +201,7 @@
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>, and
                                                 <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <p id="attr-exception-authortype">For this element, the
+        <p id="attr-exception-authortype" outputclass="attr-exception">For this element, the
                                                 <xmlatt>type</xmlatt> attribute specifies the type
                                         of author. <ph otherprops="examples">For example, possible
                                                 values enumerated in earlier versions of DITA
@@ -247,7 +247,7 @@
                                                 conkeyref="reuse-attributes/ref-universalatts"/> and
                                                 <xref keyref="attributes-common/attr-keyref"
                                                   ><xmlatt>keyref</xmlatt></xref>.</p>
-                                <p id="attr-exception">For this element, the
+                                <p id="attr-exception-translate" outputclass="attr-exception">For this element, the
                                                 <xmlatt>translate</xmlatt> attribute has a default
                                         value of <keyword>no</keyword>.</p>
                         </div><dl id="linklist-and-linkpool">
@@ -486,7 +486,7 @@
                                                   ><xmlatt>scope</xmlatt></xref>, and <xref
                                                 keyref="attributes-common/attr-format"
                                                   ><xmlatt>format</xmlatt></xref>.</p>
-                                <p id="attr-exception-2">For this element, the <xmlatt>toc</xmlatt>
+                                                <p id="attr-exception-toc" outputclass="attr-exception">For this element, the <xmlatt>toc</xmlatt>
                                         attribute has a default value of <keyword>no</keyword>.</p>
                         </div></section>
                         <section id="section-8">

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -33,7 +33,7 @@
             <xmlatt>href</xmlatt>, given below), <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/class"
               ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-universal/outputclass"
               ><xmlatt>outputclass</xmlatt></xref>.</p>
-        <p id="attr-exception">For this element: <ul id="ul_xxx_hd4_qpb">
+        <p id="attr-exception" outputclass="attr-exception">For this element: <ul id="ul_xxx_hd4_qpb">
             <li>The <xmlatt>keys</xmlatt> attribute is required.</li>
             <li>The <xmlatt>href</xmlatt> attribute might be omitted when the key definition is used
               for variable text.</li>

--- a/specification/common/reuse-w-lwdita/reuse-navtitle.dita
+++ b/specification/common/reuse-w-lwdita/reuse-navtitle.dita
@@ -25,7 +25,7 @@
       <div platform="dita">
         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
-        <p id="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
+        <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
           <keyword>navigation</keyword>.</p>
       </div>
       <p platform="lwdita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref keyref="attributes-universal/class"

--- a/specification/common/reuse-w-lwdita/reuse-topic.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topic.dita
@@ -11,7 +11,7 @@
           keyref="attributes-universal/attr-id"><xmlatt>id</xmlatt></xref>, <ph conkeyref="reuse-attributes/ref-architecturalatts"/>, <ph conkeyref="reuse-attributes/ref-localizationatts"/>, and <xref
           keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
           keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required.</p>
+    <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required.</p>
   </section>
 </refbody>
 </reference>

--- a/specification/dita-2.0-specification-subjectScheme.ditamap
+++ b/specification/dita-2.0-specification-subjectScheme.ditamap
@@ -16,6 +16,7 @@
         <subjectdef keys="RFC-2119"/>
         <subjectdef keys="documentStage"/>
         <subjectdef keys="stageDate"/>
+        <subjectdef keys="attr-exception"/>
     </subjectdef>
        <subjectdef keys="values-platform">
         <subjectdef keys="dita"/>

--- a/specification/langRef/base/anchor.dita
+++ b/specification/langRef/base/anchor.dita
@@ -26,7 +26,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required. It is
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>id</xmlatt> attribute is required. It is
         referenced by <xmlelement>anchorref</xmlelement> or by the <xmlatt>anchorref</xmlatt>
         attribute on <xmlelement>map</xmlelement> elements.</p>
     </section>

--- a/specification/langRef/base/anchorref.dita
+++ b/specification/langRef/base/anchorref.dita
@@ -67,7 +67,7 @@
                         conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
                         keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
                         keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. </p>
-                <p id="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
+                <p id="attr-exception" outputclass="attr-exception">For this element: <ul id="ul_bsg_4sq_ppb">
                         <li>The <xmlatt>href</xmlatt> attribute refers to an
                                 <xmlelement>anchor</xmlelement> element in this or another DITA
                             map.</li>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -23,7 +23,7 @@
                     keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
                     keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>,
                 and <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>.</p>
-            <p id="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
+            <p id="attr-exception" outputclass="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
                     <li>The <xmlatt>name</xmlatt> attribute is required, and specifies the name of
                         an attribute that will take a set of enumerated values.</li>
                     <li>The <xmlatt>translate</xmlatt> attribute has a default value of

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
-      <p id="attr-exception">For this element, the <xmlatt>translate</xmlatt> attribute has a
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>translate</xmlatt> attribute has a
         default value of <keyword>no</keyword>.</p>
       <dl>
         <dlentry id="author">

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -39,7 +39,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrKeyscopePrefix</keyword>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -39,7 +39,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrKeyscopeSuffix</keyword>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -40,7 +40,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrResourcPrefix</keyword>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -44,7 +44,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (except for <xmlatt>conkeyref</xmlatt>, which is removed for all elements in this domain)
         and <xref keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>name</xmlatt> attribute has a default
         value of <keyword>dvrResourcSuffix</keyword>.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -23,7 +23,7 @@
             ><xmlatt>translate</xmlatt></xref>, <xref keyref="attributes-universal/class"
             ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-common/attr-name"
             ><xmlatt>name</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element, <ul id="ul_ddp_51l_ppb">
           <li>The <xmlatt>name</xmlatt> attribute is required, and specifies the name of an element
             to which controlled attribute values are bound.</li>
           <li>The <xmlatt>translate</xmlatt> attribute has a default value of

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -36,7 +36,7 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
           keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
         defined below.</p>
-      <p id="attr-exception">For this element, <xmlatt>href</xmlatt> specifies an image.</p>
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>href</xmlatt> specifies an image.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/image-height">
           <dt/>

--- a/specification/langRef/base/linktitle.dita
+++ b/specification/langRef/base/linktitle.dita
@@ -43,7 +43,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
         keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
         <keyword>linking</keyword>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Examples</title>

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -52,7 +52,7 @@
             conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-common/attr-keyref"
               ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-common/attr-keys"
               ><xmlatt>keys</xmlatt></xref>.</p>
-        <p id="attr-exception">For this element, the <xmlatt>format</xmlatt> attribute has a default
+        <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>format</xmlatt> attribute has a default
           value of <keyword>ditamap</keyword>.</p>
       </div>
     </section>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -31,7 +31,7 @@
           <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-keys"
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
-      <p id="attr-exception">For this element, the <xmlatt>processing-role</xmlatt> attribute has a
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>processing-role</xmlatt> attribute has a
         default value of <keyword>resource-only</keyword>.</p>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/base/relatedSubjects.dita
+++ b/specification/langRef/base/relatedSubjects.dita
@@ -53,7 +53,7 @@
             ><xmlatt>processing-role</xmlatt></xref>, <xref
           keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
         and <xref keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, the <xmlatt>linking</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>linking</xmlatt> attribute has a default
         value of <keyword>normal</keyword>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -60,7 +60,7 @@
             ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
             ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
             ><xmlatt>format</xmlatt></xref>, and the attributes defined below.</p>
-      <p id="attr-exception">For this element, the <xmlatt>toc</xmlatt> attribute has a default
+      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>toc</xmlatt> attribute has a default
         value of <keyword>no</keyword>.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -25,7 +25,7 @@
                         conkeyref="reuse-attributes/ref-linkatts"/>, <xref
                         keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
                         keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
-        <p id="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
+        <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
             <li>The <xmlatt>format</xmlatt> attribute has a default value of
                 <keyword>ditamap</keyword>.</li>
             <li>The <xmlatt>type</xmlatt> attribute has a default value of

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -37,7 +37,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
         keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
         <keyword>search</keyword>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Examples</title>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -97,7 +97,7 @@
       <p id="only-universal">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-name"
             ><xmlatt>name</xmlatt></xref>, and <xref keyref="attributes-common/attr-value"
             ><xmlatt>value</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element,<ul id="ul_g3c_412_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element,<ul id="ul_g3c_412_ppb">
           <li>The <xmlatt>name</xmlatt> attribute has a default value of
             <keyword>sort-as</keyword>.</li>
           <li>The <xmlatt>value</xmlatt> attribute specifies a text to combine with the base sort

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -31,7 +31,7 @@
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
             ><xmlatt>keyref</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <xmlatt>href</xmlatt> provides a reference to a
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>href</xmlatt> provides a reference to a
         resource from which the topic is derived.</p>
       <!--<dl><dlentry id="href"><dt id="attr-href"><xmlatt>href</xmlatt></dt><dd>Provides a reference to a resource from which the present resource is derived. See <xref keyref="attributes-href"/> for detailed information on supported values and processing implications. </dd></dlentry></dl>-->
     </section>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -31,7 +31,7 @@
             ><xmlatt>toc</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, and <xref
           keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>. </p>
-      <p id="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_pz3_w3r_ppb">
           <li>The <xmlatt>collection-type</xmlatt> attribute has an expected processing default
             value of <keyword>unordered</keyword>, although this value is not defaulted in the
             grammar files. This element limits the available values for

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -22,7 +22,7 @@
             ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
             ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
             ><xmlatt>format</xmlatt></xref>, and the attribute defined below.</p>
-      <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default value of
               <keyword>resource-only</keyword>.</li>
           <li>The <xmlatt>toc</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>

--- a/specification/langRef/base/subjectref.dita
+++ b/specification/langRef/base/subjectref.dita
@@ -29,7 +29,7 @@
                     keyref="attributes-common/attr-processing-role"
                     ><xmlatt>processing-role</xmlatt></xref> and <xref
                     keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default value of
               <keyword>resource-only</keyword>.</li>
           <li>The <xmlatt>toc</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>

--- a/specification/langRef/base/subtitle.dita
+++ b/specification/langRef/base/subtitle.dita
@@ -35,7 +35,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
         keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
         <keyword>subtitle</keyword>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/titlehint.dita
+++ b/specification/langRef/base/titlehint.dita
@@ -37,7 +37,7 @@
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>title-role</xmlatt> has a default value of
           <keyword>hint</keyword>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/topicapply.dita
+++ b/specification/langRef/base/topicapply.dita
@@ -32,7 +32,7 @@ can identify a single subject. Additional subjects can be specified by nested
             ><xmlatt>linking</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"
             ><xmlatt>toc</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default value of
               <keyword>resource-only</keyword>.</li>
           <li>The <xmlatt>toc</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>

--- a/specification/langRef/base/topicsubject.dita
+++ b/specification/langRef/base/topicsubject.dita
@@ -36,7 +36,7 @@
             ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
             ><xmlatt>processing-role</xmlatt></xref> and <xref keyref="attributes-common/attr-toc"
             ><xmlatt>toc</xmlatt></xref>.</p>
-      <p id="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
+      <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default value of
               <keyword>resource-only</keyword>.</li>
           <li>The <xmlatt>toc</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>


### PR DESCRIPTION
Adds an `@outputclass` value to identify attribute exceptions - such as where an element uses a common attribute but limits which values are available.