### PR TITLE
Ensure reuse of height and width definitions

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -123,13 +123,14 @@
                                 referenced.</ph></p><p>Required attribute token: <ph
                                         id="required-attr">(REQUIRED)</ph></p><p>Deprecated
                                 attribute token: <ph id="deprecated-attr"
-                                        >(DEPRECATED)</ph></p><p><ph id="height-width-units">The
-                                        value of this attribute is a real number (expressed in
-                                        decimal notation) optionally followed by a unit of measure
-                                        from the set of pc, pt, px, in, cm, mm, em (picas, points,
-                                        pixels, inches, centimeters, millimeters, and ems
-                                        respectively). The default unit is px (pixels). Possible
-                                        values include: "5", "5in", and "10.5cm".</ph></p><p><ph
+                                        >(DEPRECATED)</ph></p><p><ph id="height-width-units" rev="review-c">The value of this attribute
+          is a real number expressed in decimal notation, optionally
+          followed by a unit of measure. The following units of measurement
+          are supported: cm, em, in, mm, pc, pt, and px (centimeters, ems,
+          inches, millimeters, picas, points, and pixels, respectively).
+          The default unit is px (pixels). Possible values
+            include:<keyword>5</keyword>, <keyword>5in</keyword>, and
+            <keyword>10.5cm</keyword>.</ph></p><p><ph
                                         id="height-width-warning">If both a height value and width
                                         value are specified, implementations <term
                                                 outputclass="RFC-2119">MAY</term> ignore one of the
@@ -305,17 +306,17 @@
                                 </dlentry>
                                 <dlentry id="image-height">
                                         <dt id="attr-height"><xmlatt>height</xmlatt></dt>
-                                        <dd>Specifies the vertical dimension for the resulting display.<!-- If necessary, the image <term outputclass="RFC-2119">SHOULD</term> be scaled to the specified size.-->
-                                                <ph conref="#conref-attribute/height-width-units"/>
-                                                <!--If a height value is specified and no width value is specified, the width <term outputclass="RFC-2119">SHOULD</term> be scaled by the same factor as the height. --><!--<ph conref="#conref-attribute/height-width-warning"/>--></dd>
+                                        <dd>Specifies the vertical
+            dimension for the resulting display. <ph
+              conref="#conref-attribute/height-width-units"/>
+          </dd>
                                 </dlentry>
                                 <dlentry id="image-width">
                                         <dt id="attr-width"><xmlatt>width</xmlatt></dt>
-                                        <dd>Specifies the horizontal dimension for the resulting
-                                                display.
-                                                  <!--If necessary, the image <term outputclass="RFC-2119">SHOULD</term> be scaled to the specified size. --><ph
-                                                  conref="#conref-attribute/height-width-units"/>
-                                                <!--If a width value is specified and no height value is specified, the height <term outputclass="RFC-2119">SHOULD</term> be scaled by the same factor as the width. <ph conref="#conref-attribute/height-width-warning"/>--></dd>
+                                        <dd>Specifies the horizontal
+            dimension for the resulting display. <ph
+              conref="#conref-attribute/height-width-units"/>
+          </dd>
                                 </dlentry>
                                 <dlentry id="image-align">
                                         <dt id="attr-align"><xmlatt>align</xmlatt></dt>

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -12,17 +12,26 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-href"/>, <xref
-          keyref="attributes-common/attr-format"/>, <xref keyref="attributes-common/attr-scope"/>,
-          <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
-        defined below.</p>
-      <p platform="lwdita"><draft-comment author="robander">href, format, and scope were moved from
-          the DL (marked for both lwdita and dita) into the paragraph above for full DITA; not sure
-          if they apply to lwdita, if so, the three should be listed here as
-        well.</draft-comment>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
-          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>.</p>
+      <p platform="dita">The following attributes are available on this
+        element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
+          <xref keyref="attributes-common/attr-href"/>, <xref
+          keyref="attributes-common/attr-format"/>, <xref
+          keyref="attributes-common/attr-scope"/>, <xref
+          keyref="attributes-common/attr-keyref"
+          ><xmlatt>keyref</xmlatt></xref>, and the attributes defined
+        below.</p>
+      <p platform="lwdita"><draft-comment author="robander">href, format,
+          and scope were moved from the DL (marked for both lwdita and
+          dita) into the paragraph above for full DITA; not sure if they
+          apply to lwdita, if so, the three should be listed here as
+          well.</draft-comment>The following attributes are available on
+        this element: <ph conkeyref="reuse-attributes/ref-localizationatts"
+        />, <xref keyref="attributes-universal/class"
+            ><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"
+          ><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-universal/outputclass"
+            ><xmlatt>outputclass</xmlatt></xref>.</p>
       <dl>
         <dlentry platform="dita">
           <dt id="attr-align"><xmlatt>align</xmlatt></dt>
