### PR TITLE
#397 making title-role required

### DIFF
--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -668,7 +668,7 @@
 <!ENTITY % titlealt.attributes
               "title-role
                           CDATA
-                                    #IMPLIED
+                                    #REQUIRED
                %univ-atts;"
 >
 <!ELEMENT  titlealt %titlealt.content;>

--- a/doctypes/rng/base/alternativeTitlesDomain.rng
+++ b/doctypes/rng/base/alternativeTitlesDomain.rng
@@ -97,9 +97,7 @@
                 </zeroOrMore>
             </define>
             <define name="navtitle.attributes">
-                <optional>
-                    <attribute name="title-role" a:defaultValue="navigation"/>
-                </optional>
+                <attribute name="title-role" a:defaultValue="navigation"/>
                 <ref name="univ-atts"/>
             </define>
             <define name="navtitle.element"> 
@@ -127,9 +125,7 @@
                 </zeroOrMore>
             </define>
             <define name="searchtitle.attributes">
-                <optional>
-                    <attribute name="title-role" a:defaultValue="search"/>
-                </optional>
+                <attribute name="title-role" a:defaultValue="search"/>
                 <ref name="univ-atts"/>
             </define>
             <define name="searchtitle.element">
@@ -158,9 +154,7 @@
                 </zeroOrMore>
             </define>
             <define name="linktitle.attributes">
-                <optional>
-                    <attribute name="title-role" a:defaultValue="linking"/>
-                </optional>
+                <attribute name="title-role" a:defaultValue="linking"/>
                 <ref name="univ-atts"/>
             </define>
             <define name="linktitle.element">
@@ -189,9 +183,7 @@
                 </zeroOrMore>
             </define>
             <define name="subtitle.attributes">
-                <optional>
-                    <attribute name="title-role" a:defaultValue="subtitle"/>
-                </optional>
+                <attribute name="title-role" a:defaultValue="subtitle"/>
                 <ref name="univ-atts"/>
             </define>
             <define name="subtitle.element">
@@ -220,9 +212,7 @@
                 </zeroOrMore>
             </define>
             <define name="titlehint.attributes">
-                <optional>
-                    <attribute name="title-role" a:defaultValue="hint"/>
-                </optional>
+                <attribute name="title-role" a:defaultValue="hint"/>
                 <ref name="univ-atts"/>
             </define>
             <define name="titlehint.element">

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -664,7 +664,8 @@
             authors. </dd>
         </dlentry>
         <dlentry>
-          <dt id="attr-title-role"><xmlatt>title-role</xmlatt></dt>
+          <dt id="attr-title-role"><xmlatt>title-role</xmlatt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the role or roles fulfilled by the alternative title. Multiple roles are
             separated by white space. Applications can define roles; the following roles are defined
             in the specification: <keyword>linking</keyword>, <keyword>navigation</keyword>,


### PR DESCRIPTION
Per discussion at last week's TC meeting, cleanup item in the grammar files, make `title-role` required. The spec text already describes it as mandatory.