### PR TITLE
Initial edits of prolog elements

### DIFF
--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -2,8 +2,8 @@
 <!DOCTYPE reference  PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="audience" xml:lang="en-us">
   <title><xmlelement>audience</xmlelement></title>
-  <shortdesc>An <xmlelement>audience</xmlelement> element specifies an audience for a
-    topic.</shortdesc>
+  <shortdesc>An audience is the group of readers for whom a piece of
+    content is intended.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -13,13 +13,15 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>A topic can indicate multiple audiences by including multiple
-          <xmlelement>audience</xmlelement> elements. For each audience specified, the high-level
-        task they are trying to accomplish can be identified with the <xmlatt>job</xmlatt>
-        attribute, and the level of experience expected can be specified with the
-          <xmlatt>experiencelevel</xmlatt> attribute. The <xmlelement>audience</xmlelement> element
-        can be used to provide a more detailed definition of values used throughout the map or topic
-        on the <xmlatt>audience</xmlatt> attribute.</p>
+      <!--<p>A topic can indicate multiple audiences by including multiple <xmlelement>audience</xmlelement> elements. For each audience specified, the high-level task they are trying to accomplish can be identified with the <xmlatt>job</xmlatt> attribute, and the level of experience expected can be specified with the <xmlatt>experiencelevel</xmlatt> attribute. </p>-->
+      <draft-comment author="Kristen J Eberlein" time="27 December 2021">
+        <p>Do we really want to state this? I've never seen this used, and
+          it seems like residue of what folks thought was on the horizon
+          15+ years ago.</p>
+      </draft-comment>
+      <p>The <xmlelement>audience</xmlelement> element can be used to
+        provide a more detailed definition of values used throughout the
+        map or topic on the <xmlatt>audience</xmlatt> attribute.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
@@ -27,45 +29,42 @@
       <dl>
         <dlentry id="type">
           <dt id="attr-type"><xmlatt>type</xmlatt></dt>
-          <dd>Specifies the type of audience for whom the content of the topic is intended. <ph
-              conkeyref="reuse-attributes/nonstandard-type"/>
-            <ph otherprops="examples">For example, possible values enumerated in earlier versions of
-              DITA included <keyword>user</keyword>, <keyword>purchaser</keyword>,
-                <keyword>administrator</keyword>, <keyword>programmer</keyword>,
-                <keyword>executive</keyword>, and <keyword>services</keyword>.</ph></dd>
+          <dd>Specifies the type of audience for whom the content is
+            intended. <ph conkeyref="reuse-attributes/nonstandard-type"/>
+          </dd>
         </dlentry>
         <dlentry id="job">
           <dt id="attr-job"><xmlatt>job</xmlatt></dt>
-          <dd>Specifies the high-level task the audience for the topic is trying to accomplish.
-            Different audiences might read the same topic in terms of different high-level tasks;
-            for example, an administrator might read the topic while administering, while a
-            programmer might read the same topic while customizing. <ph otherprops="examples">For
-              example, possible values enumerated in earlier versions of DITA included
-                <keyword>installing</keyword>, <keyword>customizing</keyword>,
-                <keyword>administering</keyword>, <keyword> programming</keyword>, <keyword>
-                using</keyword>, <keyword>maintaining</keyword>, <keyword>troubleshooting</keyword>,
-                <keyword>evaluating</keyword>, <keyword>planning</keyword>, and
-                <keyword>migrating</keyword>.</ph></dd>
+          <dd>Specifies the high-level task that the audience for the
+            content is trying to accomplish. Different audiences might read
+            the same topic in terms of different high-level tasks; for
+            example, an administrator might read the topic while
+            administering, while a programmer might read the same topic
+            while customizing. </dd>
         </dlentry>
         <dlentry id="experiencelevel">
           <dt id="attr-experiencelevel"><xmlatt>experiencelevel</xmlatt></dt>
-          <dd>Indicates the level of experience the audience is assumed to possess. Different
-            audiences might have different experience levels with respect to the same topic; for
-            example, a topic might require general knowledge from a programmer, but expert knowledge
-            from a user. <ph otherprops="examples">For example, possible values enumerated in
-              earlier versions of DITA included <keyword>novice</keyword>,
-                <keyword>general</keyword>, and <keyword>expert</keyword>.</ph></dd>
+          <dd>Indicates the level of experience that the audience is
+            assumed to possess. Different audiences might have different
+            experience levels with respect to the same topic; for example,
+            a topic might require general knowledge from a programmer, but
+            expert knowledge from a user. </dd>
         </dlentry>
         <dlentry id="name">
           <dt id="attr-name"><xmlatt>name</xmlatt></dt>
-          <dd>Specifies a name for the audience, which can be used in <xmlatt>audience</xmlatt>
-            attributes.</dd>
+          <dd>Specifies a name for the audience, which can be used in the
+              <xmlatt>audience</xmlatt> attribute.</dd>
         </dlentry>
       </dl>
     </section><example id="example" otherprops="examples">
       <title>Example</title>
-      <p>When used in a reference topic, the following code sample declares that the topic is
-        intended for experienced programmers.</p>
-      <codeblock>&lt;audience type="programmer" job="programming" experiencelevel="expert"/&gt;</codeblock>
+      <p>The following code sample shows how the
+          <xmlelement>audience</xmlelement> element can specify that a
+        topic is intended for experienced programmers:</p>
+      <codeblock>&lt;prolog>
+    &lt;metadata>
+        &lt;audience type="programmer" experiencelevel="expert"/&gt;
+    &lt;/metadata>
+&lt;/prolog></codeblock>
     </example></refbody>
 </reference>

