### PR TITLE
Remove obsolete doc from RNG until review completes

### DIFF
--- a/doctypes/rng/base/alternativeTitlesDomain.rng
+++ b/doctypes/rng/base/alternativeTitlesDomain.rng
@@ -104,8 +104,7 @@
             </define>
             <define name="navtitle.element"> 
                 <element name="navtitle" dita:longName="Navigation Title">
-                    <a:documentation>Specifies the title to use when displaying the resource in the context of a
-                        navigational aid, such as a table of contents. Category: Topic elements</a:documentation>
+                    <a:documentation></a:documentation>
                     <ref name="navtitle.attlist"/>
                     <ref name="navtitle.content"/>
                 </element>
@@ -135,8 +134,7 @@
             </define>
             <define name="searchtitle.element">
                 <element name="searchtitle" dita:longName="Search Title">
-                    <a:documentation>Specifies the title to display for this resource in search results for output
-                        systems that support topic-based searching. Category: Topic elements</a:documentation>
+                    <a:documentation></a:documentation>
                     <ref name="searchtitle.attlist"/>
                     <ref name="searchtitle.content"/>
                 </element>
@@ -167,9 +165,7 @@
             </define>
             <define name="linktitle.element">
                 <element name="linktitle" dita:longName="Link Title">
-                    <a:documentation>Specifies the title to use when populating empty links or
-                        cross-references to this topic. May also be used as a fallback for certain
-                        other alternative titles. Category: Topic elements</a:documentation>
+                    <a:documentation></a:documentation>
                     <ref name="linktitle.attlist"/>
                     <ref name="linktitle.content"/>
                 </element>
@@ -200,7 +196,7 @@
             </define>
             <define name="subtitle.element">
                 <element name="subtitle" dita:longName="Subtitle">
-                    <a:documentation>Specifies a secondary or subordinate title. Category: Topic elements</a:documentation>
+                    <a:documentation></a:documentation>
                     <ref name="subtitle.attlist"/>
                     <ref name="subtitle.content"/>
                 </element>
@@ -231,9 +227,7 @@
             </define>
             <define name="titlehint.element">
                 <element name="titlehint" dita:longName="titlehint">
-                    <a:documentation>For use in DITA maps to indicate the title of the referenced
-                        resource for the convenience of map authors; not used in output.
-                        Category: Topic elements</a:documentation>
+                    <a:documentation></a:documentation>
                     <ref name="titlehint.attlist"/>
                     <ref name="titlehint.content"/>
                 </element>

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -578,8 +578,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       </define>
     </div>
     <div>
-      <a:documentation> Predefined content model groups, based on the previous, element-only categories: txt.incl is appropriate for any mixed content definitions (those that have PCDATA) the context
-        for blocks is implicitly an InfoMaster "containing_division" </a:documentation>
+      <a:documentation>Predefined content model groups</a:documentation>
       <define name="listitem.cnt">
         <choice>
           <text/>
@@ -928,18 +927,12 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       </optional>
       <optional>
         <attribute name="conaction">
-          <a:documentation>This attribute enables users to push content into a new location.</a:documentation>
           <choice>
             <value>mark</value>
-            <a:documentation>Marks the reference position.</a:documentation>
             <value>pushafter</value>
-            <a:documentation>Push after the marked position.</a:documentation>
             <value>pushbefore</value>
-            <a:documentation>Push before the marked position.</a:documentation>
             <value>pushreplace</value>
-            <a:documentation>Push and replace content.</a:documentation>
             <value>-dita-use-conref-target</value>
-            <a:documentation>Use the value from the conref target.</a:documentation>
           </choice>
         </attribute>
       </optional>
@@ -1079,9 +1072,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="data.element">
           <element name="data" dita:longName="Data">
-            <a:documentation>The &lt;data> element represents a property within a DITA topic or map. While the &lt;data> element can be used directly to capture properties, it is particularly useful
-              as a basis for specialization. Default processing treats the property values as an unknown kind of metadata, but custom processing can match the name attribute or specialized element to
-              format properties as sidebars or other adornments or to harvest properties for automated processing. Category: Miscellaneous elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="data.attlist"/>
             <ref name="data.content"/>
           </element>
@@ -1101,8 +1092,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="unknown.element">
           <element name="unknown" dita:longName="Unknown">
-            <a:documentation>The &lt;unknown> element is an open extension that allows information architects to incorporate xml fragments that do not necessarily fit into an existing DITA use case.
-              The base processing for &lt;unknown> is to suppress unless otherwise instructed. Category: Specialization elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="unknown.attlist"/>
             <ref name="unknown.content"/>
           </element>
@@ -1122,9 +1112,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="foreign.element">
           <element name="foreign" dita:longName="Foreign">
-            <a:documentation>The &lt;foreign> element is an open extension that allows information architects to incorporate existing standard vocabularies for non-textual content. like MathML and
-              SVG, as inline objects. If &lt;foreign> contains more than one alternative content element, they will all be processed. Specialization of &lt;foreign> should be implemented as a domain,
-              but for those looking for more control over the content can implement foreign vocabulary as an element specialization. Category: Specialization elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="foreign.attlist"/>
             <ref name="foreign.content"/>
           </element>
@@ -1137,7 +1125,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       <div>
         <a:documentation>LONG NAME: Title</a:documentation>
         <define name="title.content">
-          <a:documentation>This is referenced inside CALS table</a:documentation>
           <zeroOrMore>
             <ref name="title.cnt"/>
           </zeroOrMore>
@@ -1158,8 +1145,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="title.element">
           <element name="title" dita:longName="Title">
-            <a:documentation>The &lt;title> element contains a heading or label for the main parts of a topic, including the topic as a whole, its sections and examples, and its labelled content, such
-              as figures and tables. Beginning with DITA 1.1, the element may also be used to provide a title for a map. Category: Topic elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="title.attlist"/>
             <ref name="title.content"/>
           </element>
@@ -1187,7 +1173,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="titlealt.element">
           <element name="titlealt" dita:longName="Alternate Title">
-            <a:documentation>Specifies an alternative title fulfilling a particular role. Category: Topic elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="titlealt.attlist"/>
             <ref name="titlealt.content"/>
           </element>
@@ -1215,9 +1201,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="desc.element">
           <element name="desc" dita:longName="Description">
-            <a:documentation>The &lt;desc> element contains the description of the current element. A description should provide more information than the title. This is its behavior in
-              fig/table/linklist, for example. In xref/link, it provides a description of the target; processors that support it may choose to display this as hover help. In object, it contains
-              alternate content for use when in contexts that cannot display the object. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="desc.attlist"/>
             <ref name="desc.content"/>
           </element>
@@ -1243,9 +1227,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="shortdesc.element">
           <element name="shortdesc" dita:longName="Short Description">
-            <a:documentation>The short description (&lt;shortdesc>) element occurs between the topic title and the topic body, as the initial paragraph-like content of a topic, or it can be embedded
-              in an abstract element. The short description, which represents the purpose or theme of the topic, is also intended to be used as a link preview and for searching. When used within a
-              DITA map, the short description of the &lt;topicref> can be used to override the short description in the topic. Category: Topic elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="shortdesc.attlist"/>
             <ref name="shortdesc.content"/>
           </element>
@@ -1270,7 +1252,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="p.element">
           <element name="p" dita:longName="Paragraph">
-            <a:documentation>A paragraph element (&lt;p>) is a block of text containing a single main idea. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="p.attlist"/>
             <ref name="p.content"/>
           </element>
@@ -1318,8 +1300,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="note.element">
           <element name="note" dita:longName="Note">
-            <a:documentation>A &lt;note> element contains information, differentiated from the main text, which expands on or calls attention to a particular point. Category: Body
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="note.attlist"/>
             <ref name="note.content"/>
           </element>
@@ -1344,9 +1325,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="lq.element">
           <element name="lq" dita:longName="Long Quote">
-            <a:documentation>The long quote (&lt;lq>) element indicates content quoted from another source. Use the quote element &lt;q> for short, inline quotations, and long quote &lt;lq> for
-              quotations that are too long for inline use, following normal guidelines for quoting other sources. You can store a URL to the source of the quotation in the href attribute; the href
-              value may point to a DITA topic. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="lq.attlist"/>
             <ref name="lq.content"/>
           </element>
@@ -1368,8 +1347,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="q.element">
           <element name="q" dita:longName="Quote">
-            <a:documentation>A quotation element (&lt;q>) indicates content quoted from another source. This element is used for short quotes which are displayed inline. Use the long quote element
-              (&lt;lq>) for quotations that should be set off from the surrounding text. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="q.attlist"/>
             <ref name="q.content"/>
           </element>
@@ -1406,8 +1384,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="sl.element">
           <element name="sl" dita:longName="Simple List">
-            <a:documentation>The simple list (&lt;sl>) element contains a simple list of items of short, phrase-like content, such as in documenting the materials in a kit or package. Category: Body
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="sl.attlist"/>
             <ref name="sl.content"/>
           </element>
@@ -1429,9 +1406,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="sli.element">
           <element name="sli" dita:longName="Simple List Item">
-            <a:documentation>A simple list item (&lt;sli>) is a single item in a simple list &lt;sl>. Simple list items have phrase or text content, adequate for describing package contents, for
-              example. When a DITA topic is formatted for output, the items of a simple list are placed each on its own line, with no other prefix such as a number (as in an ordered list) or bullet
-              (as in an unordered list). Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="sli.attlist"/>
             <ref name="sli.content"/>
           </element>
