### PR TITLE
Remove obsolete attr from examples

### DIFF
--- a/specification/archSpec/base/example-chunk-ignored.dita
+++ b/specification/archSpec/base/example-chunk-ignored.dita
@@ -37,13 +37,13 @@ elements.</p>
 <codeblock>&lt;map>
   &lt;title>Trying to "split" groups&lt;/title>
   &lt;topicgroup chunk="split">
-    &lt;topicref href="ingroup1.dita">...&lt;/topicref>
-    &lt;topicref href="ingroup2.dita">...&lt;/topicref>
+    &lt;topicref href="ingroup1.dita">&lt;!--...-->&lt;/topicref>
+    &lt;topicref href="ingroup2.dita">&lt;!--...-->&lt;/topicref>
   &lt;/topicgroup>
   &lt;topichead chunk="split">
     &lt;topicmeta>&lt;navtitle>Heading for a branch&lt;/navtitle>&lt;/topicmeta>
-    &lt;topicref href="inhead1.dita">...&lt;/topicref>
-    &lt;topicref href="inhead2.dita">...&lt;/topicref>
+    &lt;topicref href="inhead1.dita">&lt;!--...-->&lt;/topicref>
+    &lt;topicref href="inhead2.dita">&lt;!--...-->&lt;/topicref>
   &lt;/topichead>
 &lt;/map></codeblock>
 </fig>

--- a/specification/archSpec/base/example-index-range-defined-in-a-topic-prolog.dita
+++ b/specification/archSpec/base/example-index-range-defined-in-a-topic-prolog.dita
@@ -17,7 +17,7 @@
     &lt;topicref href="procedures.dita"/>
     &lt;topicref href="forms.dita"/>
   &lt;/topicref>
-  ...
+  &lt;!-- ... -->
 &lt;/map></codeblock>
         <p>The information developer wants an index entry that will span
                 <filepath>acct.dita</filepath> and its children. He uses the following markup in

--- a/specification/archSpec/base/example-rng-constraints-apply-multiple-constraints.dita
+++ b/specification/archSpec/base/example-rng-constraints-apply-multiple-constraints.dita
@@ -67,7 +67,7 @@
           <p>The information architect creates a constraint module that combines the constraints
             from <filepath>example-TopicConstraint.mod</filepath> and
               <filepath>example-SectionConstraint.mod</filepath>:</p>
-          <codeblock>&lt;?xml version="1.0" encoding="UTF-8"?>
+          <codeblock base="ci-xml">&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
                          schematypens="http://relaxng.org/ns/structure/1.0"?>
 &lt;grammar xmlns="http://relaxng.org/ns/structure/1.0"
@@ -105,7 +105,7 @@
         <li>
           <p>In the document-type shell, the information architect integrates the constraint module
             (and removes the inclusion statement for <filepath>topicMod.rng</filepath>):</p>
-          <codeblock>&lt;div>
+          <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>ELEMENT-TYPE CONFIGURATION INTEGRATION&lt;/a:documentation>
   &lt;include href="acme-SectionTopicContraintMod.rng"/>
 &lt;/div></codeblock>
@@ -113,7 +113,7 @@
         <li>
           <p>To constrain the highlight domain, the information architect modifies the include
             statement for the domain module:</p>
-          <codeblock>&lt;div>
+          <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
   ...
   &lt;include href="highlightDomain.rng">
@@ -141,7 +141,7 @@
         </li>
         <li>Finally, to disallow <xmlelement>ph</xmlelement>, the information architect adds the
           following statement to the constraint
-          module:<codeblock>      &lt;define name="ph.element">
+          module:<codeblock base="ci-xml">      &lt;define name="ph.element">
         &lt;notAllowed/>
       &lt;/define></codeblock></li>
       </ol>

--- a/specification/archSpec/base/filtering.dita
+++ b/specification/archSpec/base/filtering.dita
@@ -46,6 +46,9 @@ attribute is treated as "include", because an omitted attribute cannot evaluate 
    to an audience or platform that is not excluded. But if the paragraph applies to an additional
    product that has not been excluded, then its content is still relevant for the intended output
    and is preserved.</p>