--- a/specification/langRef/base/metadata.dita
+++ b/specification/langRef/base/metadata.dita
@@ -4,8 +4,8 @@
  "reference.dtd">
 <reference id="metadata" xml:lang="en-us">
 <title><xmlelement>metadata</xmlelement></title>
-  <shortdesc>A <xmlelement>metadata</xmlelement> section is a contaner that groups metadata such as
-    a topic's audience and key
+  <shortdesc>A <xmlelement>metadata</xmlelement> element is a container
+    that groups metadata such as audience and key
     words.<!-- Metadata can be used by computational processes to select particular topics or to prepare search indexes or to customize navigation.--></shortdesc>
 <prolog><metadata>
 <keywords>
@@ -15,29 +15,33 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>Elements inside of <xmlelement>metadata</xmlelement> provide information about the content
-        and subject of a topic. When used in topics, other metadata elements outside of the
-          <xmlelement>metadata</xmlelement> container generally provide lifecycle information for
-        the content unit (such as the author or copyright), which are unrelated to the subject.</p>
-      <p>When used in maps, several metadata elements are allowed both inside and outside of the
-          <xmlelement>metadata</xmlelement> container, with the container made available to provide
-        parity with topic prologs.</p>
+      <p>Elements inside of the <xmlelement>metadata</xmlelement> element
+        provide information about the content and subject of an information
+        resource.</p>
+      <p>When used in topics,  metadata elements that are outside of the
+          <xmlelement>metadata</xmlelement> element generally provide
+        lifecycle information (such as the author or copyright) for the
+        content unit.</p>
+      <p>When used in maps, several metadata elements are allowed both
+        inside and outside of the <xmlelement>metadata</xmlelement>
+        container element. This is done to provide parity with topic
+        prologs.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
       <p conkeyref="reuse-attributes/only-universal"/>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
-      <p>The following code sample shows that a topic about jet packs is only intended for advanced
-        users.</p><codeblock>&lt;prolog&gt;
-  <b>&lt;metadata&gt;</b>
-    &lt;audience type="user" job="flying" experiencelevel="advanced"/&gt;
-    &lt;keywords>
-      &lt;keyword>jet pack&lt;/keyword>
-      &lt;keyword>danger&lt;/keyword>
-      &lt;keyword>don't try this&lt;/keyword>
-    &lt;/keywords>
-  <b>&lt;/metadata&gt;</b>
+      <p>The following code sample shows how metadata can be provided in a
+        topic about jet packs:</p><codeblock>&lt;prolog&gt;
+    &lt;metadata&gt;
+        &lt;audience type="user" job="flying" experiencelevel="advanced"/&gt;
+        &lt;keywords>
+            &lt;keyword>jet pack&lt;/keyword>
+            &lt;keyword>danger&lt;/keyword>
+            &lt;keyword>liability&lt;/keyword>
+        &lt;/keywords>
+    &lt;/metadata&gt;
 &lt;/prolog&gt;</codeblock></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/test.dita
+++ b/specification/langRef/base/test.dita
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="test">
+    <title>Test</title>
+    <body><simpletable>
+  <sthead>
+    <stentry>Menu item</stentry>
+    <stentry>Price</stentry>
+  </sthead>
+  <strow>
+    <stentry>Apple pie</stentry>
+    <stentry>$7.00</stentry>
+  </strow>
+  <strow>
+    <stentry>Cheese sandwich</stentry>
+    <stentry>$10.00</stentry>
+  </strow>
+  <strow>
+    <stentry>Milk shake</stentry>
+    <stentry>$6.50</stentry>
+  </strow>
+</simpletable>
+    <table rowheader="firstcol">
+      <tgroup cols="2">
+        <colspec colname="c1" colnum="1" colwidth="1*"/>
+        <colspec colname="c2" colnum="2" colwidth="1*"/>
+        <thead>
+          <row>
+            <entry>Menu item</entry>
+            <entry>Price</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>Apple pie</entry>
+            <entry>$7.00</entry>
+          </row>
+          <row>
+            <entry>Cheese sandwich</entry>
+            <entry>$10.00</entry>
+          </row>
+          <row>
+            <entry>Milk shake</entry>
+            <entry>$6.50</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+      <table rowheader="firstcol">
+      <tgroup cols="2">
+        <thead>
+          <row>
+            <entry>Menu item</entry>
+            <entry>Price</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>Apple pie</entry>
+            <entry>$7.00</entry>
+          </row>
+          <row>
+            <entry>Cheese sandwich</entry>
+            <entry>$10.00</entry>
+          </row>
+          <row>
+            <entry>Milk shake</entry>
+            <entry>$6.50</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+    <codeblock>&lt;table rowheader="firstcol">
+    &lt;tgroup cols="2">
+        &lt;thead>
+            &lt;row>
+                &lt;entry>Menu item&lt;/entry>
+                &lt;entry>Price&lt;/entry>
+            &lt;/row>
+        &lt;/thead>
+        &lt;tbody>
+            &lt;row>
+                &lt;entry>Apple pie&lt;/entry>
+                &lt;entry>$7.00&lt;/entry>
+            &lt;/row>
+            &lt;row>
+                &lt;entry>Cheese sandwich&lt;/entry>
+                &lt;entry>$10.00&lt;/entry>
+            &lt;/row>
+            &lt;row>
+                &lt;entry>Milk shake&lt;/entry>
+                &lt;entry>$6.50&lt;/entry>
+            &lt;/row>
+        &lt;/tbody>
+    &lt;/tgroup>
+&lt;/table></codeblock></body>
+</topic>


### PR DESCRIPTION
 - Natural-language short descriptions
 - Implemented styleguide rules
 - Removed references to previous release of the DITA standard