@@ -1468,8 +1443,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="ul.element">
           <element name="ul" dita:longName="Unordered List">
-            <a:documentation>In an unordered list (&lt;ul>), the order of the list items is not significant. List items are typically styled on output with a "bullet" character, depending on nesting
-              level. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <sch:pattern name="atLeastTwoChildren">
               <sch:rule context="ul">
                 <sch:assert test="count(*) > 1" role="warning"> Please make sure you have at least 2 items for this list! </sch:assert>
@@ -1511,7 +1485,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="ol.element">
           <element name="ol" dita:longName="Ordered List">
-            <a:documentation>An ordered list (&lt;ol>) is a list of items sorted by sequence or order of importance. Category: List elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="ol.attlist"/>
             <ref name="ol.content"/>
           </element>
@@ -1533,8 +1507,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="li.element">
           <element name="li" dita:longName="List Item">
-            <a:documentation>A list (&lt;li>) item is a single item in an ordered &lt;ol> or unordered &lt;ul> list. When a DITA topic is formatted for output, numbers and alpha characters are usually
-              output with list items in ordered lists, while bullets and dashes are usually output with list items in unordered lists. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="li.attlist"/>
             <ref name="li.content"/>
           </element>
@@ -1574,8 +1547,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dl.element">
           <element name="dl" dita:longName="Definition List">
-            <a:documentation>A definition list (&lt;dl>) is a list of terms and corresponding definitions. The term (&lt;dt>) is usually flush left. The description or definition (&lt;dd>) is usually
-              either indented and on the next line, or on the same line to the right of the term. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dl.attlist"/>
             <ref name="dl.content"/>
           </element>
@@ -1600,8 +1572,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dlhead.element">
           <element name="dlhead" dita:longName="Definition List Head">
-            <a:documentation>The &lt;dlhead> element contains optional headings for the term and description columns in a definition list. The definition list heading contains a heading &lt;dthd> for
-              the column of terms and an optional heading &lt;ddhd>for the column of descriptions. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dlhead.attlist"/>
             <ref name="dlhead.content"/>
           </element>
@@ -1623,8 +1594,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dthd.element">
           <element name="dthd" dita:longName="Term Header">
-            <a:documentation>The definition term heading (&lt;dthd>) element is contained in a definition list head (&lt;dlhead>) and provides an optional heading for the column of terms in a
-              description list. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dthd.attlist"/>
             <ref name="dthd.content"/>
           </element>
@@ -1646,8 +1616,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="ddhd.element">
           <element name="ddhd" dita:longName="Definition Header">
-            <a:documentation>The definition descriptions heading (&lt;ddhd>) element contains an optional heading or title for a column of descriptions or definitions in a definition list. Category:
-              Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="ddhd.attlist"/>
             <ref name="ddhd.content"/>
           </element>
@@ -1672,8 +1641,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dlentry.element">
           <element name="dlentry" dita:longName="Definition List Entry">
-            <a:documentation>In a definition list, each list item is defined by the definition list entry (&lt;dlentry>) element. The definition list entry element includes a term &lt;dt> and one or
-              more definitions or descriptions &lt;dd> of that term. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dlentry.attlist"/>
             <ref name="dlentry.content"/>
           </element>
@@ -1698,7 +1666,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dt.element">
           <element name="dt" dita:longName="Definition Term">
-            <a:documentation>The definition term &lt;dt> element contains a term in a definition list entry. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dt.attlist"/>
             <ref name="dt.content"/>
           </element>
@@ -1720,7 +1688,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="dd.element">
           <element name="dd" dita:longName="Definition Description">
-            <a:documentation>The definition description (&lt;dd>) element contains the description of a term in a definition list entry. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="dd.attlist"/>
             <ref name="dd.content"/>
           </element>
@@ -1745,8 +1713,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="example.element">
           <element name="example" dita:longName="Example">
-            <a:documentation>The &lt;example> element is a section with the specific role of containing examples that illustrate or support the current topic. The &lt;example> element has the same
-              content model as &lt;section>. Category: Topic elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="example.attlist"/>
             <ref name="example.content"/>
           </element>
@@ -1780,9 +1747,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="fig.element">
           <element name="fig" dita:longName="Figure">
-            <a:documentation>The figure (&lt;fig>) element is a display context (sometimes called an exhibit) with an optional title for a wide variety of content. Most commonly, the figure element
-              contains an image element (a graphic or artwork), but it can contain several kinds of text objects as well. A title is placed inside the figure element to provide a caption to describe
-              the content. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="fig.attlist"/>
             <ref name="fig.content"/>
           </element>
@@ -1810,8 +1775,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="figgroup.element">
           <element name="figgroup" dita:longName="Figure Group">
-            <a:documentation>The &lt;figgroup> element is used only for specialization at this time. Figure groups can be used to contain multiple cross-references, footnotes or keywords, but not
-              multipart images. Multipart images in DITA should be represented by a suitable media type displayed by the &lt;object> element. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="figgroup.attlist"/>
             <ref name="figgroup.content"/>
           </element>
@@ -1842,9 +1806,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="pre.element">
           <element name="pre" dita:longName="Preformatted Text">
-            <a:documentation>The preformatted element (&lt;pre>) preserves line breaks and spaces entered manually by the author in the content of the element, and also presents the content in a
-              monospaced type font (depending on your output formatting processor). Do not use &lt;pre> when a more semantically specific element is appropriate, such as &lt;codeblock>. Category: Body
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="pre.attlist"/>
             <ref name="pre.content"/>
           </element>
@@ -1875,8 +1837,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="lines.element">
           <element name="lines" dita:longName="Line Respecting Text">
-            <a:documentation>The &lt;lines> element may be used to represent dialogs, lists, text fragments, and so forth. The &lt;lines> element is similar to &lt;pre> in that hard line breaks are
-              preserved, but the font style is not set to monospace, and extra spaces inside the lines are not preserved. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="lines.attlist"/>
             <ref name="lines.content"/>
           </element>
@@ -1897,7 +1858,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="div.element">
           <element name="div" dita:longName="Division">
-            <a:documentation> Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="div.attlist"/>
             <ref name="div.content"/>
           </element>
@@ -1924,9 +1885,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="text.element">
           <element name="text" dita:longName="Text">
-            <a:documentation>The text element associates no semantics with its content. It exists to serve as a container for text where a container is needed (e.g., for conref, or for restricted
-              content models in specializations). Unlike ph, text cannot contain images. Unlike keyword, text does not imply keyword-like semantics. The text element contains only text data, or nested
-              text elements. All universal attributes are available on text.</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="text.attlist"/>
             <ref name="text.content"/>
           </element>
@@ -1957,8 +1916,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="keyword.element">
           <element name="keyword" dita:longName="Keyword">
-            <a:documentation>The &lt;keyword> element identifies a keyword or token, such as a single value from an enumerated list, the name of a command or parameter, product name, or a lookup key
-              for a message. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="keyword.attlist"/>
             <ref name="keyword.content"/>
           </element>
@@ -1989,8 +1947,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="term.element">
           <element name="term" dita:longName="Term">
-            <a:documentation>The &lt;term> element identifies words that may have or require extended definitions or explanations. In future development of DITA, for example, terms might provide
-              associative linking to matching glossary entries. Category: Specialization elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="term.attlist"/>
             <ref name="term.content"/>
           </element>
@@ -2017,9 +1974,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="ph.element">
           <element name="ph" dita:longName="Phrase">
-            <a:documentation>The phrase (&lt;ph>) element is used to organize content for reuse or conditional processing (for example, when part of a paragraph applies to a particular audience). It
-              can be used by specializations of DITA to create semantic markup for content at the phrase level, which then allows (but does not require) specific processing or formatting. Category:
-              Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="ph.attlist"/>
             <ref name="ph.content"/>
           </element>
@@ -2062,8 +2017,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="tm.element">
           <element name="tm" dita:longName="Trade Mark">
-            <a:documentation>The trademark (&lt;tm>) element in DITA is used to markup and identify a term or phrase that is trademarked. Trademarks include registered trademarks, service marks,
-              slogans and logos. Category: Miscellaneous elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="tm.attlist"/>
             <ref name="tm.content"/>
           </element>
@@ -2074,11 +2028,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
 
       </div>
       <div>
-        <a:documentation xml:space="preserve">LONG NAME: State
-        
-    A state can have a name and a string value, 
-    even if empty or indeterminate
-        </a:documentation>
+        <a:documentation xml:space="preserve">LONG NAME: State</a:documentation>
         <define name="state.content">
           <empty/>
         </define>
@@ -2089,9 +2039,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="state.element">
           <element name="state" dita:longName="State">
-            <a:documentation>The &lt;state> element specifies a name/value pair whenever it is necessary to represent a named state that has a variable value. The element is primarily intended for use
-              in specializations to represent specific states (like logic circuit states, chemical reaction states, airplane instrumentation states, and so forth). Category: Specialization
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="state.attlist"/>
             <ref name="state.content"/>
           </element>
@@ -2102,7 +2050,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
 
       </div>
       <div>
-        <a:documentation>LONG NAME: Image Data</a:documentation>
+        <a:documentation>LONG NAME: Image</a:documentation>
         <define name="image.content">
           <optional>
             <ref name="alt"/>