+  <draft-comment author="rodaande" time="2021-09-14">Think maybe we should probably rework the
+   example below to not use steps, given that the steps element is not part of the base
+   spec?</draft-comment>
   <p>Similarly, with groups, a step might apply to one application server and two database
    applications:<codeblock id="groupcodesample">&lt;steps>
   &lt;step>&lt;cmd>Common step&lt;/cmd>&lt;/step>

--- a/specification/archSpec/base/generalization-attributes.dita
+++ b/specification/archSpec/base/generalization-attributes.dita
@@ -48,7 +48,7 @@
       <p>For example, the following <xmlelement>p</xmlelement> element provides two values for the
           <xmlatt>jobrole</xmlatt> attribute, one in a generalized syntax and the other in a
         specialized syntax:</p>
-      <codeblock>&lt;p person="jobrole(programmer)" jobrole="admin">
+      <codeblock base="ci-xml">&lt;p person="jobrole(programmer)" jobrole="admin">
     &lt;!-- ... -->
 &lt;/p></codeblock>
     </div>

--- a/specification/archSpec/base/reconciling-topic-and-map-metadata.dita
+++ b/specification/archSpec/base/reconciling-topic-and-map-metadata.dita
@@ -184,8 +184,8 @@ specified</entry>
     <example id="attr-cascade-example" otherprops="examples">
       <title>Example of metadata elements cascading in a DITA map</title>
       <p>The following code sample illustrates how an information architect can apply certain
-        metadata to all the DITA topics in a
-        map:<codeblock>&lt;map title="DITA maps" xml:lang="en-us">
+        metadata to all the DITA topics in a map:<codeblock>&lt;map xml:lang="en-us">
+       &lt;title>DITA maps&lt;/title>
 	&lt;topicmeta>
 		&lt;author>Kristen James Eberlein&lt;/author>
 		&lt;copyright>

--- a/specification/archSpec/base/relax-ng-coding-element-domains.dita
+++ b/specification/archSpec/base/relax-ng-coding-element-domains.dita
@@ -39,7 +39,7 @@
             patterns. Each extension of the base element type is referenced.</p>
           <example>
             <p>For example:</p>
-            <codeblock>&lt;a:documentation>DOMAIN EXTENSION PATTERNS&lt;/a:documentation>
+            <codeblock base="ci-xml">&lt;a:documentation>DOMAIN EXTENSION PATTERNS&lt;/a:documentation>
 
 &lt;define name="hi-d-ph">
   &lt;choice>
@@ -67,7 +67,7 @@
             <p>For example, the following pattern adds the highlight domain specializations of the
                 <xmlelement>ph</xmlelement> element to the content model of the
                 <xmlelement>ph</xmlelement> element:</p>
-            <codeblock>&lt;define name="ph" combine="choice">
+            <codeblock base="ci-xml">&lt;define name="ph" combine="choice">
   &lt;ref name="hi-d-ph"/>
 &lt;/define></codeblock>
           </example>
@@ -82,7 +82,7 @@
       <title>Example</title>
       <p>The following code sample shows the extension pattern for the highlight domain, as declared
         in <filepath>highlightDomain.rng</filepath>:</p>
-      <codeblock>  &lt;div>
+      <codeblock base="ci-xml">  &lt;div>
     &lt;a:documentation>DOMAIN EXTENSION PATTERNS&lt;/a:documentation>
 
     &lt;define name="hi-d-ph">

--- a/specification/archSpec/base/relax-ng-coding-requirements-for-element-configuration-modules.dita
+++ b/specification/archSpec/base/relax-ng-coding-requirements-for-element-configuration-modules.dita
@@ -25,7 +25,7 @@
                                 <xmlelement>topic</xmlelement> element imports the base module
                                 <filepath>topicMod.rng</filepath>. Within that import, it constrains
                             the <codeph>topic.content</codeph> pattern:</p>
