### PR TITLE
Edited example about using <keyword> to store variable text

### DIFF
--- a/specification/langRef/base/keyword.dita
+++ b/specification/langRef/base/keyword.dita
@@ -30,11 +30,14 @@
             be used.</p>
          <fig>
             <title><xmlelement>keyword</xmlelement> element used to store a product name</title>
-            <p>In the following code sample, the <xmlelement>keyword</xmlelement> element holds a
-               product name.</p>
+            <p>In the following code sample, the
+            <xmlelement>keyword</xmlelement> element holds a product name
+          that can be referenced using content reference (conref) or
+          content key reference (conkeyref):</p>
             <codeblock>&lt;keyword id="acme-bird-feeder">ACME Bird Feeder&lt;/keyword></codeblock>
-            <p>The product name can be referenced using one of the DITA reuse mechanisms: content
-               reference (conref), content key reference (conkeyref), or key reference (keyref).</p>
+        <p>To enable referencing variable text using
+          <xmlatt>keyref</xmlatt>, store the product name in a
+            <xmlelement>keytext</xmlelement> element.</p>
          </fig>
          <fig>
             <title><xmlelement>keyword</xmlelement> element as metadata</title>


### PR DESCRIPTION
 * Removed references to using keyword to store variable text intended to be referenced by keyref
 * Added paragraph stating to use keytext for storing variable text intended to be referenced using keys