@@ -2171,11 +2119,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="image.element">
           <element name="image" dita:longName="Image Data">
-            <a:documentation>Include artwork or images in a DITA topic by using the &lt;image> element. The &lt;image> element has optional attributes that indicate whether the placement of the
-              included graphic or artwork should be inline (like a button or icon) or on a separate line for a larger image. There are also optional attributes that indicate the size to which the
-              included graphic or artwork should be scaled. An href attribute is required on the image element, as this attribute creates a pointer to the image, and allows the output formatting
-              processor to bring the image into the text flow. To make the intent of the image more accessible for users using screen readers or text-only readers, always include a description of the
-              image's content in the alt element. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="image.attlist"/>
             <ref name="image.content"/>
           </element>
@@ -2202,8 +2146,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="alt.element">
           <element name="alt" dita:longName="Alternate text">
-            <a:documentation>The alt element provides alternate text for an image. It is equivalent to the alt attribute on the image element; the attribute is deprecated, so the alt element should be
-              used instead. As an element, alt provides direct text entry within an XML editor and is more easily accessed than an attribute for translation. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="alt.attlist"/>
             <ref name="alt.content"/>
           </element>
@@ -2245,7 +2188,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="longdescref.element">
           <element name="longdescref" dita:longName="Long description reference">
-            <a:documentation>A reference to a textual description of the graphic or object.</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="longdescref.attlist"/>
             <ref name="longdescref.content"/>
           </element>
@@ -2342,7 +2285,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="object.element">
           <element name="object" dita:longName="Object (Streaming/Executable Data)">
-            <a:documentation>DITA's &lt;object> element corresponds to the HTML &lt;object> element. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="object.attlist"/>
             <ref name="object.content"/>
           </element>
@@ -2382,9 +2325,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="param.element">
           <element name="param" dita:longName="Parameter">
-            <a:documentation>The parameter (&lt;param>) element specifies a set of values that may be required by an &lt;object> at runtime. Any number of &lt;param> elements may appear in the content
-              of an object in any order, but must be placed at the start of the content of the enclosing object. This element is comparable to the XHMTL &lt;param> element. Category: Body
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="param.attlist"/>
             <ref name="param.content"/>
           </element>
@@ -2424,10 +2365,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="simpletable.element">
           <element name="simpletable" dita:longName="Simple Table">
-            <a:documentation>The &lt;simpletable> element is used for tables that are regular in structure and do not need a caption. Choose the simple table element when you want to show information
-              in regular rows and columns. For example, multi-column tabular data such as phone directory listings or parts lists are good candidates for simpletable. Another good use of simpletable
-              is for information that seems to beg for a "three-part definition list"—just use the keycol attribute to indicate which column represents the "key" or term-like column of your structure.
-              Category: Table elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="simpletable.attlist"/>
             <ref name="simpletable.content"/>
           </element>
@@ -2449,7 +2387,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="sthead.element">
           <element name="sthead" dita:longName="Simple Table Head">
-            <a:documentation>The simpletable header (&lt;sthead>) element contains the table's header row. The header row is optional in a simple table. Category: Table elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="sthead.attlist"/>
             <ref name="sthead.content"/>
           </element>
@@ -2471,7 +2409,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="strow.element">
           <element name="strow" dita:longName="Simple Table Row">
-            <a:documentation>The &lt;simpletable> row (&lt;strow>) element specifies a row in a simple table. Category: Table elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="strow.attlist"/>
             <ref name="strow.content"/>
           </element>
@@ -2557,9 +2495,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="draft-comment.element">
           <element name="draft-comment" dita:longName="Review Comments Block">
-            <a:documentation>The &lt;draft-comment> element allows simple review and discussion of topic contents within the marked-up content. Use the &lt;draft-comment> element to ask a question or
-              make a comment that you would like others to review. To indicate the source of the draft comment or the status of the comment, use the author, time or disposition attributes. Category:
-              Miscellaneous elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="draft-comment.attlist"/>
             <ref name="draft-comment.content"/>
           </element>
@@ -2582,9 +2518,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="required-cleanup.element">
           <element name="required-cleanup" dita:longName="Required Cleanup Block">
-            <a:documentation>A &lt;required-cleanup> element is used as a placeholder for migrated elements that cannot be appropriately tagged without manual intervention. As the element name
-              implies, the intent for authors is to clean up the contained material and eventually get rid of the &lt;required-cleanup> element. Authors should not insert this element into documents.
-              Category: Specialization elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="required-cleanup.attlist"/>
             <ref name="required-cleanup.content"/>
           </element>
@@ -2609,8 +2543,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="fn.element">
           <element name="fn" dita:longName="Footnote">
-            <a:documentation>Use footnote (&lt;fn>) to annotate text with notes that are not appropriate for inclusion in line or to indicate the source for facts or other material used in the text.
-              Category: Miscellaneous elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="fn.attlist"/>
             <ref name="fn.content"/>
           </element>
@@ -2647,8 +2580,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="indexterm.element">
           <element name="indexterm" dita:longName="Index Term">
-            <a:documentation>An &lt;indexterm> element allows the author to indicate that a certain word or phrase should produce an index entry in the generated index. Category: Miscellaneous
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="indexterm.attlist"/>
             <ref name="indexterm.content"/>
           </element>
@@ -2677,8 +2609,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       </define>
       <define name="index-see.element">
         <element name="index-see" dita:longName="Index See">
-          <a:documentation>An &lt;index-see> element within an &lt;indexterm> directs the reader to another index entry that the reader should reference instead of the current one.
-          </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="index-see.attlist"/>
           <ref name="index-see.content"/>
         </element>
@@ -2707,7 +2638,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
       </define>
       <define name="index-see-also.element">
         <element name="index-see-also" dita:longName="Index See Also">
-          <a:documentation>An &lt;index-see-also> element ... </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="index-see-also.attlist"/>
           <ref name="index-see-also.content"/>
         </element>
@@ -2732,8 +2663,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="cite.element">
           <element name="cite" dita:longName="Citation (bibliographic source)">
-            <a:documentation>The &lt;cite> element is used when you need a bibliographic citation that refers to a book or article. It specifically identifies the title of the resource. Category: Body
-              elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="cite.attlist"/>
             <ref name="cite.content"/>
           </element>
@@ -2780,8 +2710,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="xref.element">
           <element name="xref" dita:longName="Cross Reference/Link">
-            <a:documentation>Use the cross-reference (&lt;xref>) element to link to a different location within the current topic, or a different topic within the same help system, or to external
-              sources, such as Web pages, or to a location in another topic. The href attribute on the &lt;xref> element provides the location of the target. Category: Body elements</a:documentation>
+            <a:documentation></a:documentation>
             <ref name="xref.attlist"/>
             <ref name="xref.content"/>
           </element>
@@ -2817,8 +2746,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
   </define>
   <define name="fallback.element">
     <element name="fallback" dita:longName="Fallback">
-      <a:documentation>The &lt;fallback> element contains content to be rendered when a multimedia
-        object reference cannot be rendered.</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="fallback.attlist"/>
       <ref name="fallback.content"/>
     </element>
@@ -2870,9 +2798,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
   </define>
   <define name="include.element">
     <element name="include" dita:longName="Inclusion">
-      <a:documentation>Use the inclusion (&lt;include>) element to transclude content stored in another resource into a DITA topic. The
-        @href and @keyref attributes specify the resource to be transcluded. The @parse attribute declares the mode by which to include
-        the content.Category: Body elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="include.attlist"/>
       <ref name="include.content"/>
     </element>
@@ -2968,8 +2894,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     </define>
     <define name="audio.element">
       <element name="audio" dita:longName="Audio">
-        <a:documentation>DITA's &lt;audio> element corresponds to the HTML &lt;audio> element.
-          Category: Body elements</a:documentation>
+        <a:documentation></a:documentation>
         <ref name="audio.attlist"/>
         <ref name="audio.content"/>
       </element>
@@ -3081,8 +3006,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     </define>
     <define name="video.element">
       <element name="video" dita:longName="Video">
-        <a:documentation>DITA's &lt;video> element corresponds to the HTML &lt;video> element.
-          Category: Body elements</a:documentation>
+        <a:documentation></a:documentation>
         <ref name="video.attlist"/>
         <ref name="video.content"/>
       </element>
@@ -3121,7 +3045,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     </define>
     <define name="media-source.element">
       <element name="media-source" dita:longName="Audio">
-        <a:documentation>DITA's &lt;media-source> element corresponds to the HTML &lt;source> element within &lt;video> and &lt;audio> elements.</a:documentation>
+        <a:documentation></a:documentation>
         <ref name="media-source.attlist"/>
         <ref name="media-source.content"/>
       </element>
@@ -3175,7 +3099,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
     </define>
     <define name="media-track.element">
       <element name="media-track" dita:longName="Audio object reference">
-        <a:documentation>DITA's &lt;media-track> element corresponds to the HTML &lt;track> element within &lt;video> and &lt;audio> elements.</a:documentation>
+        <a:documentation></a:documentation>
         <ref name="media-track.attlist"/>
         <ref name="media-track.content"/>
       </element>

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -2,7 +2,7 @@
 <?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
                          schematypens="http://relaxng.org/ns/structure/1.0"?>
 <grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:dita="http://dita.oasis-open.org/architecture/2005/" xmlns="http://relaxng.org/ns/structure/1.0"