-                        <codeblock>  &lt;div>
+                        <codeblock base="ci-xml">  &lt;div>
     &lt;a:documentation>ATTRIBUTES AND CONTENT MODEL OVERRIDES&lt;/a:documentation>
     &lt;include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0">
       &lt;define name="topic.content" combine="interleave">
@@ -49,7 +49,7 @@
                                 <xmlelement>section</xmlelement> imports the base module
                                 <filepath>topicMod.rng</filepath>. Within that import, it expands
                             the <codeph>section.content</codeph> pattern:</p>
-                        <codeblock>    &lt;a:documentation>CONTENT MODEL AND ATTRIBUTE LIST OVERRIDES&lt;/a:documentation>
+                        <codeblock base="ci-xml">    &lt;a:documentation>CONTENT MODEL AND ATTRIBUTE LIST OVERRIDES&lt;/a:documentation>
     &lt;include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0">
       <b>&lt;define name="section.content" combine="interleave">
         &lt;optional>
@@ -88,7 +88,7 @@
                                     <xmlelement>section</xmlelement> and
                                     <xmlelement>shortdesc</xmlelement>, a single module can be
                                 defined as follows:</p>
-                            <codeblock>&lt;include href="topicMod.rng"&gt;
+                            <codeblock base="ci-xml">&lt;include href="topicMod.rng"&gt;
   &lt;define name="section.content"&gt;
     &lt;!-- Constrained model for section -->
   &lt;/define>

--- a/specification/archSpec/base/relax-ng-coding-structural-modules.dita
+++ b/specification/archSpec/base/relax-ng-coding-structural-modules.dita
@@ -28,7 +28,7 @@
         <p>For example, the following definition references the <codeph>arch-atts</codeph> and
             <codeph>specializations-att</codeph> patterns as part of the definition for the
             <xmlelement>concept</xmlelement> element.</p>
-        <codeblock>&lt;div&gt;
+        <codeblock base="ci-xml">&lt;div&gt;
   &lt;a:documentation&gt; LONG NAME: Concept &lt;/a:documentation&gt;
   &lt;!-- ... -->
   &lt;define name="concept.attlist" combine="interleave"&gt;
@@ -71,7 +71,7 @@
               rules.</p>
             <div otherprops="examples">
               <p>For example:</p>
-              <codeblock>&lt;div>
+              <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>INFO TYPES PATTERNS&lt;/a:documentation>
   &lt;define name="mytopic-info-types">
     &lt;ref name="subtopictype-01.element"/>
@@ -83,7 +83,7 @@
             <p>To disable topic nesting, specify the <xmlelement>empty</xmlelement> element.</p>
             <div otherprops="examples">
               <p>For example:</p>
-              <codeblock>&lt;define name="learningAssessment-info-types"&gt;
+              <codeblock base="ci-xml">&lt;define name="learningAssessment-info-types"&gt;
   &lt;empty/&gt;
 &lt;/define&gt;</codeblock>
             </div>
@@ -94,7 +94,7 @@
             </draft-comment>
             <div otherprops="examples">
               <p>For example:</p>
-              <codeblock>&lt;div>
+              <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>INFO TYPES PATTERNS&lt;/a:documentation>
   &lt;define name="mytopic-info-types">
     &lt;ref name="info-types"/>
@@ -113,7 +113,7 @@
             <div otherprops="examples">
               <p>For example, the <xmlelement>concept</xmlelement> element places the pattern after
                   <xmlelement>related-links</xmlelement>:</p>
-              <codeblock>&lt;div>
+              <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>LONG NAME: Concept&lt;/a:documentation>
   &lt;define name="concept.content">
     &lt;!-- ... -->

--- a/specification/archSpec/base/theconrefendattribute.dita
+++ b/specification/archSpec/base/theconrefendattribute.dita
@@ -69,7 +69,7 @@
       <fig>
         <title>List example: Source <filepath>topic.dita</filepath> with ids</title>
         <codeblock>&lt;topic id="x">
