### PR TITLE
Markup cleanup for lq, highlight and emphasis

### DIFF
--- a/doctypes/dtd/base/commonElements.ent
+++ b/doctypes/dtd/base/commonElements.ent
@@ -42,8 +42,6 @@
 <!ENTITY % desc        "desc"                                        >
 <!ENTITY % p           "p"                                           >
 <!ENTITY % note        "note"                                        >
-<!ENTITY % longquoteref
-                       "longquoteref"                                >
 <!ENTITY % lq          "lq"                                          >
 <!ENTITY % q           "q"                                           >
 <!ENTITY % sl          "sl"                                          >

--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -307,7 +307,6 @@
                %basic.ph; |
                %data.elements.incl; |
                %foreign.unknown.incl; |
-               %longquoteref; |
                %txt.incl;"
 >
 <!ENTITY % tblcell.cnt
@@ -742,59 +741,12 @@
 <!ATTLIST  note %note.attributes;>
 
 
-<!--                    LONG NAME: Long Quote Reference            -->
-<!ENTITY % longquoteref.content
-                       "EMPTY"
->
-<!ENTITY % longquoteref.attributes
-              "href
-                          CDATA
-                                    #IMPLIED
-               keyref
-                          CDATA
-                                    #IMPLIED
-               type
-                          CDATA
-                                    #IMPLIED
-               format
-                          CDATA
-                                    #IMPLIED
-               scope
-                          (external |
-                           local |
-                           peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               %univ-atts;"
->
-<!ELEMENT  longquoteref %longquoteref.content;>
-<!ATTLIST  longquoteref %longquoteref.attributes;>
-
-
 <!--                    LONG NAME: Long Quote                      -->
 <!ENTITY % lq.content
                        "(%longquote.cnt;)*"
 >
 <!ENTITY % lq.attributes
-              "href
-                          CDATA
-                                    #IMPLIED
-               keyref
-                          CDATA
-                                    #IMPLIED
-               format
-                          CDATA
-                                    #IMPLIED
-               type
-                          CDATA
-                                    #IMPLIED
-               scope
-                          (external |
-                           local |
-                           peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               reftitle
+              "keyref
                           CDATA
                                     #IMPLIED
                %univ-atts;"
@@ -1868,7 +1820,6 @@
 <!ATTLIST  li             class CDATA "- topic/li "         >
 <!ATTLIST  lines          class CDATA "- topic/lines "      >
 <!ATTLIST  longdescref    class CDATA "- topic/longdescref ">
-<!ATTLIST  longquoteref   class CDATA "- topic/longquoteref ">
 <!ATTLIST  lq             class CDATA "- topic/lq "         >
 <!ATTLIST  media-source   class CDATA "- topic/media-source ">
 <!ATTLIST  media-track    class CDATA "- topic/media-track ">

--- a/doctypes/dtd/base/emphasisDomain.mod
+++ b/doctypes/dtd/base/emphasisDomain.mod
@@ -47,7 +47,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % strong.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  strong %strong.content;>
 <!ATTLIST  strong %strong.attributes;>
@@ -63,7 +66,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % em.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  em %em.content;>
 <!ATTLIST  em %em.attributes;>

--- a/doctypes/dtd/base/highlightDomain.mod
+++ b/doctypes/dtd/base/highlightDomain.mod
@@ -54,7 +54,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % b.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  b %b.content;>
 <!ATTLIST  b %b.attributes;>
@@ -70,7 +73,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % u.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  u %u.content;>
 <!ATTLIST  u %u.attributes;>
@@ -86,7 +92,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % i.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  i %i.content;>
 <!ATTLIST  i %i.attributes;>
@@ -102,7 +111,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % line-through.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  line-through %line-through.content;>
 <!ATTLIST  line-through %line-through.attributes;>
@@ -118,7 +130,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % overline.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  overline %overline.content;>
 <!ATTLIST  overline %overline.attributes;>
@@ -134,7 +149,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % tt.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  tt %tt.content;>
 <!ATTLIST  tt %tt.attributes;>
@@ -150,7 +168,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % sup.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  sup %sup.content;>
 <!ATTLIST  sup %sup.attributes;>
@@ -166,7 +187,10 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % sub.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  sub %sub.content;>
 <!ATTLIST  sub %sub.attributes;>

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -144,9 +144,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     <define name="longdescref">
       <ref name="longdescref.element"/>
     </define>
-    <define name="longquoteref">
-      <ref name="longquoteref.element"/>
-    </define>
     <define name="lq">
       <ref name="lq.element"/>
     </define>
@@ -662,7 +659,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
           <ref name="basic.ph"/>
           <ref name="data.elements.incl"/>
           <ref name="foreign.unknown.incl"/>
-          <ref name="longquoteref"/>
           <ref name="txt.incl"/>
         </choice>
       </define>
@@ -1334,50 +1330,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
 
       </div>
       <div>
-        <a:documentation>LONG NAME: Long quote reference</a:documentation>
-        <define name="longquoteref.content">
-          <empty/>
-        </define>
-        <define name="longquoteref.attributes">
-          <optional>
-            <attribute name="href"/>
-          </optional>
-          <optional>
-            <attribute name="keyref"/>
-          </optional>
-          <optional>
-            <attribute name="type"/>
-          </optional>
-          <optional>
-            <attribute name="format"/>
-          </optional>
-          <optional>
-            <attribute name="scope">
-              <choice>
-                <value>external</value>
-                <value>local</value>
-                <value>peer</value>
-                <value>-dita-use-conref-target</value>
-              </choice>
-            </attribute>
-          </optional>
-          <ref name="univ-atts"/>
-        </define>
-        <define name="longquoteref.element">
-          <element name="longquoteref" dita:longName="Long Quote Reference">
-            <a:documentation>The &lt;longquoteref> element provides a reference to the source of a long quote. The long quote (&lt;lq>) element itself allows an href attribute to specify the source of
-              a quote, but it does not allow other standard linking attributes such as keyref, scope, and format. The &lt;longquoteref> element should be used for references that make use of these
-              attributes. </a:documentation>
-            <ref name="longquoteref.attlist"/>
-            <ref name="longquoteref.content"/>
-          </element>
-        </define>
-        <define name="longquoteref.attlist" combine="interleave">
-          <ref name="longquoteref.attributes"/>
-        </define>
-
-      </div>
-      <div>
         <a:documentation>LONG NAME: Long Quote (Excerpt)</a:documentation>
         <define name="lq.content">
           <zeroOrMore>
@@ -1386,29 +1338,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="lq.attributes">
           <optional>
-            <attribute name="href"/>
-          </optional>
-          <optional>
             <attribute name="keyref"/>
-          </optional>
-          <optional>
-            <attribute name="format"/>
-          </optional>
-          <optional>
-            <attribute name="type"/>
-          </optional>
-          <optional>
-            <attribute name="scope">
-              <choice>
-                <value>external</value>
-                <value>local</value>
-                <value>peer</value>
-                <value>-dita-use-conref-target</value>
-              </choice>
-            </attribute>
-          </optional>
-          <optional>
-            <attribute name="reftitle"/>
           </optional>
           <ref name="univ-atts"/>
         </define>
@@ -3400,11 +3330,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     <define name="longdescref.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- topic/longdescref "/>
-      </optional>
-    </define>
-    <define name="longquoteref.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- topic/longquoteref "/>
       </optional>
     </define>
     <define name="lq.attlist" combine="interleave">

--- a/doctypes/rng/base/emphasisDomain.rng
+++ b/doctypes/rng/base/emphasisDomain.rng
@@ -87,6 +87,9 @@
         </zeroOrMore>
       </define>
       <define name="strong.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="strong.element"> 
@@ -117,6 +120,9 @@
         </zeroOrMore>
       </define>
       <define name="em.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="em.element">

--- a/doctypes/rng/base/highlightDomain.rng
+++ b/doctypes/rng/base/highlightDomain.rng
@@ -111,6 +111,9 @@
         </zeroOrMore>
       </define>
       <define name="b.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="b.element">
@@ -141,6 +144,9 @@
         </zeroOrMore>
       </define>
       <define name="u.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="u.element">
@@ -169,6 +175,9 @@
         </zeroOrMore>
       </define>
       <define name="i.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="i.element">
@@ -198,6 +207,9 @@
         </zeroOrMore>
       </define>
       <define name="line-through.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="line-through.element">
@@ -226,6 +238,9 @@
         </zeroOrMore>
       </define>
       <define name="overline.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="overline.element">
@@ -254,6 +269,9 @@
         </zeroOrMore>
       </define>
       <define name="tt.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="tt.element">
@@ -282,6 +300,9 @@
         </zeroOrMore>
       </define>
       <define name="sup.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="sup.element">
@@ -312,6 +333,9 @@
         </zeroOrMore>
       </define>
       <define name="sub.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="sub.element">

--- a/specification/archSpec/base/processing-keyref-for-text.dita
+++ b/specification/archSpec/base/processing-keyref-for-text.dita
@@ -44,14 +44,18 @@
                                 <xmlelement>topicmeta</xmlelement>, the content of the
                                 <xmlelement>shortdesc</xmlelement> element also provides effective
                             content for a <xmlelement>desc</xmlelement> sub-element.</li>
-                        <li>The <xmlelement>longdescref</xmlelement> and
-                                <xmlelement>longquoteref</xmlelement> elements are empty elements
+                        <li>The <xmlelement>longdescref</xmlelement> element is an empty element
                             with no effective content. Key definitions do not set effective text for
-                            these elements.</li>
+                            this element.</li>
                         <li>The <xmlelement>param</xmlelement> element does not have any effective
                             content, so key definitions do not result in effective content for
                                 <xmlelement>param</xmlelement> elements.</li>
                     </ul>
+                    <draft-comment author="robander" time="1 june 2021">we've allowed @keyref on
+                        &lt;lq> for a while now. Based on discussion at today's TC (1 june 2021)
+                        this would be interpreted as the title of the source of the quotation - thus
+                        the removal of href/reftitle. OK to update accordingly, or does that need
+                        further confirmation from TC?</draft-comment>
                 </dd>
             </dlentry>
             <dlentry>

--- a/specification/langRef/base/harvested-content-base.dita
+++ b/specification/langRef/base/harvested-content-base.dita
@@ -114,10 +114,9 @@ this is unwieldy, the <xmlelement>data</xmlelement> element can go in the
   </section>
   <section>
    <title><xmlelement>lq</xmlelement></title>
-   <p>Authors can use the <xmlatt>href</xmlatt> and <xmlatt>keyref</xmlatt> attributes to specify
-    the source of the quotation. Use the quote element <xmlelement>q</xmlelement> for short
-    quotations that are intended to be rendered inline. The <xmlelement>longquoteref</xmlelement>
-    element is available for more complex references to the source of a quotation.</p>
+   <p>Authors can use the <xmlatt>keyref</xmlatt> attribute to specify the source of the quotation.
+        Use the quote element <xmlelement>q</xmlelement> for short quotations that are intended to
+        be rendered inline.</p>
   </section>
     <section>
       <title><xmlelement>map</xmlelement></title>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -14,18 +14,7 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <draft-comment author="robander" time="14 May 2021"><xmlelement>longquoteref</xmlelement> was
-        added to help with translation, moving translatable titles out of @reftitle. Not sure why we
-        still have reftitle and all the linking attributes on lq itself, when that's what
-        longquoteref is for?</draft-comment>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, and the attributes defined below.</p>
-      <dl>
-        <dlentry id="reftitle">
-          <dt id="attr-reftitle"><xmlatt>reftitle</xmlatt></dt>
-          <dd>The title of the document or topic that is quoted.</dd>
-        </dlentry>
-      </dl>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
     </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/body-elements.ditamap
+++ b/specification/langRef/body-elements.ditamap
@@ -26,7 +26,6 @@
   <topicref keyref="elements-li" />
   <topicref keyref="elements-lines" />
   <topicref keyref="elements-longdescref" />
-  <topicref keyref="elements-longquoteref" />
   <topicref keyref="elements-lq" />
   <topicref keyref="elements-note" />
   <topicref keyref="elements-object" />

--- a/specification/langRef/key-definitions-body-elements.ditamap
+++ b/specification/langRef/key-definitions-body-elements.ditamap
@@ -25,7 +25,6 @@
  <keydef href="base/li.dita" keys="elements-li" />
  <keydef href="base/lines.dita" keys="elements-lines" />
  <keydef href="base/longdescref.dita" keys="elements-longdescref" />
- <keydef href="base/longquoteref.dita" keys="elements-longquoteref" />
  <keydef href="base/lq.dita" keys="elements-lq" />
  <keydef href="base/note.dita" keys="elements-note" />
  <keydef href="base/object.dita" keys="elements-object" />

--- a/specification/langRef/quick-reference/base-elements-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-elements-a-to-z.dita
@@ -90,7 +90,6 @@
     <sli><xref keyref="elements-linkpool"/></sli>
     <sli><xref keyref="elements-linktext"/></sli>
     <sli><xref keyref="elements-longdescref"/></sli>
-    <sli><xref keyref="elements-longquoteref"/></sli>
     <sli><xref keyref="elements-lq"/></sli>
     <sli><xref keyref="elements-map"/></sli>
     <sli><xref keyref="elements-mapref"/></sli>


### PR DESCRIPTION
Per #397 discussed at today's TC:
* Highlight and emphasis elements should have `@keyref` like their ancestor `<ph>`
* Link attributes (except keyref) to be removed from `lq`, and `longquoteref` removed entirely, as function can be accomplished without the extra elements by using `@keyref` or `<cite>`