### PR TITLE
Editing for RFC MUST that cannot be validated

### DIFF
--- a/specification/archSpec/base/conref-processing.dita
+++ b/specification/archSpec/base/conref-processing.dita
@@ -30,11 +30,7 @@
         outputclass="RFC-2119">SHOULD</term> tolerate specializations of valid elements. Processors
         <term outputclass="RFC-2119">MAY</term> generalize elements in the pushed or pulled content
       fragment as needed for the resolving context.</p>
-    <draft-comment author="robander">Without @domains, without constraints, and without a built-in
-      knowledge of every document type, it is not be possible to determine every case that could be
-      rendered invalid. As such, should we change the following MUST NOT to SHOULD
-      NOT?</draft-comment>
-  <p>A conref processor <term outputclass="RFC-2119">MUST NOT</term> permit resolution of a reuse
+  <p>A conref processor <term outputclass="RFC-2119">SHOULD NOT</term> permit resolution of a reuse
       relationship that could be rendered invalid under the rules of either the reused or reusing
       content.</p>
  </conbody>


### PR DESCRIPTION
As noted in the draft comment being deleted, the spec currently says processors MUST NOT allow something they cannot always validate. By definition, this cannot be MUST; changing to SHOULD NOT.