- 	...
+ 	&lt;title>Sample file topic.dita&lt;/title>
  	&lt;body>
  		&lt;ol>
  			&lt;li id="apple">A&lt;/li>
@@ -85,7 +85,7 @@
       <fig id="fig_C0AF6F23F1E74AF98540F736113DFFAB">
         <title>List example: Reusing topic with conrefs</title>
         <codeblock> &lt;topic id="y">
- 	...
+ 	&lt;title>Sample file reusing content&lt;/title>
  	&lt;body>
  		&lt;ol>
  			&lt;li>My own first item&lt;/li>
@@ -99,7 +99,7 @@
       <fig id="fig_A79BE8A6869B4DFDAAFA2F55BC113AA1">
         <title>List example: Processed result of reusing topic</title>
         <codeblock> &lt;topic id="y">
- 	...
+ 	&lt;title>Sample file reusing content&lt;/title>
  	&lt;body>
  		&lt;ol>
  			&lt;li>My own first item&lt;/li>
@@ -118,7 +118,7 @@
       <fig id="fig_7BB281DFE28F474BB9197BAE691B927C">
         <title>Block level example: Source <filepath>topic.dita</filepath> with ids</title>
         <codeblock>&lt;topic id="x">
- 	...
+ 	&lt;title>Sample file topic.dita&lt;/title>
  	&lt;body&gt;
    &lt;p id="p1"&gt;First para&lt;/p&gt;
  	 &lt;ol id="mylist"&gt;
@@ -136,7 +136,7 @@
       <fig id="fig_BF890E35527C41FBA93878660EFC1636">
         <title>Block level example: Reusing topic with conrefs</title>
         <codeblock> &lt;topic id="y"&gt;
- 	...
+ 	&lt;title>Sample file reusing content&lt;/title>
  	&lt;body&gt;
  		&lt;p conref="topic.dita#x/p1" conrefend="topic.dita#x/p2"/&gt;
  	&lt;/body&gt;
@@ -145,7 +145,7 @@
       <fig id="fig_D257C3B1EE2B49DA85457B1753A8C79D">
         <title>Block level example: Processed result of reusing topic</title>
         <codeblock> &lt;topic id="y"&gt;
- 	...
+ 	&lt;title>Sample file reusing content&lt;/title>
  	&lt;body&gt;
     &lt;p&gt;First para&lt;/p&gt;
  	  &lt;ol id="mylist"&gt;

--- a/specification/langRef/base/body.dita
+++ b/specification/langRef/base/body.dita
@@ -7,7 +7,7 @@
     <section conkeyref="reuse-body/attributes" id="attributes"/>
 <example id="example" otherprops="examples"><title>Example</title>
       
-      <p>The following code sample shows a DITA topic that contains a title and a body.</p><codeblock>&lt;topic&gt;
+      <p>The following code sample shows a DITA topic that contains a title and a body.</p><codeblock>&lt;topic id="styleguidebold"&gt;
   &lt;title&gt;Mycompany Style Guide: the &lt;xmlelement&gt;b&lt;/xmlelement&gt; element&lt;/title&gt;
   <b>&lt;body&gt;</b>&lt;p&gt;Use the bold tag &lt;b&gt;for visual emphasis only&lt;/b&gt;; do not use it if another 
 phrase-level element better signifies the reason for the emphasis.&lt;/p&gt;<b>&lt;/body&gt;</b>

--- a/specification/langRef/base/div.dita
+++ b/specification/langRef/base/div.dita
@@ -38,7 +38,7 @@
         <title>Using <xmlelement>div</xmlelement> for specialization</title>
         <p>In the following example, <xmlelement>div</xmlelement> is used as the basis for
           specializing a new domain element, <xmlelement>pullquote</xmlelement>:</p>
-        <codeblock>&lt;!ENTITY % pullquote.content
+        <codeblock base="ci-skip">&lt;!ENTITY % pullquote.content
   "(%div.cnt;)*"
 >
 &lt;!ENTITY % pullquote.attributes