-  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <moduleDesc xmlns="http://dita.oasis-open.org/architecture/2005/">
     <moduleTitle>DITA Common Elements</moduleTitle>
     <headerComment><![CDATA[
@@ -1444,11 +1444,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         <define name="ul.element">
           <element name="ul" dita:longName="Unordered List">
             <a:documentation></a:documentation>
-            <sch:pattern name="atLeastTwoChildren">
-              <sch:rule context="ul">
-                <sch:assert test="count(*) > 1" role="warning"> Please make sure you have at least 2 items for this list! </sch:assert>
-              </sch:rule>
-            </sch:pattern>
             <ref name="ul.attlist"/>
             <ref name="ul.content"/>
           </element>

--- a/doctypes/rng/base/ditavalrefDomain.rng
+++ b/doctypes/rng/base/ditavalrefDomain.rng
@@ -100,18 +100,12 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       </optional>
       <optional>
         <attribute name="conaction">
-          <a:documentation>This attribute enables users to push content into a new location.</a:documentation>
           <choice>
             <value>mark</value>
-            <a:documentation>Marks the reference position.</a:documentation>
             <value>pushafter</value>
-            <a:documentation>Push after the marked position.</a:documentation>
             <value>pushbefore</value>
-            <a:documentation>Push before the marked position.</a:documentation>
             <value>pushreplace</value>
-            <a:documentation>Push and replace content.</a:documentation>
             <value>-dita-use-conref-target</value>
-            <a:documentation>Use the value from the conref target.</a:documentation>
           </choice>
         </attribute>
       </optional>
@@ -192,7 +186,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="ditavalmeta.element">
-      <a:documentation>The &lt;ditavalmeta> element ...</a:documentation>
+      <a:documentation></a:documentation>
       <element name="ditavalmeta" a:longName="DITAVAL Ref Metadata">
         <ref name="ditavalmeta.attlist"/>
         <ref name="ditavalmeta.content"/>
@@ -223,7 +217,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="dvrResourcePrefix.element">
-      <a:documentation>The &lt;dvrResourcePrefix> element ...</a:documentation>
+      <a:documentation></a:documentation>
       <element name="dvrResourcePrefix" a:longName="DITVAL Ref Resource Prefix">
         <ref name="dvrResourcePrefix.attlist"/>
         <ref name="dvrResourcePrefix.content"/>
@@ -254,7 +248,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="dvrResourceSuffix.element">
-      <a:documentation>The &lt;dvrResourceSuffix> element ...</a:documentation>
+      <a:documentation></a:documentation>
       <element name="dvrResourceSuffix" a:longName="DITVAL Ref Resource Suffix">
         <ref name="dvrResourceSuffix.attlist"/>
         <ref name="dvrResourceSuffix.content"/>
@@ -285,7 +279,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="dvrKeyscopePrefix.element">
-      <a:documentation>The &lt;dvrKeyscopePrefix> element ...</a:documentation>
+      <a:documentation></a:documentation>
       <element name="dvrKeyscopePrefix" a:longName="DITVAL Ref Key Scope Prefix">
         <ref name="dvrKeyscopePrefix.attlist"/>
         <ref name="dvrKeyscopePrefix.content"/>
@@ -316,7 +310,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
       <ref name="ditavalref-univ-atts"/>
     </define>
     <define name="dvrKeyscopeSuffix.element">
-      <a:documentation>The &lt;dvrKeyscopeSuffix> element ...</a:documentation>
+      <a:documentation></a:documentation>
       <element name="dvrKeyscopeSuffix" a:longName="DITVAL Ref Resource Suffix">
         <ref name="dvrKeyscopeSuffix.attlist"/>
         <ref name="dvrKeyscopeSuffix.content"/>

--- a/doctypes/rng/base/emphasisDomain.rng
+++ b/doctypes/rng/base/emphasisDomain.rng
@@ -94,9 +94,7 @@
       </define>
       <define name="strong.element"> 
         <element name="strong" dita:longName="Strong">
-          <a:documentation>Strong text can be used to indicate content that is considered to be important 
-            or serious, or that has some form of urgency. Category: Emphasis elements
-          </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="strong.attlist"/>
           <ref name="strong.content"/>
         </element>
@@ -127,9 +125,7 @@
       </define>
       <define name="em.element">
         <element name="em" dita:longName="Emphasis">
-          <a:documentation>Emphasized text is used to indicate stress or to otherwise 
-            highlight content. Category: Emphasis elements
-          </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="em.attlist"/>
           <ref name="em.content"/>
         </element>

--- a/doctypes/rng/base/hazardstatementDomain.rng
+++ b/doctypes/rng/base/hazardstatementDomain.rng
@@ -107,10 +107,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="hazardstatement.element">
         <element name="hazardstatement" dita:longName="Hazard Statement">
-          <a:documentation>The &lt;hazardstatement> element contains hazard warning information. It
-            is based on the regulations of the ANSI Z535 and the ISO 3864 standards. It gives the
-            author the opportunity to select the hazard statement, to add one or more safety signs
-            and to add the required phrases.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hazardstatement.attlist"/>
           <ref name="hazardstatement.content"/>
         </element>
@@ -190,10 +187,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="hazardsymbol.element">
         <element name="hazardsymbol" dita:longName="Hazard Symbol">
-          <a:documentation>A graphic representation intended to convey a message without the use of
-            words. It may represent a hazard, a hazardous situation, a precaution to avoid a hazard,
-            a result of not avoiding a hazard, or any combination of these
-            messages.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hazardsymbol.attlist"/>
           <ref name="hazardsymbol.content"/>
         </element>
@@ -242,10 +236,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="messagepanel.element">
         <element name="messagepanel" dita:longName="Hazard Message panel">
-          <a:documentation>The &lt;messagepanel> element describes the area of a safety sign or
-            label that contains the word message which identifies a hazard, indicates how to avoid
-            the hazard, and advises of the probable consequences of not avoiding the
-            hazard.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="messagepanel.attlist"/>
           <ref name="messagepanel.content"/>
         </element>
@@ -272,9 +263,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="typeofhazard.element">
         <element name="typeofhazard" dita:longName="The Type of Hazard">
-          <a:documentation>&lt;typeofhazard> element is the container for the first text entry of a
-            safety label. It contains the description of the type of hazard, such as &#34;Moving
-            parts can crush and cut&#34;.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="typeofhazard.attlist"/>
           <ref name="typeofhazard.content"/>
         </element>
@@ -301,9 +290,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="consequence.element">
         <element name="consequence" dita:longName="Consequences of not Avoiding the Hazard">
-          <a:documentation>The &lt;consequence> element is the container for the second text entry
-            of a safety label. It contains the description of the consequences of not avoiding the
-            hazard, such as &#34;Keep guard in place&#34;.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="consequence.attlist"/>
           <ref name="consequence.content"/>
         </element>
@@ -333,9 +320,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
       </define>
       <define name="howtoavoid.element">
         <element name="howtoavoid" dita:longName="How to Avoid the Hazard">
-          <a:documentation>The &lt;howtoavoid> element is the container for the third text entry of
-            a safety label. It contains the description of how to avoid the hazard, such as
-            &#34;Lock out power before servicing&#34;.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="howtoavoid.attlist"/>
           <ref name="howtoavoid.content"/>
         </element>

--- a/doctypes/rng/base/highlightDomain.rng
+++ b/doctypes/rng/base/highlightDomain.rng
@@ -118,9 +118,7 @@
       </define>
       <define name="b.element">
         <element name="b" dita:longName="Bold">
-          <a:documentation>Bold text is used to draw attention to a word or 
-            phrase for utilitarian purposes without implying that there is any 
-            extra importance. Category: Typographic elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="b.attlist"/>
           <ref name="b.content"/>
         </element>
@@ -151,7 +149,7 @@
       </define>
       <define name="u.element">
         <element name="u" dita:longName="Underlined">
-          <a:documentation>The underline (&lt;u>) element is used to apply underline highlighting to the content of the element. Category: Typographic elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="u.attlist"/>
           <ref name="u.content"/>
         </element>
@@ -182,9 +180,7 @@
       </define>
       <define name="i.element">
         <element name="i" dita:longName="Italic">
-          <a:documentation>Italic text is used to indicate either an alternate voice 
-            or mood, or to otherwise offset it from the content around it to indicate 
-            a different quality of text. Category: Typographic elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="i.attlist"/>
           <ref name="i.content"/>
         </element>
@@ -214,7 +210,7 @@
       </define>
       <define name="line-through.element">
         <element name="line-through" dita:longName="Line through">
-          <a:documentation>Category: Typographic elements </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="line-through.attlist"/>
           <ref name="line-through.content"/>
         </element>
@@ -245,7 +241,7 @@
       </define>
       <define name="overline.element">
         <element name="overline" dita:longName="Overline">
-          <a:documentation>Category: Typographic elements </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="overline.attlist"/>
           <ref name="overline.content"/>
         </element>
@@ -255,7 +251,7 @@
       </define>
     </div>
     <div>
-      <a:documentation>LONG NAME: Typewriter</a:documentation>
+      <a:documentation>LONG NAME: Teletype</a:documentation>
       <define name="tt.content">
         <zeroOrMore>
           <choice>
@@ -276,7 +272,7 @@
       </define>
       <define name="tt.element">
         <element name="tt" dita:longName="Teletype (monospaced)">
-          <a:documentation> The teletype (&lt;tt>) element is used to apply monospaced highlighting to the content of the element. Category: Typographic elements </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="tt.attlist"/>
           <ref name="tt.content"/>
         </element>
@@ -307,9 +303,7 @@
       </define>
       <define name="sup.element">
         <element name="sup" dita:longName="Superscript">
-          <a:documentation>The superscript (&lt;sup>) element indicates that text should be superscripted, or vertically raised in relationship to the surrounding text. Superscripts are usually a
-            smaller font than the surrounding text. Use this element only when there is not some other more proper tag. This element is part of the DITA highlighting domain. Category: Typographic
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="sup.attlist"/>
           <ref name="sup.content"/>
         </element>
@@ -340,8 +334,7 @@
       </define>
       <define name="sub.element">
         <element name="sub" dita:longName="Subscript">
-          <a:documentation>A subscript (&lt;sub>) indicates that text should be subscripted, or placed lower in relationship to the surrounding text. Subscripted text is often a smaller font than the
-            surrounding text. Formatting may vary depending on your output process. This element is part of the DITA highlighting domain. Category: Typographic elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="sub.attlist"/>
           <ref name="sub.content"/>
         </element>

--- a/doctypes/rng/base/mapGroupDomain.rng
+++ b/doctypes/rng/base/mapGroupDomain.rng
@@ -119,8 +119,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="topichead.element">
         <element name="topichead">
-          <a:documentation>The &lt;topichead> element provides a title-only entry in a navigation map, as an alternative to the fully-linked title provided by the &lt;topicref> element. Category:
-            Mapgroup elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="topichead.attlist"/>
           <ref name="topichead.content"/>
         </element>
@@ -151,9 +150,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="topicgroup.element">
         <element name="topicgroup">
-          <a:documentation>The &lt;topicgroup> element is for creating groups of &lt;topicref> elements without affecting the hierarchy, as opposed to nested &lt; topicref> elements within a
-            &lt;topicref>, which does imply a structural hierarchy. It is typically used outside a hierarchy to identify groups for linking without affecting the resulting toc/navigation output.
-            Category: Mapgroup elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="topicgroup.attlist"/>
           <ref name="topicgroup.content"/>
         </element>
@@ -263,8 +260,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="anchorref.element">
         <element name="anchorref">
-          <a:documentation>The contents of an &lt;anchorref> element are rendered both in the original authored location and at the location of the referenced &lt;anchor> element. The referenced
-            &lt;anchor> element can be defined in the current map or another map.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="anchorref.attlist"/>
           <ref name="anchorref.content"/>
         </element>
@@ -302,9 +298,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="mapref.element">
         <element name="mapref" dita:longName="Map reference">
-          <a:documentation>The &lt;mapref> element is a convenience element that has the same meaning as a &lt;topicref> element that explicitly sets the format attribute to &#34;ditamap&#34;. The
-            hierarchy of the referenced map is merged into the container map at the position of the reference, and the relationship tables of the child map are added to the parent
-            map.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="mapref.attlist"/>
           <ref name="mapref.content"/>
         </element>
@@ -415,9 +409,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="keydef.element">
         <element name="keydef">
-          <a:documentation>The &lt;keydef> element is a convenience element that is used to define keys without any of the other effects that occur when using a &lt;topicref> element: no content is
-            included in output, no title is included in the table of contents, and no linking or other relationships are defined. The &lt;keydef> element is not the only way to define keys; its
-            purpose is to simplify the process by defaulting several attributes to achieve the described behaviors.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="keydef.attlist"/>
           <ref name="keydef.content"/>
         </element>
@@ -513,7 +505,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
       </define>
       <define name="mapresources.element">
         <element name="mapresources">
-          <a:documentation/>
+          <a:documentation></a:documentation>
           <ref name="mapresources.attlist"/>
           <ref name="mapresources.content"/>
         </element>

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -520,9 +520,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="select-atts"/>
       </define>
       <define name="map.element">
-        <a:documentation>The &lt;map> element is used to define a map which describes the relationships among a set of resources, such as DITA topics. Maps consist of references to topics and other
-          resources organized into hierarchies, groups, and tables. Maps provide a way to express these relationships in a single common format that can be used for different outputs. Category: Map
-          elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="map" dita:longName="Map">
           <ref name="map.attlist"/>
           <ref name="map.content"/>
@@ -549,8 +547,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         </optional>
       </define>
       <define name="navref.element">
-        <a:documentation> The &lt;navref> represents a pointer to another map which should be preserved as a transcluding link rather than resolved. Output formats that support such linking will
-          integrate the target when displaying the referencing map to an end user. Category: Map elements </a:documentation>
+        <a:documentation></a:documentation>
         <element name="navref" dita:longName="Navigation Reference">
           <ref name="navref.attlist"/>
           <ref name="navref.content"/>
@@ -590,11 +587,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="topicref.element">
-        <a:documentation> The &lt;topicref> element identifies a topic (such as a concept, task, or reference) or other resource. A &lt;topicref> can contain other&lt;topicref> elements, allowing you
-          to express navigation or table-of-contents hierarchies, as well as implying relationships between the containing &lt;topicref> and its children. You can set the collection-type of a
-          container &lt;topicref> to determine how its children are related to each other. You can also express relationships among &lt;topicref>s using group and table structures (using
-          &lt;topicgroup> and &lt;reltable>). Relationships end up expressed as links in the output (with each participant in a relationship having links to the other participants by default).
-          Category: Map elements </a:documentation>
+        <a:documentation></a:documentation>
         <element name="topicref" dita:longName="Topic Reference">
           <ref name="topicref.attlist"/>
           <ref name="topicref.content"/>
@@ -622,9 +615,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="select-atts"/>
       </define>
       <define name="anchor.element">
-        <a:documentation>The &lt;anchor> element is used for runtime integration of navigation. It provides an integration point that another map can point to in order to insert its navigation into
-          the current navigation tree. For those familiar with Eclipse help systems, this serves the same purpose as the &lt;anchor> element in that system. It may not be supported for all output
-          formats. Category: Map elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="anchor" dita:longName="Anchor">
           <ref name="anchor.attlist"/>
           <ref name="anchor.content"/>
@@ -662,10 +653,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="reltable.element">
-        <a:documentation>The relationship table (&lt;reltable>) defines relationships between topics, based on the familiar table model of rows (&lt;relrow>), columns (&lt;relheader>), and cells
-          (&lt;relcell>). The &lt;relcell> elements can contain &lt;topicref> elements, which are then related to other &lt;topicref> elements in the same row (although not necessarily in the same
-          cell). By default, the contents of a &lt;reltable> element are not output for navigation or TOC purposes, and are used only to define relationships that can be expressed as topic-to-topic
-          links. Category: Map elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="reltable" dita:longName="Relationship Table">
           <ref name="reltable.attlist"/>
           <ref name="reltable.content"/>
@@ -687,8 +675,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="relheader.element">
-        <a:documentation>The &lt;relheader> element is a row of column definitions (&lt;relcolspec> elements) in a relationship table. Each table can have only one set of column definitions. Category:
-          Map elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="relheader" dita:longName="Relationship Header">
           <ref name="relheader.attlist"/>
           <ref name="relheader.content"/>
@@ -717,8 +704,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="relcolspec.element">
-        <a:documentation>A column definition in the relationship table. You can use &lt;relcolspec> column definitions to set defaults for the attributes of &lt;topicref> elements in the column. For
-          example, you can set type="concept" to treat all untyped &lt;topicref> elements in the column as concepts. Category: Map elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="relcolspec" dita:longName="Relationship Column Specification">
           <ref name="relcolspec.attlist"/>
           <ref name="relcolspec.content"/>
@@ -740,8 +726,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="relrow.element">
-        <a:documentation> A &lt;relrow> is a row in the relationship table. This creates a relationship between the cells in the row, which will end up expressed as links among the &lt;topicref>
-          elements in the cells. Category: Map elements </a:documentation>
+        <a:documentation></a:documentation>
         <element name="relrow" dita:longName="Relationship Table Row">
           <ref name="relrow.attlist"/>
           <ref name="relrow.content"/>
@@ -767,9 +752,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="relcell.element">
-        <a:documentation>A &lt;relcell> element is a cell in the relationship table. The &lt;topicref> elements it contains will be related to topicrefs in other cells of the same row. By default,
-          topicrefs in the same cell are not related to each other, unless you change the relcell's collection-type attribute to indicate that they are related. Category: Map
-          elements</a:documentation>
+        <a:documentation></a:documentation>
         <element name="relcell" dita:longName="Relationship Table Cell">
           <ref name="relcell.attlist"/>
           <ref name="relcell.content"/>
@@ -845,10 +828,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <ref name="univ-atts"/>
       </define>
       <define name="topicmeta.element">
-        <a:documentation>The &lt;topicmeta> element defines the metadata that applies to a topic when it appears in a map, and to the other topics in the map that are contained by the same element
-          that contains the &lt;topicmeta> element. When creating links, it can also be used to override the title and short description of the topic. In addition, it can be used to add index entries
-          to referenced content using the &lt;keywords> element. Category: Map elements</a:documentation>
         <element name="topicmeta" dita:longName="Topic Metadata">
+          <a:documentation></a:documentation>
           <ref name="topicmeta.attlist"/>
           <ref name="topicmeta.content"/>
         </element>
@@ -879,6 +860,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       </define>
       <define name="keytext.element">
         <element name="keytext" dita:longName="Key text">
+          <a:documentation></a:documentation>
           <ref name="keytext.attlist"/>
           <ref name="keytext.content"/>
         </element>
@@ -943,8 +925,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         </optional>
       </define>
       <define name="ux-window.element">
-        <a:documentation> Category: Map elements</a:documentation>
         <element name="ux-window" dita:longName="User Experience Window">
+          <a:documentation></a:documentation>
           <ref name="ux-window.attlist"/>
           <ref name="ux-window.content"/>
         </element>

--- a/doctypes/rng/base/metaDeclMod.rng
+++ b/doctypes/rng/base/metaDeclMod.rng
@@ -92,7 +92,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="author.element">
         <element name="author" dita:longName="Author">
-          <a:documentation>The &lt;author> metadata element contains the name of the topic's author. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="author.attlist"/>
           <ref name="author.content"/>
         </element>
@@ -139,8 +139,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="source.element">
         <element name="source" dita:longName="Source">
-          <a:documentation>The &lt;source> element contains a reference to a resource from which the present topic is derived, either completely or in part. The element can contain a description of
-            the resource; the href reference can be a string or a URL that points to it. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="source.attlist"/>
           <ref name="source.content"/>
         </element>
@@ -184,8 +183,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="publisher.element">
         <element name="publisher" dita:longName="Publisher">
-          <a:documentation>The &lt;publisher> metadata element contains the name of the person, company, or organization responsible for making the content or subject of the topic available. Category:
-            Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="publisher.attlist"/>
           <ref name="publisher.content"/>
         </element>
@@ -211,8 +209,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="copyright.element">
         <element name="copyright" dita:longName="Copyright">
-          <a:documentation>The &lt;copyright> element is used for a single copyright entry. It includes the copyright years and the copyright holder. Multiple &lt;copyright> statements are allowed.
-            Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="copyright.attlist"/>
           <ref name="copyright.content"/>
         </element>
@@ -235,7 +232,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="copyryear.element">
         <element name="copyryear" dita:longName="Copyright Year">
-          <a:documentation>The &lt;copyryear> element contains the copyright year as specified by the year attribute. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="copyryear.attlist"/>
           <ref name="copyryear.content"/>
         </element>
@@ -257,7 +254,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="copyrholder.element">
         <element name="copyrholder" dita:longName="Copyright Holder">
-          <a:documentation>The copyright holder (&lt;copyrholder>) element names the entity that holds legal rights to the material contained in the topic. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="copyrholder.attlist"/>
           <ref name="copyrholder.content"/>
         </element>
@@ -282,8 +279,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="critdates.element">
         <element name="critdates" dita:longName="Critical Dates">
-          <a:documentation>The &lt;critdates> element contains the critical dates in a document life cycle, such as the creation date and multiple revision dates. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="critdates.attlist"/>
           <ref name="critdates.content"/>
         </element>
@@ -316,7 +312,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="created.element">
         <element name="created" dita:longName="Created Date">
-          <a:documentation>The &lt;created> element specifies the document creation date using the date attribute. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="created.attlist"/>
           <ref name="created.content"/>
         </element>
@@ -349,8 +345,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="revised.element">
         <element name="revised" dita:longName="Revised Date">
-          <a:documentation>The &lt;revised> element in the prolog is used to maintain tracking dates that are important in a topic development cycle, such as the last modification date, the original
-            availability date, and the expiration date. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="revised.attlist"/>
           <ref name="revised.content"/>
         </element>
@@ -371,8 +366,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="permissions.element">
         <element name="permissions" dita:longName="Permissions">
-          <a:documentation>The &lt;permissions> prolog element can indicate any preferred controls for access to a topic. Topics can be filtered based on the permissions element. This capability
-            depends on your output formatting process. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="permissions.attlist"/>
           <ref name="permissions.content"/>
         </element>
@@ -394,8 +388,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="category.element">
         <element name="category" dita:longName="Category">
-          <a:documentation>The &lt;category> element can represent any category by which a topic might be classified for retrieval or navigation; for example, the categories could be used to group
-            topics in a generated navigation bar. Topics can belong to multiple categories. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="category.attlist"/>
           <ref name="category.content"/>
         </element>
@@ -435,10 +428,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="metadata.element">
         <element name="metadata" dita:longName="Metadata">
-          <a:documentation>The &lt;metadata> section of the prolog contains information about a topic such as audience and product information. Metadata can be used by computational processes to
-            select particular topics or to prepare search indexes or to customize navigation. Elements inside of &lt;metadata> provide information about the content and subject of a topic; prolog
-            elements outside of &lt;metadata> provide lifecycle information for the content unit (such as the author or copyright), which are unrelated to the subject. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="metadata.attlist"/>
           <ref name="metadata.content"/>
         </element>
@@ -472,10 +462,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="audience.element">
         <element name="audience" dita:longName="Audience">
-          <a:documentation>The &lt;audience> metadata element indicates, through the value of its type attribute, the intended audience for a topic. Since a topic can have multiple audiences, you can
-            include multiple audience elements. For each audience you specify, you can identify the high-level task (job) they are trying to accomplish and the level of experience (experiencelevel)
-            expected. The audience element may be used to provide a more detailed definition of values used throughout the map or topic on the audience attribute. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="audience.attlist"/>
           <ref name="audience.content"/>
         </element>
@@ -500,8 +487,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="keywords.element">
         <element name="keywords" dita:longName="Keywords">
-          <a:documentation>The &lt;keywords> element contains a list of key words (using &lt;indexterm> or &lt;keyword> markup) that can be used by a search engine. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="keywords.attlist"/>
           <ref name="keywords.content"/>
         </element>
@@ -534,8 +520,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="prodinfo.element">
         <element name="prodinfo" dita:longName="Product Information">
-          <a:documentation>The &lt;prodinfo> metadata element in the prolog contains information about the product or products that are the subject matter of the current topic. The prodinfo element
-            may be used to provide a more detailed definition of values used throughout the map or topic on the product attribute. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="prodinfo.attlist"/>
           <ref name="prodinfo.content"/>
         </element>
@@ -557,7 +542,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="prodname.element">
         <element name="prodname" dita:longName="Product Name">
-          <a:documentation>The &lt;prodname> metadata element contains the name of the product that is supported by the information in this topic. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="prodname.attlist"/>
           <ref name="prodname.content"/>
         </element>
@@ -579,8 +564,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="vrmlist.element">
         <element name="vrmlist" dita:longName="Version Release and Modification List">
-          <a:documentation>The &lt;vrmlist> element contains a set of &lt;vrm> elements for logging the version, release, and modification information for multiple products or versions of products to
-            which the topic applies. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="vrmlist.attlist"/>
           <ref name="vrmlist.content"/>
         </element>
@@ -607,8 +591,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="vrm.element">
         <element name="vrm" dita:longName="Version Release and Modification">
-          <a:documentation>The vrm empty element contains information about a single product's version, modification, and release, to which the current topic applies. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="vrm.attlist"/>
           <ref name="vrm.content"/>
         </element>
@@ -630,8 +613,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="brand.element">
         <element name="brand" dita:longName="Brand">
-          <a:documentation>The &lt;brand> element indicates the manufacturer or brand associated with the product described by the parent &lt;prodinfo> element. Category: Prolog
-            elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="brand.attlist"/>
           <ref name="brand.content"/>
         </element>
@@ -653,7 +635,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="series.element">
         <element name="series" dita:longName="Series">
-          <a:documentation>The &lt;series> metadata element contains information about the product series that the topic supports. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="series.attlist"/>
           <ref name="series.content"/>
         </element>
@@ -675,8 +657,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="platform.element">
         <element name="platform" dita:longName="Platform">
-          <a:documentation>The &lt;platform> metadata element contains a description of the operating system and/or hardware related to the product being described by the &lt;prodinfo> element. The
-            platform element may be used to provide a more detailed definition of values used throughout the map or topic on the platform attribute. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="platform.attlist"/>
           <ref name="platform.content"/>
         </element>
@@ -698,8 +679,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="prognum.element">
         <element name="prognum" dita:longName="Program Number">
-          <a:documentation>The &lt;prognum> metadata element identifies the program number of the associated program product. This is typically an order number or a product tracking code that could be
-            replaced by an order number when a product completes development. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="prognum.attlist"/>
           <ref name="prognum.content"/>
         </element>
@@ -721,7 +701,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="featnum.element">
         <element name="featnum" dita:longName="Feature Number">
-          <a:documentation>The &lt;featnum> element contains the feature number of a product in the metadata. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="featnum.attlist"/>
           <ref name="featnum.content"/>
         </element>
@@ -743,10 +723,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="component.element">
         <element name="component" dita:longName="Component">
-          <a:documentation>The &lt;component> element describes the component of the product that this topic is concerned with. For example, a product might be made up of many components, each of
-            which is installable separately. Components might also be shared by several products so that the same component is available for installation with many products. An implementation may (but
-            need not) use this identification to check cross-component dependencies when some components are installed, but not others. An implementation may also (but need not) use the identification
-            make sure that topics are hidden, removed, or flagged in some way when the component they describe isn't installed. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="component.attlist"/>
           <ref name="component.content"/>
         </element>
@@ -777,9 +754,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="othermeta.element">
         <element name="othermeta" dita:longName="Other Metadata">
-          <a:documentation>The &lt;othermeta> element can be used to identify properties not otherwise included in &lt;metadata> and assign name/content values to those properties. The name attribute
-            identifies the property and the content attribute specifies the property's value. The values in this attribute are output as HTML metadata elements, and have no defined meaning for other
-            possible outputs such as PDF. Category: Prolog elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="othermeta.attlist"/>
           <ref name="othermeta.content"/>
         </element>
@@ -831,8 +806,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Metadata//EN"
       </define>
       <define name="resourceid.element">
         <element name="resourceid" dita:longName="Resource Identifier">
-          <a:documentation>The &lt;resourceid> element provides an identifier for applications that require them in a particular format, when the normal id attribute of the topic can't be used. Each
-            resourceid entry should be unique. It is one of the metadata elements that can be included within the prolog of a topic, along with document tracking and product information, etc.</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="resourceid.attlist"/>
           <ref name="resourceid.content"/>
         </element>

--- a/doctypes/rng/base/tblDeclMod.rng
+++ b/doctypes/rng/base/tblDeclMod.rng
@@ -356,9 +356,7 @@ For <entry>, add:
   </define>
   <define name="tgroup.element">
     <element name="tgroup" dita:longName="Table Group">
-      <a:documentation>The &lt;tgroup> element in a table contains column, row, spanning, header and
-        footer specifications, and the body (&lt;tbody>) of the table. 
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="tgroup.attlist"/>
       <ref name="tgroup.content"/>
     </element>
@@ -430,9 +428,7 @@ For <entry>, add:
   </define>
   <define name="colspec.element">
     <element name="colspec" dita:longName="Column Specification">
-      <a:documentation>The &lt;colspec> element contains a column specification for a table,
-        including assigning a column name and number, cell content alignment, and column width.
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="colspec.attlist"/>
       <ref name="colspec.content"/>
     </element>
@@ -463,9 +459,7 @@ For <entry>, add:
   </define>
   <define name="thead.element">
     <element name="thead" dita:longName="Table Header">
-      <a:documentation>The table header (&lt;thead>) element precedes the table body (&lt;tbody>)
-        element in a complex table. 
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="thead.attlist"/>
       <ref name="thead.content"/>
     </element>
@@ -496,8 +490,7 @@ For <entry>, add:
   </define>
   <define name="tbody.element">
     <element name="tbody" dita:longName="Table Body">
-      <a:documentation>The &lt;tbody> element contains the rows in a table. 
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="tbody.attlist"/>
       <ref name="tbody.content"/>
     </element>
@@ -531,8 +524,7 @@ For <entry>, add:
   </define>
   <define name="row.element">
     <element name="row" dita:longName="Table Row">
-      <a:documentation>The &lt;row> element contains a single row in a table &lt;tgroup>. 
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="row.attlist"/>
       <ref name="row.content"/>
     </element>
@@ -611,8 +603,7 @@ For <entry>, add:
   </define>
   <define name="entry.element">
     <element name="entry" dita:longName="Table Row Entry">
-      <a:documentation>The &lt;entry> element defines a single cell in a table. 
-        Category: Table elements</a:documentation>
+      <a:documentation></a:documentation>
       <ref name="entry.attlist"/>
       <ref name="entry.content"/>
     </element>

--- a/doctypes/rng/base/utilitiesDomain.rng
+++ b/doctypes/rng/base/utilitiesDomain.rng
@@ -100,11 +100,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       </define>
       <define name="imagemap.element">
         <element dita:longName="Imagemap" name="imagemap">
-          <a:documentation>The imagemap element supports the basic functionality 
-            of the HTML client-side image map markup. Imagemap allows you to designate 
-            a linkable area or region over an image,
-            allowing a link in that region to display another topic. 
-            Category: Utilities elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="imagemap.attlist"/>
           <ref name="imagemap.content"/>
         </element>
@@ -126,9 +122,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       </define>
       <define name="area.element">
         <element dita:longName="Hotspot Area Description" name="area">
-          <a:documentation>The area element supports the basic functionality of the HTML 
-            image map markup. 
-            Category: Utilities elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="area.attlist"/>
           <ref name="area.content"/>
         </element>
@@ -156,8 +150,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       </define>
       <define name="shape.element">
         <element dita:longName="Shape of the Hotspot" name="shape">
-          <a:documentation>The shape element defines the shape of a linkable 
-            area in an imagemap. Category: Utilities elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="shape.attlist"/>
           <ref name="shape.content"/>
         </element>
@@ -182,8 +175,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       </define>
       <define name="coords.element">
         <element dita:longName="Coordinates of the Hotspot" name="coords">
-          <a:documentation>The coords element specifies the coordinates of the 
-            linkable region in an imagemap area. Category: Utilities elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="coords.attlist"/>
           <ref name="coords.content"/>
         </element>
@@ -214,7 +206,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
       </define>
       <define name="sort-as.element">
         <element dita:longName="Sort phrase specifier" name="sort-as">
-          <a:documentation> Category: Utilities elements</a:documentation>
+          <a:documentation></a:documentation>
           <ref name="sort-as.attlist"/>
           <ref name="sort-as.content"/>
         </element>

--- a/doctypes/rng/subjectScheme/classifyDomain.rng
+++ b/doctypes/rng/subjectScheme/classifyDomain.rng
@@ -153,7 +153,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         </optional>
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicsubject> element identifies the subjects for which the topic or collection of topics provides the authoritative treatment. The subjects can be identified by keys (if defined in the scheme) or, if the subject definition topic exists, by href (as with ordinary topic references). Additional secondary subjects can be specified by nested <subjectref> elements.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicsubject.element">
         <element name="topicsubject" dita:longName="Topic Subject">
           <ref name="topicsubject.attlist"/>
@@ -250,7 +250,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         </optional>
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicapply> element identifies subjects that qualify the content for filtering or flagging but not retrieval. The <topicapply> element can identify a single subject. Additional subjects can be specified by nested <subjectref> elements.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicapply.element">
         <element name="topicapply" dita:longName="Topic Apply">
           <ref name="topicapply.attlist"/>
@@ -340,7 +340,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         </optional>
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <subjectref> element identifies a subject to classify content. The <subjectref> can identify the subject with a keyref attribute (if the scheme has a <subjectdef> with a keys attribute that assigns a key to the subject) or an href attribute (if a topic captures the consensus definition for the subject).]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="subjectref.element">
         <element name="subjectref" dita:longName="Subject Reference">
           <ref name="subjectref.attlist"/>
@@ -372,7 +372,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         <ref name="topicref-atts-no-toc"/>
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicSubjectTable> element is a specialized relationship table which allows a map to use relationship tables to associate topics with subjects. In a <topicSubjectTable>, the first column is reserved for references to content. Subsequent columns are reserved for subjects that classify the content, each column supplying the subjects for a different category as identified in the header. The table resembles a traditional relationship table in which the first column identifies the source and the other columns identify the targets, but the relationship reflects the subjects covered by the content rather than linking between documents.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicSubjectTable.element">
         <element name="topicSubjectTable" dita:longName="Topic Subject Relationship Table">
           <ref name="topicSubjectTable.attlist"/>
@@ -386,9 +386,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
     </div>
     <div>
       <a:documentation>LONG NAME: Topic Subject Table Header</a:documentation>
-      <a:documentation> The header defines the set of subjects for each column. By default, the subject in the header cell must be a broader ancestor within a scheme available during processing for
-        the subjects in the same column of other rows In the header, the topicCell serves primarily as a placeholder for the topic column but could also provide some constraints or metadata for the
-        topics </a:documentation>
       <define name="topicSubjectHeader.content">
         <ref name="topicCell"/>
         <oneOrMore>
@@ -398,7 +395,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
       <define name="topicSubjectHeader.attributes">
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicSubjectHeader> element specifies constraints on the subjects used in classifications.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicSubjectHeader.element">
         <element name="topicSubjectHeader" dita:longName="Topic Subject Table Header">
           <ref name="topicSubjectHeader.attlist"/>
@@ -421,7 +418,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
       <define name="topicSubjectRow.attributes">
         <ref name="univ-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicSubjectRow> is a grouping element that contains one row of a subject table. It contains topic references in the first column, and relates those references to the subjects in each following column.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicSubjectRow.element">
         <element name="topicSubjectRow" dita:longName="Topic Subject Table Row">
           <ref name="topicSubjectRow.attlist"/>
@@ -447,7 +444,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         <ref name="univ-atts"/>
         <ref name="topicref-atts"/>
       </define>
-      <a:documentation><![CDATA[The <topicCell> element contains topics that will be associated with subjects in each following column of the current row in the <topicSubjectTable>.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="topicCell.element">
         <element name="topicCell" dita:longName="Topic Subject Table Cell">
           <ref name="topicCell.attlist"/>
@@ -474,7 +471,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
         <ref name="univ-atts"/>
         <ref name="topicref-atts"/>
       </define>
-      <a:documentation><![CDATA[The <subjectCell> element contains subjects that are associated with topics in the first column of the current row in the <topicSubjectTable>. The subjects themselves have no defined relationship across columns, other than the fact that they apply to the same content.]]></a:documentation>
+      <a:documentation></a:documentation>
       <define name="subjectCell.element">
         <element name="subjectCell" dita:longName="Topic Subject Cell">
           <ref name="subjectCell.attlist"/>

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -234,7 +234,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectScheme.element">
         <element name="subjectScheme" dita:longName="Subject Scheme Map">
-          <a:documentation><![CDATA[A subjectScheme is a specialized DITA map that defines a collection of controlled values rather than a collection of topics.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectScheme.attlist"/>
           <ref name="subjectScheme.content"/>
         </element>
@@ -298,7 +298,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="schemeref.element">
         <element name="schemeref" dita:longName="Scheme reference">
-          <a:documentation><![CDATA[A <schemeref> element provides a reference to another scheme. Typically, the referenced scheme defines a base set of controlled values extended by the current scheme. The values in the referenced scheme are merged with the current scheme; the result is equivalent to specifying all of the values in a single map.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="schemeref.attlist"/>
           <ref name="schemeref.content"/>
         </element>
@@ -365,7 +365,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="hasNarrower.element">
         <element name="hasNarrower" dita:longName="Has Narrower Relationship">
-          <a:documentation><![CDATA[For subjects within the <hasNarrower> element, the container subject is more general than each of the contained subjects. That is, this element makes the default hierarchical relationship explicit, although the way in which a relationship is narrower is not specified.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hasNarrower.attlist"/>
           <ref name="hasNarrower.content"/>
         </element>
@@ -432,7 +432,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="hasKind.element">
         <element name="hasKind" dita:longName="Has Kind Relationship">
-          <a:documentation><![CDATA[Specifies that the contained hierarchy expresses KIND-OF relationships between subjects.]]>
+          <a:documentation></a:documentation>
           </a:documentation>
           <ref name="hasKind.attlist"/>
           <ref name="hasKind.content"/>
@@ -500,7 +500,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="hasPart.element">
         <element name="hasPart" dita:longName="Has Part Relationship">
-          <a:documentation><![CDATA[The <hasPart> element specifies that the contained hierarchy expresses PART-OF relationships between subjects.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hasPart.attlist"/>
           <ref name="hasPart.content"/>
         </element>
@@ -567,7 +567,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="hasInstance.element">
         <element name="hasInstance" dita:longName="Has Instance Relationship">
-          <a:documentation><![CDATA[Specifies that the contained hierarchy expresses INSTANCE-OF relationships between subjects. In an INSTANCE-OF hierarchy, the child subject is a specific entity or object and the parent subject is a type, kind, or class of entity or object. For example, New York City is a specific instance of a city.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hasInstance.attlist"/>
           <ref name="hasInstance.content"/>
         </element>
@@ -604,7 +604,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
         </optional>
         <optional>
           <attribute name="collection-type">
-            <a:documentation>Default removed for DITA 1.3.</a:documentation>
             <choice>
               <value>choice</value>
               <value>family</value>
@@ -646,7 +645,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="hasRelated.element">
         <element name="hasRelated" dita:longName="Has Related Relationship">
-          <a:documentation><![CDATA[The <hasRelated> element identifies an associative relationship between the container subject and each of the contained subjects.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="hasRelated.attlist"/>
           <ref name="hasRelated.content"/>
         </element>
@@ -749,7 +748,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectdef.element">
         <element name="subjectdef" dita:longName="Subject definition">
-          <a:documentation><![CDATA[The <subjectdef> element defines a subject (also known as a controlled value) within a scheme. To make the subject easy to identify, a <subjectdef> may use a keys attribute to assign a key to the subject. A subject with a key can be identified elsewhere with a keyref. The <subjectdef> may use a navtitle element to supply a label for the subject. The <subjectdef> may also refer to a topic that captures the consensus definition for the subject.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectdef.attlist"/>
           <ref name="subjectdef.content"/>
         </element>
@@ -814,7 +813,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectHead.element">
         <element name="subjectHead" dita:longName="Subject Heading">
-          <a:documentation><![CDATA[The <subjectHead> element provides a heading for a group of subjects. The subjectHead element itself does not reference a file and cannot be referenced as a key, so it does not define any controlled values.]]>
+          <a:documentation></a:documentation>
           </a:documentation>
           <ref name="subjectHead.attlist"/>
           <ref name="subjectHead.content"/>
@@ -840,7 +839,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectHeadMeta.element">
         <element name="subjectHeadMeta" dita:longName="Subject Heading Metadata">
-          <a:documentation><![CDATA[The <subjectHeadMeta> element allows a navigation title and short description to be associated with a subject heading.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectHeadMeta.attlist"/>
           <ref name="subjectHeadMeta.content"/>
         </element>
@@ -890,7 +889,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="enumerationdef.element">
         <element name="enumerationdef" dita:longName="Enumeration definition">
-          <a:documentation><![CDATA[The <enumerationdef> element identifies one attribute and one or more categories that contain the controlled values for the enumeration. The type attribute has a default value of keys.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="enumerationdef.attlist"/>
           <ref name="enumerationdef.content"/>
         </element>
@@ -940,7 +939,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="elementdef.element">
         <element name="elementdef" dita:longName="Element definition">
-          <a:documentation><![CDATA[The <elementdef> element identifies an element on which an attribute is enumerated. When the <elementdef> is left out of an <enumerationdef> element, the enumeration is bound to the attribute in all elements.]]>
+          <a:documentation></a:documentation>
           </a:documentation>
           <ref name="elementdef.attlist"/>
           <ref name="elementdef.content"/>
@@ -991,7 +990,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="attributedef.element">
         <element name="attributedef" dita:longName="Attribute definition">
-          <a:documentation><![CDATA[The <attributedef> element defines an attribute as an enumeration by specifying controlled values from a scheme.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="attributedef.attlist"/>
           <ref name="attributedef.content"/>
         </element>
@@ -1070,7 +1069,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="defaultSubject.element">
         <element name="defaultSubject" dita:longName="Default Subject">
-          <a:documentation><![CDATA[The <defaultSubject> element is used within an attribute enumeration to set the default value for that attribute in cases where no value is specified on the attribute. The default subject must be one of the controlled values within the categories specified for the attribute.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="defaultSubject.attlist"/>
           <ref name="defaultSubject.content"/>
         </element>
@@ -1155,9 +1154,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="relatedSubjects.element">
         <element name="relatedSubjects" dita:longName="Related Subjects">
-          <a:documentation><![CDATA[The <relatedSubjects> element establishes associative relationships between each child subject and every other child subject (unless the association is restricted by the linking attribute of the subjects).
-      To define roles within a relationship, you can specialize the relatedSubjects container and its contained subjectdef elements, possibly setting the linking attribute to
-        targetonly or sourceonly. For instance, a dependency relationship could contain depended-on and dependent subjects. ]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="relatedSubjects.attlist"/>
           <ref name="relatedSubjects.content"/>
         </element>
@@ -1189,10 +1186,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectRelTable.element">
         <element name="subjectRelTable" dita:longName="Subject Relationship Table">
-          <a:documentation><![CDATA[The <subjectRelTable> element is a specialized relationship table which establishes relationships between the subjects in different columns of the same row.      
-            
-            Where there are many instances of a subject relationship in which different subjects have defined roles within the relationship, you can use or specialize the subjectRelTable.
-        Note that each row matrixes relationships across columns such that a subject receives relationships to every subject in other columns within the same row. ]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectRelTable.attlist"/>
           <ref name="subjectRelTable.content"/>
         </element>
@@ -1214,9 +1208,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectRelHeader.element">
         <element name="subjectRelHeader" dita:longName="Subject Table Header">
-          <a:documentation><![CDATA[The <subjectRelHeader> element specifies the roles played by subjects in associations.
-            The role definition can be an informal navtitle or a formal reference]]>
-          </a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectRelHeader.attlist"/>
           <ref name="subjectRelHeader.content"/>
         </element>
@@ -1238,7 +1230,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectRel.element">
         <element name="subjectRel" dita:longName="Subject Table Row">
-          <a:documentation><![CDATA[The <subjectRel> element contains a set of subjects that are related in some manner. Each group of subjects is contained in a <subjectRole> element; the associations between different columns in the same row are evaluated in the same way as those in a <relrow> (from which <subjectRel> is specialized) but define relationships between the subjects instead of links between topic documents.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectRel.attlist"/>
           <ref name="subjectRel.content"/>
         </element>
@@ -1265,7 +1257,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
       <define name="subjectRole.element">
         <element name="subjectRole" dita:longName="Subject Role">
-          <a:documentation><![CDATA[The <subjectRole> element contains a set of subjects that are related to other subjects in the same row of the current <subjectRelTable>. By default, no relationship is defined between multiple subjects in the same <subjectRole> element.]]></a:documentation>
+          <a:documentation></a:documentation>
           <ref name="subjectRole.attlist"/>
           <ref name="subjectRole.content"/>
         </element>


### PR DESCRIPTION
Removing `a:documentation` definitions of elements -- most of these are really obsolete, some based on short descriptions from the spec in DITA 1.0 or 1.1. We should not be providing definitions of of the elements that are inconsistent with the actual specification. Once the specification is reviewed and the short descriptions are set, we should add (consistent) docs back to replace these. It should be possible to do this during or even after public review, as it is just metadata within the grammar file.

A couple other notes:
* I've removed docs for `@conaction` from the RNG - also inconsistent, and might be the only attribute that included a definition of the attribute and values
* I noticed that `<ul>` has an embedded schematron rule, which we probably want to remove?