### PR TITLE
Add missing height/width to video

### DIFF
--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -1752,6 +1752,12 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
+               height
+                          NMTOKEN
+                                    #IMPLIED
+               width
+                          NMTOKEN
+                                    #IMPLIED
                tabindex
                           NMTOKEN
                                     #IMPLIED


### PR DESCRIPTION
Attrs defined in spec and in RNG are missing from DTD