@@ -50,7 +50,7 @@
 &lt;!ATTLIST pullquote      class CDATA "+ topic/div pubcontent-d/pullquote "></codeblock>
         <p>Instances of <xmlelement>pullquote</xmlelement> could then be used in both
             <xmlelement>body</xmlelement> and <xmlelement>section</xmlelement> contexts:</p>
-        <codeblock>&lt;topic id="article-01">
+        <codeblock base="ci-xml">&lt;topic id="article-01">
   &lt;title>My Article&lt;/title>
   &lt;body>
     &lt;p>Something pithy someone said&lt;/p>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -47,8 +47,7 @@
           <xmlelement>draft-comment</xmlelement> element to pose a question to reviewers.</p>
       <codeblock>&lt;draft-comment 
   <b>author="EBP"</b> 
-  <b>time="23 May 2017"</b> 
-  status="missing-info"&gt;
+  <b>time="23 May 2017"</b>&gt;
 Where's the usage information for this section?
 &lt;/draft-comment&gt;</codeblock>
       <p>Processors might render the information from the highlighted attributes at viewing or

--- a/specification/langRef/base/keydef.dita
+++ b/specification/langRef/base/keydef.dita
@@ -33,7 +33,7 @@
   &lt;keydef keys="dita-tc" scope="external" format="html"
           href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita">
     &lt;topicmeta>
-      &lt;linktext>DITA Technical Committee&lt;/linktext>
+      &lt;keytext>DITA Technical Committee&lt;/keytext>
     &lt;/topicmeta>
   &lt;/keydef>
   &lt;!-- Key definition #2-->
@@ -41,7 +41,7 @@
   &lt;!-- Key definition #3-->
   &lt;keydef keys="dita-version">
     &lt;topicmeta>
-      &lt;linktext>2.0&lt;/linktext>
+      &lt;keytext>2.0&lt;/keytext>
     &lt;/topicmeta>
   &lt;/keydef>
 &lt;/map></codeblock>

--- a/specification/langRef/base/keytext.dita
+++ b/specification/langRef/base/keytext.dita
@@ -93,7 +93,7 @@
   &lt;topicmeta>
     &lt;keytext>Acme Tools&lt;/keytext>
     &lt;navtitle>Acme Tools web site&lt;/navtitle>
-    &lt;linktext>Acme Tools Web Portal&lt;/linktext>
+    &lt;linktitle>Acme Tools Web Portal&lt;/linktitle>
   &lt;/topicmeta>
 &lt;/keydef></codeblock>
                 <p>Once processed, the effective text content of both <codeph>&lt;ph

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -66,13 +66,13 @@
             <filepath>map-group-elements.ditamap)</filepath>:</p>
         <codeblock>&lt;map>
  &lt;title>Base elements&lt;/title>
- ...
+ &lt;!-- ... -->
  &lt;topicref href="containers/domain-elements.dita" >
-  ...
+  &lt;!-- ... -->
   <b>&lt;mapref href="map-group-elements.ditamap"/></b>
-  ...
+  &lt;!-- ... -->
  &lt;/topicref>
- ...
+ &lt;!-- ... -->
 &lt;/map></codeblock>
       </fig>
       <fig>
@@ -96,9 +96,9 @@
           references that originally were located in the submap:</p>
 <codeblock>&lt;map>
  &lt;title>Base elements&lt;/title>
- ...
+ &lt;!-- ... -->
  &lt;topicref href="containers/domain-elements.dita" >
-  ...
+  &lt;!-- ... -->
   <b>&lt;topicref keyref="mapgroup-d" >
     &lt;topicref keyref="anchorref" />
     &lt;topicref keyref="keydef" />
@@ -106,9 +106,9 @@
     &lt;topicref keyref="topicgroup" />
     &lt;topicref keyref="topichead" />
   &lt;/topicref></b>
-  ...
+  &lt;!-- ... -->
  &lt;/topicref>
