### PR TITLE
Fix typo in subjectHead example

### DIFF
--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -51,9 +51,8 @@
     </section>
     <example id="example" rev="review-d">
       <title>Example</title>
-      <p>In the following code sample, the
-          <xmlelement>subjectHead</xmlelement> elements define two
-        groupings of subjects and associates labels.</p>
+      <p>In the following code sample, the <xmlelement>subjectHead</xmlelement> elements define two
+        groupings of subjects and associate labels.</p>
       <codeblock>&lt;subjectScheme toc="yes" search="no">
   &lt;subjectdef keys="hobbies">
     &lt;subjectdef keys="fiber-arts">


### PR DESCRIPTION
Fixing a typo, "associate" => "associates" for the two subjectHead elements.