### PR TITLE
Remove subjectRelTable, relatedSubjects

### DIFF
--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -47,12 +47,6 @@
                        "defaultSubject"                              >
 <!ENTITY % relatedSubjects
                        "relatedSubjects"                             >
-<!ENTITY % subjectRelTable
-                       "subjectRelTable"                             >
-<!ENTITY % subjectRelHeader
-                       "subjectRelHeader"                            >
-<!ENTITY % subjectRel  "subjectRel"                                  >
-<!ENTITY % subjectRole "subjectRole"                                 >
 
 <!-- ============================================================= -->
 <!--                    ELEMENT DECLARATIONS                       -->
@@ -119,7 +113,6 @@
                           %schemeref; |
                           %subjectdef; |
                           %subjectHead; |
-                          %subjectRelTable; |
                           %topicref;)*)"
 >
 <!ENTITY % subjectScheme.attributes
@@ -495,58 +488,6 @@
 <!ATTLIST  relatedSubjects %relatedSubjects.attributes;>
 
 
-<!--                    LONG NAME: Subject Relationship Table      -->
-<!ENTITY % subjectRelTable.content
-                       "((%title;)?,
-                         (%topicmeta;)?,
-                         (%subjectRelHeader;)?,
-                         (%subjectRel;)+)"
->
-<!ENTITY % subjectRelTable.attributes
-              "%topicref-atts-no-toc;
-               %univ-atts;"
->
-<!ELEMENT  subjectRelTable %subjectRelTable.content;>
-<!ATTLIST  subjectRelTable %subjectRelTable.attributes;>
-
-
-<!--                    LONG NAME: Subject Table Header            -->
-<!ENTITY % subjectRelHeader.content
-                       "(%subjectRole;)+"
->
-<!ENTITY % subjectRelHeader.attributes
-              "%univ-atts;"
->
-<!ELEMENT  subjectRelHeader %subjectRelHeader.content;>
-<!ATTLIST  subjectRelHeader %subjectRelHeader.attributes;>
-
-
-<!--                    LONG NAME: Subject Table Row               -->
-<!ENTITY % subjectRel.content
-                       "(%subjectRole;)+"
->
-<!ENTITY % subjectRel.attributes
-              "%univ-atts;"
->
-<!ELEMENT  subjectRel %subjectRel.content;>
-<!ATTLIST  subjectRel %subjectRel.attributes;>
-
-
-<!--                    LONG NAME: Subject Role                    -->
-<!ENTITY % subjectRole.content
-                       "(%data.elements.incl; |
-                         %subjectdef; |
-                         %topicref;)*"
->
-<!ENTITY % subjectRole.attributes
-              "%topicref-atts;
-               %univ-atts;"
->
-<!ELEMENT  subjectRole %subjectRole.content;>
-<!ATTLIST  subjectRole %subjectRole.attributes;>
-
-
-
 <!-- ============================================================= -->
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
@@ -561,10 +502,6 @@
 <!ATTLIST  subjectHeadMeta   class CDATA "- map/topicmeta subjectScheme/subjectHeadMeta ">
 <!ATTLIST  subjectdef     class CDATA "- map/topicref subjectScheme/subjectdef ">
 <!ATTLIST  relatedSubjects   class CDATA "- map/topicref subjectScheme/relatedSubjects ">
-<!ATTLIST  subjectRelTable   class CDATA "- map/reltable subjectScheme/subjectRelTable ">
-<!ATTLIST  subjectRelHeader   class CDATA "- map/relrow subjectScheme/subjectRelHeader ">
-<!ATTLIST  subjectRel     class CDATA "- map/relrow subjectScheme/subjectRel ">
-<!ATTLIST  subjectRole    class CDATA "- map/relcell subjectScheme/subjectRole ">
 
 <!-- ================== End of DITA Subject Scheme Map Type ==================== -->
  

--- a/doctypes/dtd/subjectScheme/subjectScheme.mod
+++ b/doctypes/dtd/subjectScheme/subjectScheme.mod
@@ -45,8 +45,6 @@
                        "attributedef"                                >
 <!ENTITY % defaultSubject
                        "defaultSubject"                              >
-<!ENTITY % relatedSubjects
-                       "relatedSubjects"                             >
 
 <!-- ============================================================= -->
 <!--                    ELEMENT DECLARATIONS                       -->