- ...
+ &lt;!-- ... -->
 &lt;/map></codeblock>
 </fig></example>
 </refbody>

--- a/specification/langRef/base/messagepanel.dita
+++ b/specification/langRef/base/messagepanel.dita
@@ -44,7 +44,7 @@ hazard.</shortdesc>
         &lt;/ul>
       &lt;/howtoavoid>
     <b>&lt;/messagepanel></b>
-    ...
+    &lt;!-- ... -->
     <b>&lt;messagepanel></b>
       &lt;typeofhazard>
         &lt;hazardsymbol keyref="hazard-hotsurface"/>

--- a/specification/langRef/base/navref.dita
+++ b/specification/langRef/base/navref.dita
@@ -47,7 +47,8 @@
       </dl>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>In the following code sample, the map titled "MyComponent tasks" references the maps
-          <filepath>othermap2.ditamap</filepath> and <filepath>othermap3.ditamap</filepath>.</p><codeblock>&lt;map title="MyComponent tasks"&gt;
+          <filepath>othermap2.ditamap</filepath> and <filepath>othermap3.ditamap</filepath>.</p><codeblock>&lt;map&gt;
+ &lt;title>MyComponent tasks&lt;/title>
  &lt;navref mapref="../com.example.plugin.xml.doc/othermap1.ditamap"/&gt;
  &lt;navref mapref="../com.example.plugin.xml.doc/othermap2.ditamap"/&gt;
 &lt;/map&gt;</codeblock></example>

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -152,7 +152,8 @@
       <title>Example</title>
       <p>In the following example, user-assistance context hooks are applied to three topics that
         are referenced from a DITA map. The second topic has two hooks for the same topic.</p>
-      <codeblock>&lt;map title="Widget Help">
+      <codeblock>&lt;map>
+ &lt;title>Widget Help&lt;/title>
  &lt;topicref href="file_ops.dita" type="concept">
    &lt;topicref href="saving.dita" type="task">
      &lt;topicmeta>

--- a/specification/langRef/base/unknown.dita
+++ b/specification/langRef/base/unknown.dita
@@ -25,7 +25,7 @@
       <p>By definition, the content of <xmlelement>unknown</xmlelement> can only be understood by
         DITA processors as unknown XML. This means that processors would generally ignore this
         content unless they are configured to recognize the <xmlelement>my-unknown</xmlelement>
-        specialization.</p><codeblock>&lt;body>
+        specialization.</p><codeblock base="ci-xml">&lt;body>
   &lt;my-unknown class="+ topic/unknown mything/my-unknown ">
     &lt;thing value="4"/>
     &lt;otherthing value="16"/>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -120,7 +120,8 @@
         <p>The following code sample shows how a window with a name of "help" is defined in the map.
           The window name is later referenced by the <xmlatt>ux-windowref</xmlatt> attribute on the
             <xmlelement>resourceid</xmlelement> element.</p>
-        <codeblock>&lt;map title="Widget Help">
+        <codeblock>&lt;map>
+ &lt;title>Widget Help&lt;/title>
  &lt;topicmeta>
   <b>&lt;ux-window id="fg23" name="help" top="10" left="20" height="400" width="500" 
      features="status=yes,toolbar=no,menubar=no,location=no" relative="yes"
@@ -144,7 +145,8 @@
         <title>Using multiple <xmlelement>ux-window</xmlelement> definitions</title>
         <p>The following code sample shows different window specifications for tablet and display
           presentation.</p>
-        <codeblock>&lt;map title="Puggles Help"&gt;
+        <codeblock>&lt;map&gt;
+ &lt;title>Puggles Help&lt;/title>
  &lt;topicmeta>
  <b>&lt;ux-window id="p76" name="ux-tablet" top="1cm" left="1cm" height="4cm" width="3cm" 
     features="status=no,toolbar=no,menubar=no,location=no" relative="no"


### PR DESCRIPTION
4 topics still used the title attribute on a map in their examples