@@ -30,14 +39,9 @@
             specified as <keyword>break</keyword>. Common values include <keyword>left</keyword>,
               <keyword>right</keyword>, and <keyword>center</keyword>.</dd>
         </dlentry>
-        <dlentry>
-          <dt id="attr-height"><xmlatt>height</xmlatt></dt>
-          <dd>Indicates the vertical dimension for the resulting display. The value of this
-            attribute is a real number (expressed in decimal notation) optionally followed by a unit
-            of measure from the set of pc, pt, px, in, cm, mm, em (picas, points, pixels, inches,
-            centimeters, millimeters, and ems respectively). The default unit is px (pixels).
-            Example values include <keyword>5</keyword>, <keyword>5in</keyword>, and
-              <keyword>10.5cm</keyword>. </dd>
+        <dlentry conkeyref="reuse-attributes/image-height" id="height">
+          <dt/>
+          <dd/>
         </dlentry>
         <dlentry platform="dita">
           <dt id="attr-placement"><xmlatt>placement</xmlatt></dt>
@@ -86,14 +90,9 @@
               reasonable value. </p>
           </dd>
         </dlentry>
-        <dlentry>
-          <dt id="attr-width"><xmlatt>width</xmlatt></dt>
-          <dd>Indicates the horizontal dimension for the resulting display. The value of this
-            attribute is a real number (expressed in decimal notation) optionally followed by a unit
-            of measure from the set of pc, pt, px, in, cm, mm, em (picas, points, pixels, inches,
-            centimeters, millimeters, and ems respectively). The default unit is px (pixels).
-            Example values include <keyword>5</keyword>, <keyword>5in</keyword>, and
-              <keyword>10.5cm</keyword>.</dd>
+        <dlentry conkeyref="reuse-attributes/image-width" id="width">
+          <dt/>
+          <dd/>
         </dlentry>
       </dl>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-video.dita
+++ b/specification/common/reuse-w-lwdita/reuse-video.dita
@@ -91,12 +91,9 @@
         <dlentry>
           <dt id="attr-height"><xmlatt>height</xmlatt></dt>
           <dd>Indicates the vertical dimension for the resulting display.
-            The value of this attribute is a real number (expressed in
-            decimal notation) optionally followed by a unit of measure from
-            the set of cm, em, in, mm, pc, pt, px, and Q (centimeters, ems,
-            inches, millimeters, picas, points, pixels, and
-            quarter-millimeters, respectively). The default unit is px
-            (pixels). Possible values include "5", "5in", and "10.5cm". </dd>
+              <ph
+              conref="../conref-attribute.dita#conref-attribute/height-width-units"
+            /></dd>
         </dlentry>
         <dlentry platform="dita">
           <!--KJE: RDA and I discussed this on 29 April 2019. We could not come up with a phrasing that would not include "should". Adding this comment so that we don't have the discussion again.-->
@@ -154,11 +151,10 @@
         </dlentry>
         <dlentry>
           <dt id="attr-width"><xmlatt>width</xmlatt></dt>
-          <dd>Indicates the horizontal dimension for the resulting display. The value of this
-            attribute is a real number (expressed in decimal notation) optionally followed by a unit
-            of measure from the set of cm, em, in, mm, pc, pt, px, and Q (centimeters, ems, inches,
-            picas, points, pixels, millimeters, and quarter-millimeters, respectively). The default
-            unit is px (pixels). Possible values include: "5", "5in", and "10.5cm". </dd>
+          <dd>Indicates the horizontal dimension for the resulting display.
+              <ph
+              conref="../conref-attribute.dita#conref-attribute/height-width-units"
+            /></dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -59,19 +59,15 @@
         </dlentry>
         <dlentry>
           <dt id="uxatt-height"><xmlatt>height</xmlatt></dt>
-          <dd>Specifies the height of the window. The value of this
-            attribute is a real number optionally followed by a unit of
-            measure from the set of pc, pt, px, in, cm, mm, em (picas,
-            points, pixels, inches, centimeters, millimeters, and ems
-            respectively). The default unit is px (pixels).</dd>
+          <dd>Specifies the height of the window. <ph
+              conref="../../common/conref-attribute.dita#conref-attribute/height-width-units"
+            /></dd>
         </dlentry>
         <dlentry>
           <dt id="uxatt-width"><xmlatt>width</xmlatt></dt>
-          <dd>Specifies the width of the window. The value of this
-            attribute is a real number optionally followed by a unit of
-            measure from the set of pc, pt, px, in, cm, mm, em (picas,
-            points, pixels, inches, centimeters, millimeters, and ems
-            respectively). The default unit is px (pixels).</dd>
+          <dd>Specifies the width of the window. <ph
+              conref="../../common/conref-attribute.dita#conref-attribute/height-width-units"
+            /></dd>
         </dlentry>
         <dlentry>
           <dt id="uxatt-on-top"><xmlatt>on-top</xmlatt></dt>


### PR DESCRIPTION
 Add conrefs to <dlentry> and <ph> defined in reuse files