@@ -108,7 +106,6 @@
                          (%data.elements.incl; |
                           %enumerationdef; |
                           %navref; |
-                          %relatedSubjects; |
                           %reltable; |
                           %schemeref; |
                           %subjectdef; |
@@ -432,62 +429,6 @@
 <!ATTLIST  defaultSubject %defaultSubject.attributes;>
 
 
-<!--                    LONG NAME: Related Subjects                -->
-<!ENTITY % relatedSubjects.content
-                       "(%data.elements.incl; |
-                         %subjectdef; |
-                         %topicref;)*"
->
-<!ENTITY % relatedSubjects.attributes
-              "href
-                          CDATA
-                                    #IMPLIED
-               keyref
-                          CDATA
-                                    #IMPLIED
-               keys
-                          CDATA
-                                    #IMPLIED
-               collection-type
-                          (choice |
-                           family |
-                           sequence |
-                           unordered |
-                           -dita-use-conref-target)
-                                    'family'
-               processing-role
-                          (normal |
-                           resource-only |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               type
-                          CDATA
-                                    #IMPLIED
-               cascade
-                          CDATA
-                                    #IMPLIED
-               scope
-                          (external |
-                           local |
-                           peer |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               format
-                          CDATA
-                                    #IMPLIED
-               linking
-                          (none |
-                           normal |
-                           sourceonly |
-                           targetonly |
-                           -dita-use-conref-target)
-                                    'normal'
-               %univ-atts;"
->
-<!ELEMENT  relatedSubjects %relatedSubjects.content;>
-<!ATTLIST  relatedSubjects %relatedSubjects.attributes;>
-
-
 <!-- ============================================================= -->
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
@@ -501,7 +442,6 @@
 <!ATTLIST  subjectHead    class CDATA "- map/topicref subjectScheme/subjectHead ">
 <!ATTLIST  subjectHeadMeta   class CDATA "- map/topicmeta subjectScheme/subjectHeadMeta ">
 <!ATTLIST  subjectdef     class CDATA "- map/topicref subjectScheme/subjectdef ">
-<!ATTLIST  relatedSubjects   class CDATA "- map/topicref subjectScheme/relatedSubjects ">
 
 <!-- ================== End of DITA Subject Scheme Map Type ==================== -->
  

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -78,18 +78,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
     <define name="relatedSubjects">
       <ref name="relatedSubjects.element"/>
     </define>
-    <define name="subjectRelTable">
-      <ref name="subjectRelTable.element"/>
-    </define>
-    <define name="subjectRelHeader">
-      <ref name="subjectRelHeader.element"/>
-    </define>
-    <define name="subjectRel">
-      <ref name="subjectRel.element"/>
-    </define>
-    <define name="subjectRole">
-      <ref name="subjectRole.element"/>
-    </define>
   </div>
   <div>
     <a:documentation>COMMON ATTRIBUTE SETS</a:documentation>
@@ -189,7 +177,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
             <ref name="schemeref"/>
             <ref name="subjectdef"/>
             <ref name="subjectHead"/>
-            <ref name="subjectRelTable"/>
             <ref name="topicref"/>
           </choice>
         </zeroOrMore>
@@ -789,109 +776,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
 
     </div>
-    <div>
-      <a:documentation>LONG NAME: Subject Relationship Table</a:documentation>
-      <define name="subjectRelTable.content">
-        <optional>
-          <ref name="title"/>
-        </optional>
-        <optional>
-          <ref name="topicmeta"/>
-        </optional>
-        <optional>
-          <ref name="subjectRelHeader"/>
-        </optional>
-        <oneOrMore>
-          <ref name="subjectRel"/>
-        </oneOrMore>
-      </define>
-      <define name="subjectRelTable.attributes">
-        <ref name="topicref-atts-no-toc"/>
-        <ref name="univ-atts"/>
-      </define>
-      <define name="subjectRelTable.element">
-        <element name="subjectRelTable" dita:longName="Subject Relationship Table">
-          <a:documentation></a:documentation>
-          <ref name="subjectRelTable.attlist"/>
-          <ref name="subjectRelTable.content"/>
-        </element>
-      </define>
-      <define name="subjectRelTable.attlist" combine="interleave">
-        <ref name="subjectRelTable.attributes"/>
-      </define>
-
-    </div>
-    <div>
-      <a:documentation>LONG NAME: Subject Table Header</a:documentation>
-      <define name="subjectRelHeader.content">
-        <oneOrMore>
-          <ref name="subjectRole"/>
-        </oneOrMore>
-      </define>
-      <define name="subjectRelHeader.attributes">
-        <ref name="univ-atts"/>
-      </define>
-      <define name="subjectRelHeader.element">
-        <element name="subjectRelHeader" dita:longName="Subject Table Header">
-          <a:documentation></a:documentation>
-          <ref name="subjectRelHeader.attlist"/>
-          <ref name="subjectRelHeader.content"/>
-        </element>
-      </define>
-      <define name="subjectRelHeader.attlist" combine="interleave">
-        <ref name="subjectRelHeader.attributes"/>
-      </define>
-
-    </div>
-    <div>
-      <a:documentation>LONG NAME: Subject Table Row</a:documentation>
-      <define name="subjectRel.content">
-        <oneOrMore>
-          <ref name="subjectRole"/>
-        </oneOrMore>
-      </define>
-      <define name="subjectRel.attributes">
-        <ref name="univ-atts"/>
-      </define>
-      <define name="subjectRel.element">
-        <element name="subjectRel" dita:longName="Subject Table Row">
-          <a:documentation></a:documentation>
-          <ref name="subjectRel.attlist"/>
-          <ref name="subjectRel.content"/>
-        </element>
-      </define>
-      <define name="subjectRel.attlist" combine="interleave">
-        <ref name="subjectRel.attributes"/>
-      </define>
-
-    </div>
-    <div>
-      <a:documentation>LONG NAME: Subject Role</a:documentation>
-      <define name="subjectRole.content">
-        <zeroOrMore>
-          <choice>
-            <ref name="data.elements.incl"/>
-            <ref name="subjectdef"/>
-            <ref name="topicref"/>
-          </choice>
-        </zeroOrMore>
-      </define>
-      <define name="subjectRole.attributes">
-        <ref name="topicref-atts"/>
-        <ref name="univ-atts"/>
-      </define>
-      <define name="subjectRole.element">
-        <element name="subjectRole" dita:longName="Subject Role">
-          <a:documentation></a:documentation>
-          <ref name="subjectRole.attlist"/>
-          <ref name="subjectRole.content"/>
-        </element>
-      </define>
-      <define name="subjectRole.attlist" combine="interleave">
-        <ref name="subjectRole.attributes"/>
-      </define>
-
-    </div>
   </div>
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
@@ -944,26 +828,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
     <define name="relatedSubjects.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref subjectScheme/relatedSubjects "/>
-      </optional>
-    </define>
-    <define name="subjectRelTable.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/reltable subjectScheme/subjectRelTable "/>
-      </optional>
-    </define>
-    <define name="subjectRelHeader.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/relrow subjectScheme/subjectRelHeader "/>
-      </optional>
-    </define>
-    <define name="subjectRel.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/relrow subjectScheme/subjectRel "/>
-      </optional>
-    </define>
-    <define name="subjectRole.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/relcell subjectScheme/subjectRole "/>
       </optional>
     </define>
   </div>

--- a/doctypes/rng/subjectScheme/subjectSchemeMod.rng
+++ b/doctypes/rng/subjectScheme/subjectSchemeMod.rng
@@ -75,9 +75,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
     <define name="defaultSubject">
       <ref name="defaultSubject.element"/>
     </define>
-    <define name="relatedSubjects">
-      <ref name="relatedSubjects.element"/>
-    </define>
   </div>
   <div>
     <a:documentation>COMMON ATTRIBUTE SETS</a:documentation>
@@ -172,7 +169,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
             <ref name="data.elements.incl"/>
             <ref name="enumerationdef"/>
             <ref name="navref"/>
-            <ref name="relatedSubjects"/>
             <ref name="reltable"/>
             <ref name="schemeref"/>
             <ref name="subjectdef"/>
@@ -691,91 +687,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
       </define>
 
     </div>
-    <div>
-      <a:documentation>LONG NAME: Related Subjects</a:documentation>
-      <define name="relatedSubjects.content">
-        <zeroOrMore>
-          <choice>
-            <ref name="data.elements.incl"/>
-            <ref name="subjectdef"/>
-            <ref name="topicref"/>
-          </choice>
-        </zeroOrMore>
-      </define>
-      <define name="relatedSubjects.attributes">
-        <optional>
-          <attribute name="href"/>
-        </optional>
-        <optional>
-          <attribute name="keyref"/>
-        </optional>
-        <optional>
-          <attribute name="keys"/>
-        </optional>
-        <optional>
-          <attribute name="collection-type" a:defaultValue="family">
-            <choice>
-              <value>choice</value>
-              <value>family</value>
-              <value>sequence</value>
-              <value>unordered</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
-          <attribute name="processing-role">
-            <choice>
-              <value>normal</value>
-              <value>resource-only</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
-          <attribute name="type"/>
-        </optional>
-        <optional>
-          <attribute name="cascade"/>
-        </optional>
-        <optional>
-          <attribute name="scope">
-            <choice>
-              <value>external</value>
-              <value>local</value>
-              <value>peer</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
-          <attribute name="format"/>
-        </optional>
-        <optional>
-          <attribute name="linking" a:defaultValue="normal">
-            <choice>
-              <value>none</value>
-              <value>normal</value>
-              <value>sourceonly</value>
-              <value>targetonly</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <ref name="univ-atts"/>
-      </define>
-      <define name="relatedSubjects.element">
-        <element name="relatedSubjects" dita:longName="Related Subjects">
-          <a:documentation></a:documentation>
-          <ref name="relatedSubjects.attlist"/>
-          <ref name="relatedSubjects.content"/>
-        </element>
-      </define>
-      <define name="relatedSubjects.attlist" combine="interleave">
-        <ref name="relatedSubjects.attributes"/>
-      </define>
-
-    </div>
   </div>
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
@@ -823,11 +734,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Scheme Map//EN"
     <define name="subjectdef.attlist" combine="interleave">
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref subjectScheme/subjectdef "/>
-      </optional>
-    </define>
-    <define name="relatedSubjects.attlist" combine="interleave">
-      <optional>
-        <attribute name="class" a:defaultValue="- map/topicref subjectScheme/relatedSubjects "/>
       </optional>
     </define>
   </div>


### PR DESCRIPTION
Continuing the work from https://github.com/oasis-tcs/dita/issues/397

* Remove subjectRelTable (commit was not pushed before that PR merged)
* remove relatedSubjects (was in the proposal to remove has* elements but missed originally in the implementation)