### PR TITLE
Cleaning up examples to ensure validity

### DIFF
--- a/admin/element-reference-guidelines.dita
+++ b/admin/element-reference-guidelines.dita
@@ -121,8 +121,11 @@
         relevant elements in the code sample might be highlighted (bold) to
         draw the readers attention. Code samples should be indented four
         spaces.</p>
-      <p>If content is "snipped" from the code sample, it should be
-        indicated with <codeph>&lt;!-- ... --></codeph>.</p>
+      <p>If content is "snipped" from the code sample, it should be indicated with <codeph>&lt;!--
+          ... --></codeph>. All code samples that use real DITA need to validate. If a code sample
+        includes non-DITA XML, add <codeph>base="ci-xml"</codeph> to ensure our CI testing validates
+        it as XML (but not as DITA). If a code sample includes non-XML, add
+          <codeph>base="ci-skip"</codeph> to have the CI testing skip that code block.</p>
       <div rev="review-c">
         <p>If the "Example" section points to another topic, instead of
           containing its own example, be sure and hyperlink directly to the

--- a/specification/archSpec/base/alternative-titles.dita
+++ b/specification/archSpec/base/alternative-titles.dita
@@ -17,7 +17,7 @@
         respectively, so that authors do not have to specify those roles
         explicitly. Content containing these specializations could look
         like the following.</p>
-      <codeblock>&lt;helpTopic id="topic167">
+      <codeblock base="ci-xml">&lt;helpTopic id="topic167">
   &lt;title>Doing the Thing in the Place where the Stuff Is&lt;/title>
   &lt;prolog>
     &lt;windowtitle>Doing Things&lt;/windowtitle>
@@ -26,7 +26,7 @@
       <p>They could also incorporate these elements into their map document
         type shell, enabling map authors to override the values in
         topics.</p>
-      <codeblock>&lt;topicref href="topic167.dita">
+      <codeblock base="ci-xml">&lt;topicref href="topic167.dita">
   &lt;topicmeta>
     &lt;breadcrumbtitle>Thing Doing&lt;/breadcrumbtitle>
   &lt;/topicmeta>

--- a/specification/archSpec/base/example-chunk-combine-all.dita
+++ b/specification/archSpec/base/example-chunk-combine-all.dita
@@ -85,17 +85,17 @@
   &lt;topic id="background">
     &lt;title>Prerequisite concepts&lt;/title>
     &lt;shortdesc>This information is necessary before starting&lt;/shortdesc>
-    &lt;body> ... &lt;/body>
+    &lt;body> &lt;!-- ... --> &lt;/body>
       &lt;!-- More background topics -->
   &lt;/topic>
   <b>&lt;!-- original content of goals.dita --></b>
   &lt;topic id="goals">
     &lt;title>Lesson <ph rev="review-h">goals</ph>&lt;/title>
     &lt;shortdesc>After you complete the lesson ...&lt;/shortdesc>
-    &lt;body> ... &lt;/body>
+    &lt;body> &lt;!-- ... --> &lt;/body>
     &lt;!-- More goal topics -->
   &lt;/topic>
-   &lt;!-- More topics -->
+  &lt;!-- More topics -->
 &lt;/dita></codeblock>
       <p><ph rev="review-h">The</ph> content from all topics within the map
         is combined into a single result <ph rev="review-h">document</ph>,

--- a/specification/archSpec/base/example-chunk-combine-group.dita
+++ b/specification/archSpec/base/example-chunk-combine-group.dita
@@ -72,7 +72,7 @@
       <p>The following code blocks show the content of <filepath>
           chunkgroup-1.dita</filepath> and <filepath>
           chunkgroup-2.dita</filepath>:</p>
-      <codeblock><b>&lt;!-- chunkgroup-1.dita --></b>
+      <codeblock base="ci-xml"><b>&lt;!-- chunkgroup-1.dita --></b>
 &lt;dita>
   &lt;!-- Content of ingroup1.dita -->
   &lt;!-- Content of ingroup2.dita -->

--- a/specification/archSpec/base/example-key-definition-for-variable-text.dita
+++ b/specification/archSpec/base/example-key-definition-for-variable-text.dita
@@ -21,7 +21,10 @@
 &lt;/map&gt;</codeblock>
   <p>A topic can reference the "product-name" key by using the following markup:
       <codeblock>&lt;topic id="topicid"&gt;
-  &lt;p&gt;&lt;keyword keyref="product-name"/&gt; is a product designed to ...&lt;/p&gt;
+  &lt;title>...&lt;/title>
+  &lt;body>
+    &lt;p&gt;&lt;keyword keyref="product-name"/&gt; is a product designed to ...&lt;/p&gt;
+  &lt;/body>
 &lt;/topic&gt;</codeblock></p>
   <p>When processed, the output contains the text "Thing-O-Matic is a product designed to …".</p>
   <p>In the following example, the key definition contains both a reference to a resource and

--- a/specification/archSpec/base/example-keys-removing-link.dita
+++ b/specification/archSpec/base/example-keys-removing-link.dita
@@ -38,10 +38,11 @@
      define the key definition for "extended-warranties" as follows:</p>
     <codeblock>&lt;map>
   &lt;!-- ... -->
-  &lt;keydef keys="extended-warranties"/>
+  &lt;keydef keys="extended-warranties">
     &lt;topicmeta>
       &lt;keytext>This product does not offer extended warranties.&lt;/keytext>
     &lt;/topicmeta>
+  &lt;/keydef>
   &lt;!-- ... -->
 &lt;/map></codeblock>
     <p>When this team renders their content, there is no hyperlink in the output, just the text

--- a/specification/archSpec/base/example-keys-scope-defining-precedence.dita
+++ b/specification/archSpec/base/example-keys-scope-defining-precedence.dita
@@ -49,7 +49,7 @@
       referenced.</p>
     <fig id="fig_qxt_3lz_sr">
       <title>Complex map with multiple submaps and scopes</title>
-      <codeblock>&lt;map>   &lt;!-- Start of the root map -->
+      <codeblock base="ci-xml">&lt;map>   &lt;!-- Start of the root map -->
 
   &lt;mapref href="submapA.ditamap" keyscope="scopeA">  
     &lt;!-- Contents of submapA.ditamap begin here -->

--- a/specification/archSpec/base/example-multiple-ditavalref-as-child-of-map.dita
+++ b/specification/archSpec/base/example-multiple-ditavalref-as-child-of-map.dita
@@ -49,7 +49,7 @@ on &lt;keyword platform="mac">Mac&lt;/keyword>&lt;keyword platform="linux">Linux
         conditions that are referenced by the <xmlelement>ditavalref</xmlelement> element results in
         two variants of the title and common metadata. While this cannot be expressed using valid
         DITA markup, it is conceptually similar to something like the following.</p>
-      <codeblock>&lt;!-- The following wrapperElement is not a real DITA element.
+      <codeblock base="ci-xml">&lt;!-- The following wrapperElement is not a real DITA element.
      It is used here purely as an example to illustrate one possible 
      way of picturing the conditions. -->
 &lt;wrapperElement>

--- a/specification/archSpec/base/relax-ng-coding-attribute-domains.dita
+++ b/specification/archSpec/base/relax-ng-coding-attribute-domains.dita
@@ -41,7 +41,7 @@
           <div otherprops="examples">
             <p>For example, the following code samples shows the the <xmlatt>audience</xmlatt>
               specialization of <xmlatt>props</xmlatt>:</p>
-            <codeblock>&lt;define name="audienceAtt-d-attribute">
+            <codeblock base="ci-xml">&lt;define name="audienceAtt-d-attribute">
   &lt;optional>
     &lt;attribute name="audience" dita:since="2.0">
       &lt;a:documentation>Specifies the audience to which an element applies.&lt;/a:documentation>
@@ -67,7 +67,7 @@
                   pattern.</p>
                 <div otherprops="examples">
                   <p>For example:</p>
-                  <codeblock>&lt;define name="props-attribute-extensions" combine="interleave">
+                  <codeblock base="ci-xml">&lt;define name="props-attribute-extensions" combine="interleave">
   &lt;ref name="audienceAtt-d-attribute"/>
 &lt;/define></codeblock>
                 </div>
@@ -82,7 +82,7 @@
                   pattern.</p>
                 <div otherprops="examples">
                   <p>For example:</p>
-                  <codeblock>&lt;define name="base-attribute-extensions" combine="interleave">
+                  <codeblock base="ci-xml">&lt;define name="base-attribute-extensions" combine="interleave">
     &lt;ref name="myBaseSpecializationAtt-d-attribute"/>
 &lt;/define></codeblock>
                 </div>

--- a/specification/archSpec/base/specialization-class-attribute.dita
+++ b/specification/archSpec/base/specialization-class-attribute.dita
@@ -108,7 +108,7 @@
         element in the guiTask module, which is specialized from <xmlelement>task</xmlelement>. The
         element is specialized from <xmlelement>keyword</xmlelement> in the base topic vocabulary,
         rather than from an element in the task module:</p>
-      <codeblock>&lt;windowName class="- topic/keyword task/keyword guiTask/windowname ">...&lt;/windowName></codeblock>
+      <codeblock base="ci-xml">&lt;windowName class="- topic/keyword task/keyword guiTask/windowname ">...&lt;/windowName></codeblock>
       <p>The intermediate values are necessary so that generalizing and specializing transformations
         can map the values simply and accurately. For example, if <codeph>task/keyword</codeph> was
         missing as a value, and a user decided to generalize this guiTask up to a task topic, then

--- a/specification/archSpec/base/theconactionattribute.dita
+++ b/specification/archSpec/base/theconactionattribute.dita
@@ -54,8 +54,7 @@
           <xmlatt>id</xmlatt> set to example<keyword/>, and it contains a
           <xmlelement>step</xmlelement> element with the <xmlatt>id</xmlatt> set to
           <keyword>b</keyword>:</p>
-      <p>
-        <codeblock>&lt;task id="example" xml:lang="en">
+      <codeblock id="codeblock_scr_wqh_psb">&lt;task id="example" xml:lang="en">
   &lt;title>Example topic&lt;/title>
   &lt;taskbody>
     &lt;steps>
@@ -65,17 +64,16 @@
     &lt;/steps>
   &lt;/taskbody>
 &lt;/task></codeblock>
-      </p>
       <p>In order to replace the step with <codeph>id="b"</codeph>, another topic must combine a
           <xmlatt>conaction</xmlatt> value of <keyword>pushreplace</keyword> with a
           <xmlatt>conref</xmlatt> attribute that references this
-        <xmlelement>step</xmlelement>:<codeblock>&lt;task id="other" xml:lang="en">
-  ...
-   &lt;step conaction="pushreplace" 
-         conref="example.dita#example/b">
-     &lt;cmd>Updated B&lt;/cmd>
-   &lt;/step>
-  ...
+        <xmlelement>step</xmlelement>:<codeblock>&lt;!-- Steps element within another task -->
+&lt;steps>
+  &lt;step conaction="pushreplace" 
+        conref="example.dita#example/b">
+    &lt;cmd>Updated B&lt;/cmd>
+  &lt;/step>
+&lt;/steps>
 &lt;/task></codeblock></p>
       <p>The result will be an updated version of <filepath>example.dita</filepath> which contains
         the pushed
@@ -150,11 +148,14 @@
 <example id="example-pushbefore" otherprops="examples">
       <title>Example: pushing an element before the target</title>
       <p>The following example pushes a <xmlelement>step</xmlelement> before "b" in the
-          <filepath>example.dita</filepath> file shown above.
-        <codeblock>&lt;step conaction="pushbefore">&lt;cmd>Do this before B&lt;/cmd>&lt;/step>
-<ph >&lt;step conaction="mark" conref="example.dita#example/b">
-  &lt;cmd/>
-&lt;/step></ph></codeblock></p>
+          <filepath>example.dita</filepath> file shown above. <codeblock>&lt;steps>
+  &lt;step conaction="pushbefore">
+    &lt;cmd>Do this before B&lt;/cmd>
+  &lt;/step>
+  &lt;step conaction="mark" conref="example.dita#example/b">
+    &lt;cmd/>
+  &lt;/step>
+&lt;/steps></codeblock></p>
       <p>The result contains the pushed <xmlelement>step</xmlelement> element before
         "b".<codeblock>&lt;task id="example" xml:lang="en">
   &lt;title>Example topic&lt;/title>
@@ -171,12 +172,14 @@
 <example id="example-pushafter" otherprops="examples">
       <title>Example: pushing an element after the target</title>
       <p>Pushing an element after a target is exactly the same as pushing before, except that the
-        order of the "mark" element and the pushed element are
-        reversed.<codeblock><ph >&lt;step conaction="mark" conref="example.dita#example/b">
-  &lt;cmd/>
-&lt;/step></ph>
-&lt;step conaction="pushafter">&lt;cmd>Do this AFTER B&lt;/cmd>&lt;/step>
-</codeblock></p>
+        order of the "mark" element and the pushed element are reversed.<codeblock>&lt;steps>
+  &lt;step conaction="mark" conref="example.dita#example/b">
+    &lt;cmd/>
+  &lt;/step>
+  &lt;step conaction="pushafter">
+    &lt;cmd>Do this AFTER B&lt;/cmd>
+  &lt;/step>
+&lt;/steps></codeblock></p>
       <p>In this case the resulting document has the pushed content after
           <xmlelement>step</xmlelement>
         b:<codeblock>&lt;task id="example" xml:lang="en">

--- a/specification/archSpec/base/theconrefendattribute.dita
+++ b/specification/archSpec/base/theconrefendattribute.dita
@@ -69,48 +69,45 @@
       <fig>
         <title>List example: Source <filepath>topic.dita</filepath> with ids</title>
         <codeblock>&lt;topic id="x">
- 	&lt;title>Sample file topic.dita&lt;/title>
- 	&lt;body>
- 		&lt;ol>
- 			&lt;li id="apple">A&lt;/li>
- 			&lt;li id="bear">B&lt;/li>
- 			&lt;li id="cat">C&lt;/li>
- 			&lt;li id="dog">D&lt;/li>
- 			&lt;li id="eel">E&lt;/li>
- 		&lt;/ol>
- 	&lt;/body>
- &lt;/topic>
- </codeblock>
+  &lt;title>Sample file topic.dita&lt;/title>
+  &lt;body>
+    &lt;ol>
+      &lt;li id="apple">A&lt;/li>
+      &lt;li id="bear">B&lt;/li>
+      &lt;li id="cat">C&lt;/li>
+      &lt;li id="dog">D&lt;/li>
+      &lt;li id="eel">E&lt;/li>
+    &lt;/ol>
+  &lt;/body>
+&lt;/topic></codeblock>
       </fig>
       <fig id="fig_C0AF6F23F1E74AF98540F736113DFFAB">
         <title>List example: Reusing topic with conrefs</title>
-        <codeblock> &lt;topic id="y">
- 	&lt;title>Sample file reusing content&lt;/title>
- 	&lt;body>
- 		&lt;ol>
- 			&lt;li>My own first item&lt;/li>
- 			&lt;li conref="topic.dita#x/bear" conrefend="topic.dita#x/dog"/>
- 			&lt;li>And a different final item&lt;/li>
- 		&lt;/ol>
- 	&lt;/body>
- &lt;/topic>
- </codeblock>
+        <codeblock>&lt;topic id="y">
+  &lt;title>Sample file reusing content&lt;/title>
+  &lt;body>
+    &lt;ol>
+      &lt;li>My own first item&lt;/li>
+      &lt;li conref="topic.dita#x/bear" conrefend="topic.dita#x/dog"/>
+      &lt;li>And a different final item&lt;/li>
+    &lt;/ol>
+  &lt;/body>
+&lt;/topic></codeblock>
       </fig>
       <fig id="fig_A79BE8A6869B4DFDAAFA2F55BC113AA1">
         <title>List example: Processed result of reusing topic</title>
-        <codeblock> &lt;topic id="y">
- 	&lt;title>Sample file reusing content&lt;/title>
- 	&lt;body>
- 		&lt;ol>
- 			&lt;li>My own first item&lt;/li>
- 			&lt;li>B&lt;/li>
- 			&lt;li id="cat">C&lt;/li>
- 			&lt;li>D&lt;/li>
- 			&lt;li>And a different final item&lt;/li>
- 		&lt;/ol>
- 	&lt;/body>
-&lt;/topic>
-</codeblock>
+        <codeblock>&lt;topic id="y">
+  &lt;title>Sample file reusing content&lt;/title>
+  &lt;body>
+    &lt;ol>
+      &lt;li>My own first item&lt;/li>
+      &lt;li>B&lt;/li>
+      &lt;li id="cat">C&lt;/li>
+      &lt;li>D&lt;/li>
+      &lt;li>And a different final item&lt;/li>
+    &lt;/ol>
+  &lt;/body>
+&lt;/topic></codeblock>
       </fig>
     </example>
     <example id="example-reuse-blocks" otherprops="examples">
@@ -118,37 +115,36 @@
       <fig id="fig_7BB281DFE28F474BB9197BAE691B927C">
         <title>Block level example: Source <filepath>topic.dita</filepath> with ids</title>
         <codeblock>&lt;topic id="x">
- 	&lt;title>Sample file topic.dita&lt;/title>
- 	&lt;body&gt;
-   &lt;p id="p1"&gt;First para&lt;/p&gt;
- 	 &lt;ol id="mylist"&gt;
-     &lt;li id="apple"&gt;A&lt;/li&gt;
-     &lt;li id="bear"&gt;B&lt;/li&gt;
-     &lt;li id="cat"&gt;C&lt;/li&gt;
-     &lt;li id="dog"&gt;D&lt;/li&gt;
-     &lt;li id="eel"&gt;E&lt;/li&gt;
-   &lt;/ol&gt;
-   &lt;p id="p2"&gt;Second para&lt;/p&gt;
- 	&lt;/body&gt;
- &lt;/topic&gt;
- </codeblock>
+  &lt;title>Sample file topic.dita&lt;/title>
+  &lt;body>
+    &lt;p id="p1"&gt;First para&lt;/p&gt;
+    &lt;ol id="mylist"&gt;
+      &lt;li id="apple"&gt;A&lt;/li&gt;
+      &lt;li id="bear"&gt;B&lt;/li&gt;
+      &lt;li id="cat"&gt;C&lt;/li&gt;
+      &lt;li id="dog"&gt;D&lt;/li&gt;
+      &lt;li id="eel"&gt;E&lt;/li&gt;
+    &lt;/ol&gt;
+    &lt;p id="p2"&gt;Second para&lt;/p&gt;
+  &lt;/body&gt;
+&lt;/topic&gt;</codeblock>
       </fig>
       <fig id="fig_BF890E35527C41FBA93878660EFC1636">
         <title>Block level example: Reusing topic with conrefs</title>
-        <codeblock> &lt;topic id="y"&gt;
- 	&lt;title>Sample file reusing content&lt;/title>
- 	&lt;body&gt;
- 		&lt;p conref="topic.dita#x/p1" conrefend="topic.dita#x/p2"/&gt;
- 	&lt;/body&gt;
- &lt;/topic&gt;</codeblock>
+        <codeblock>&lt;topic id="y"&gt;
+  &lt;title>Sample file reusing content&lt;/title>
+  &lt;body>
+    &lt;p conref="topic.dita#x/p1" conrefend="topic.dita#x/p2"/&gt;
+  &lt;/body>
+&lt;/topic&gt;</codeblock>
       </fig>
       <fig id="fig_D257C3B1EE2B49DA85457B1753A8C79D">
         <title>Block level example: Processed result of reusing topic</title>
-        <codeblock> &lt;topic id="y"&gt;
- 	&lt;title>Sample file reusing content&lt;/title>
- 	&lt;body&gt;
+        <codeblock>&lt;topic id="y"&gt;
+  &lt;title>Sample file reusing content&lt;/title>
+  &lt;body>
     &lt;p&gt;First para&lt;/p&gt;
- 	  &lt;ol id="mylist"&gt;
+    &lt;ol id="mylist"&gt;
       &lt;li id="apple"&gt;A&lt;/li&gt;
       &lt;li id="bear"&gt;B&lt;/li&gt;
       &lt;li id="cat"&gt;C&lt;/li&gt;
@@ -156,9 +152,8 @@
       &lt;li id="eel"&gt;E&lt;/li&gt;
     &lt;/ol&gt;
     &lt;p&gt;Second para&lt;/p&gt;
- 	&lt;/body&gt;
-&lt;/topic&gt;
-</codeblock>
+  &lt;/body&gt;
+&lt;/topic&gt;</codeblock>
       </fig>
     </example>
     <section id="conkeyref">
@@ -183,13 +178,12 @@
         <title>Defining and referencing a key with <xmlatt>conkeyref</xmlatt></title>
         <p>In this example the key <keyword>xmp</keyword> is defined as the first topic in the file
             <filepath>examples.dita.</filepath></p>
-        <codeblock>&lt;map>
+        <codeblock id="codeblock_hwy_krh_psb">&lt;map>
   &lt;!-- ... -->
   &lt;keydef keys="xmp" href="examples.dita"/>
   &lt;!-- ... -->
-&lt;/map>
-
-examples.dita:
+&lt;/map></codeblock>
+        <codeblock id="codeblock_iwy_krh_psb">&lt;!-- examples.dita: -->
 &lt;topic id="examples">
   &lt;title>These are examples&lt;/title>
   &lt;body>
@@ -199,8 +193,7 @@ examples.dita:
       &lt;li id="last">Final example&lt;/li>
     &lt;/ul>
   &lt;/body>
-&lt;/topic>
-</codeblock>
+&lt;/topic></codeblock>
         <p>To reuse these list items by using the key, the <xmlatt>conkeyref</xmlatt> attribute
           combines the key itself with the sub-topic id (first) to define the start of the range.
           The <xmlatt>conrefend</xmlatt> attribute defines a default high-level object along with

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -76,8 +76,8 @@
   &lt;/subjectdef>
   &lt;enumerationdef>
     &lt;attributedef name="platform"/>
-    <b>&lt;defaultSubject keyref="linux"/></b>
     &lt;subjectdef keyref="os"/>
+    <b>&lt;defaultSubject keyref="linux"/></b>
   &lt;/enumerationdef>
 &lt;/subjectScheme></codeblock>
       <p>The result is that only the following values are permitted for

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -64,28 +64,33 @@
                   source, processors operate as if the @audience attribute
                   is explicitly set to
                 <keyword>spec-editors</keyword></ph>:</p>
-              <codeblock>&lt;enumerationdef>
+              <codeblock>&lt;subjectScheme>
+  &lt;!-- ... -->
+  &lt;enumerationdef>
     &lt;elementdef name="draft-comment"/>
     &lt;attributedef name="audience"/>
     &lt;subjectdef keyref="values-audience-draft-comment"/>
     &lt;defaultSubject keyref="spec-editors"/>
-&lt;/enumerationdef></codeblock>
+  &lt;/enumerationdef>
+  &lt;!-- ... -->
+&lt;/subjectScheme></codeblock>
             </div></dd>
 
         </dlentry>
                 <dlentry>
                     <dt>Specify that an attribute is not valid.</dt>
-                    <dd><p>When the <xmlelement>enumerationdef</xmlelement>
-              element <ph rev="review-d">contains a
-                  <xmlatt>subjectdef</xmlatt> element that does not
-                reference a subject</ph>, no value is valid for the
-              attribute.</p><p otherprops="examples"/>For example, the
-            following code sample specifies that no tokens are valid for
-            the <xmlatt>props</xmlatt>
-            attribute:<codeblock>&lt;enumerationdef>
+                    <dd><p>When the <xmlelement>enumerationdef</xmlelement> element <ph
+                rev="review-d">contains a <xmlatt>subjectdef</xmlatt> element that does not
+                reference a subject</ph>, no value is valid for the attribute.</p><p
+              otherprops="examples"/>For example, the following code sample specifies that no tokens
+            are valid for the <xmlatt>props</xmlatt> attribute:<codeblock>&lt;subjectScheme>
+  &lt;!-- ... -->
+  &lt;enumerationdef>
     &lt;attributedef name="props"/>
     &lt;subjectdef/>
-&lt;/enumerationdef></codeblock></dd>
+  &lt;/enumerationdef>
+  &lt;!-- ... -->
+&lt;/subjectScheme></codeblock></dd>
                 </dlentry>
             </dl>
 

--- a/specification/langRef/base/fn.dita
+++ b/specification/langRef/base/fn.dita
@@ -17,7 +17,8 @@
     <section conkeyref="reuse-fn/rendering-expectations" id="rendering-expectations"
       ><title/></section>
     <section conkeyref="reuse-fn/attributes" id="attributes"/>
-<example id="example" otherprops="examples"><title>Examples</title>
+<example id="example" otherprops="examples">
+      <title>Examples</title>
       <p>This section contains examples of how the <xmlelement>fn</xmlelement> element can be
         used.</p>
       <fig>
@@ -25,37 +26,31 @@
         <p>The following code sample shows a single-use footnote. It contains a simple
             <xmlelement>fn</xmlelement> element, with no <xmlatt>id</xmlatt> or
             <xmlatt>callout</xmlatt> attribute.</p>
-        <codeblock>The memory storage capacity of the computer is 
+        <codeblock>&lt;p>The memory storage capacity of the computer is 
 2 GB&lt;fn&gt;A GB (gigabyte) is equal to 
-1000 million bytes&lt;/fn&gt; with error correcting support.</codeblock>
-        <p>When rendered, typically a superscript symbol is placed at the
-          location of the <xmlelement>fn</xmlelement> element; this
-          superscript symbol is hyperlinked to the content of the
-            <xmlelement>fn</xmlelement>, which is typically placed at the
-          bottom of a PDF page or the end of an online article. The type of
-          symbol used is implementation specific.</p>
-        <p>The above code sample might produce the following output similar
-          to the following:</p>
-        <image placement="break" href="../images/simple-footnote.jpg"
-          scale="80">
-          <alt>The screen capture shows a text in a document that includes
-            a footnote. In the body of the text, the location of the
-            footnote is marked with the numeral one in superscript. At the
-            bottom on the page, the text of the footnote appears along with
-            the associated numeral one. The edges of the screen capture are
-            tattered, to indicate that the image is part of a larger
-            document.</alt>
+1000 million bytes&lt;/fn&gt; with error correcting support.&lt;/p></codeblock>
+        <p>When rendered, typically a superscript symbol is placed at the location of the
+            <xmlelement>fn</xmlelement> element; this superscript symbol is hyperlinked to the
+          content of the <xmlelement>fn</xmlelement>, which is typically placed at the bottom of a
+          PDF page or the end of an online article. The type of symbol used is implementation
+          specific.</p>
+        <p>The above code sample might produce the following output similar to the following:</p>
+        <image placement="break" href="../images/simple-footnote.jpg" scale="80">
+          <alt>The screen capture shows a text in a document that includes a footnote. In the body
+            of the text, the location of the footnote is marked with the numeral one in superscript.
+            At the bottom on the page, the text of the footnote appears along with the associated
+            numeral one. The edges of the screen capture are tattered, to indicate that the image is
+            part of a larger document.</alt>
         </image>
         <!--<p><lq><p>The memory storage capacity of the computer is 2 GB<sup>1</sup> with error correcting support.</p><p><codeph>......</codeph></p><p><sup>1</sup> A GB (gigabyte) is equal to 1000 million bytes</p></lq></p>-->
       </fig>
       <fig>
-        <title>An example of a single-use footnote with a
-            <xmlatt>callout</xmlatt> attribute</title>
+        <title>An example of a single-use footnote with a <xmlatt>callout</xmlatt> attribute</title>
         <p>The following code sample shows a single-use footnote that uses a
             <xmlatt>callout</xmlatt> attribute:</p>
-        <codeblock>The memory storage capacity of the computer is 
+        <codeblock>&lt;p>The memory storage capacity of the computer is 
 2 GB&lt;fn callout="#"&gt;A GB (gigabyte) is equal to 
-1000 million bytes&lt;/fn&gt; with error correcting support.</codeblock>
+1000 million bytes&lt;/fn&gt; with error correcting support.&lt;/p></codeblock>
         <p>The rendered output is similar to that of the previous example, although processors that
           support it will render the footnote symbol as # (hashtag).</p>
         <!--<p>That DITA markup might produce output similar to the following:<lq><p>The memory storage capacity of the computer is 2 GB<sup>#</sup> with error correcting support.</p><p><codeph>......</codeph></p><p><sup>#</sup> A GB (gigabyte) is equal to 1000 million bytes</p><p>[bottom of page]</p></lq></p>-->
@@ -66,17 +61,17 @@
             <xmlelement>fn</xmlelement> elements have <xmlatt>id</xmlatt> attributes, and inline
             <xmlelement>xref</xmlelement> elements reference those <xmlelement>fn</xmlelement>
           elements:</p>
-        <codeblock>&lt;fn id="dog-name"&gt;Fido&lt;/fn&gt;
-&lt;fn id="cat-name">Puss&lt;/fn>
-&lt;fn id="llama-name">My llama&lt;/fn>
-...
-&lt;p>I like pets. At my house, I have a dog&lt;xref href="#topic/dog-name" type="fn"/&gt;, a
-cat&lt;xref href="#topic/cat-name" type="fn"/&gt;, and a 
-llama&lt;xref href="#topic/llama-name" type="fn"/&gt;.&lt;/p></codeblock>
-        <p>The code sample might produce output similar to the
-          following:</p>
-        <image placement="break"
-          href="../images/footnote-use-by-reference.jpg" scale="80">
+        <codeblock>&lt;section>
+  &lt;fn id="dog-name"&gt;Fido&lt;/fn&gt;
+  &lt;fn id="cat-name">Puss&lt;/fn>
+  &lt;fn id="llama-name">My llama&lt;/fn>
+  &lt;!-- ... -->
+  &lt;p>I like pets. At my house, I have a dog&lt;xref href="#topic/dog-name" type="fn"/&gt;, a
+     cat&lt;xref href="#topic/cat-name" type="fn"/&gt;, and a 
+     llama&lt;xref href="#topic/llama-name" type="fn"/&gt;.&lt;/p>
+&lt;/section></codeblock>
+        <p>The code sample might produce output similar to the following:</p>
+        <image placement="break" href="../images/footnote-use-by-reference.jpg" scale="80">
           <alt/>
         </image>
       </fig>
@@ -86,10 +81,14 @@ llama&lt;xref href="#topic/llama-name" type="fn"/&gt;.&lt;/p></codeblock>
             (<filepath>footnotes.dita</filepath>):</p>
         <codeblock>&lt;!-- Content from footnotes.dita -->
 &lt;topic id="footnotes">
-...
-  &lt;fn id="strunk">Elements of Style&lt;/fn>
-  &lt;fn id="DQTI">Developing Quality Technical Information, 2nd edition&lt;/fn>
-...
+  &lt;title>Shared topic...&lt;/title>
+  &lt;body>
+    &lt;bodydiv>
+      &lt;fn id="strunk">Elements of Style&lt;/fn>
+      &lt;fn id="DQTI">Developing Quality Technical Information, 2nd edition&lt;/fn>
+      &lt;!-- ... -->
+    &lt;/bodydiv>
+  &lt;/body>
 &lt;/topic></codeblock>
         <p>To use those footnotes, authors conref them into the relevant topics:</p>
         <codeblock>&lt;p>See the online resource&lt;fn conref="footnotes.dita#footnotes/DQTI"/> for more 
@@ -101,15 +100,17 @@ llama&lt;xref href="#topic/llama-name" type="fn"/&gt;.&lt;/p></codeblock>
         <codeblock>&lt;topic id="evaluating-quality">
   &lt;title>Evaluating documentation quality&lt;/title>
   &lt;body>
-  &lt;!-- ... -->
-  &lt;fn conref="footnotes.dita#footnotes/DQTI" id="dqti"/>
-  &lt;!-- ... -->
-  &lt;p>See the online resource&lt;xref="./evaluating-quality/dqti" type="fn"/> for more 
-     information about how to assess the quality of technical documentation ...&lt;/p>
-  &lt;!-- ... -->
+    &lt;bodydiv>
+      &lt;fn conref="footnotes.dita#footnotes/DQTI" id="dqti"/>
+    &lt;/bodydiv>
+    &lt;!-- ... -->
+    &lt;p>See the online resource&lt;xref="#./dqti" type="fn"/> for more 
+       information about how to assess the quality of technical documentation ...&lt;/p>
+    &lt;!-- ... -->
   &lt;/body>
 &lt;topic></codeblock>
-      </fig></example>
+      </fig>
+    </example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -90,9 +90,11 @@ are presented instead.</p>
   &lt;title>Summary of changes&lt;/title>
   &lt;shortdesc>This topic describes changes in the project source code.&lt;/shortdesc>
   &lt;body>
-    &lt;include href="../src/README.txt" parse="text" encoding="UTF-8">
-      &lt;fallback>See README.txt in the source package for a list of changes.&lt;/fallback>
-    &lt;/include>
+    &lt;section>
+      &lt;include href="../src/README.txt" parse="text" encoding="UTF-8">
+        &lt;fallback>See README.txt in the source package for a list of changes.&lt;/fallback>
+      &lt;/include>
+    &lt;/section>
   &lt;/body>
 &lt;/topic></codeblock>
             </fig>
@@ -111,10 +113,9 @@ are presented instead.</p>
           proprietary <xmlatt>parse</xmlatt> value that instructs a
           processor how to render a <ph rev="review-c">comma-separated</ph>
           data set within the figure:</p>
-                <codeblock>
-&lt;fig>
+                <codeblock>&lt;fig>
   &lt;title>Data Table&lt;/title>
-  &lt;include href="data.csv"  encoding="UTF-8"
+  &lt;include href="data.csv" encoding="UTF-8"
     parse="http://www.example.com/dita/includeParsers/csv-to-simpletable"/>
 &lt;/fig></codeblock>
             </fig>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -18,16 +18,12 @@
     </section>
 <example id="example" otherprops="examples">
       <title>Example</title>
-      <p>The following code sample contains a quotation. <ph rev="review-c"
-          >The <xmlatt>href</xmlatt> attribute indicates a Web site where
-          the full text of the address can be accessed, and the
-            <xmlelement>cite</xmlelement> attribute specifies the title of
-          the document that is quoted</ph></p>
+      <p>The following code sample contains a quotation. <ph rev="review-c">The
+                        <xmlelement>cite</xmlelement> attribute specifies the title of the document
+                    that is quoted.</ph></p>
       <codeblock>&lt;p&gt;This is the first line of the address that Abraham Lincoln delivered
 on November 19, 1863 for the dedication of the cemetery at Gettysburg, Pennsylvania.&lt;/p&gt;
-&lt;lq reftitle="Gettysburg address"
-href="https://en.wikisource.org/wiki/Gettysburg_Address_(Nicolay_draft)" format="html"
-scope="external"&gt;Four score and seven years ago our fathers brought forth on this continent 
+&lt;lq&gt;Four score and seven years ago our fathers brought forth on this continent 
 a new nation, conceived in liberty, and dedicated to the proposition that all men
 are created equal. &lt;cite>Gettysburg address&lt;/cite>&lt;/lq&gt;</codeblock>
     </example>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -117,7 +117,7 @@
             <xmlelement>glossterm</xmlelement></title>
         <codeblock>&lt;glossentry id="gloss-dada">
   &lt;glossterm>&lt;sort-as value="dada"/>&amp;#x5927;&amp;#x5927;&lt;/glossterm>
-    &lt;glossdef>Literally "big big".&lt;/glossdef>
+  &lt;glossdef>Literally "big big".&lt;/glossdef>
 &lt;/glossentry></codeblock>
       </fig>
       <fig>
@@ -125,10 +125,10 @@
           <xmlelement>prolog</xmlelement></title>
         <codeblock>&lt;glossentry id="gloss-dada">
   &lt;glossterm>&amp;#x5927;&amp;#x5927;&lt;/glossterm>
+  &lt;glossdef>Literally "big big".&lt;/glossdef>
   &lt;prolog>
     &lt;sort-as>dada&lt;/sort-as>
   &lt;/prolog>
-    &lt;glossdef>Literally "big big".&lt;/glossdef>
 &lt;/glossentry></codeblock>
       </fig>
     </example>

--- a/specification/langRef/base/topicSubjectTable.dita
+++ b/specification/langRef/base/topicSubjectTable.dita
@@ -53,7 +53,7 @@
             removed as part of a proposal to remove the classification domain. If that domain is
             retained, we need to update this example.</draft-comment>
         </p>
-        <codeblock>&lt;subjectScheme>
+        <codeblock base="ci-xml">&lt;subjectScheme>
     &lt;hasKind>
         &lt;subjectdef href="goalType.dita" keys="goal">
             &lt;subjectdef href="performanceGoal.dita" keys="performance"/>
@@ -91,7 +91,7 @@
             not define any relationship between the goal of <keyword>performance</keyword> and the
             operating systems <keyword>linux</keyword> or <keyword>unix</keyword>.</li>
         </ul>
-        <codeblock>&lt;map>
+        <codeblock base="ci-xml">&lt;map>
 &lt;!-- ... -->
 &lt;topicSubjectTable>
   &lt;topicSubjectHeader>

--- a/specification/non-normative/foreigngeneralization.dita
+++ b/specification/non-normative/foreigngeneralization.dita
@@ -42,15 +42,13 @@
         generalized using normal rules. The <xmlelement>m:math</xmlelement> element, which is not a
         DITA element, will be exported to another file. The <xmlelement>data</xmlelement> element
         will remain:</p>
-      <codeblock>&lt;foreign class="+ topic/foreign mathml-d/mathml "&gt;
+      <codeblock id="codeblock_kg3_vsh_psb">&lt;foreign class="+ topic/foreign mathml-d/mathml "&gt;
   &lt;object data="dita-generalized-topicid_mathml1.xml" type="DITA-foreign"/&gt;
   &lt;data&gt;X plus three&lt;/data&gt;
-&lt;/foreign&gt;
-
-Contents of dita-generalized-topicid_mathml1.xml:
+&lt;/foreign&gt;</codeblock>
+      <codeblock id="codeblock_lg3_vsh_psb" base="ci-xml">&lt;!-- Contents of dita-generalized-topicid_mathml1.xml: -->
 &lt;foreign class="+ topic/foreign mathml-d/mathml "
          xmlns:m="http://www.w3.org/1998/Math/MathML"&gt;
-&gt;
   &lt;m:math&gt;
     &lt;m:mi&gt;x&lt;/m:mi&gt;&lt;m:mo&gt;+&lt;/m:mo&gt;&lt;m:mn&gt;3&lt;/m:mn&gt;
   &lt;/m:math&gt;
@@ -80,7 +78,7 @@ Contents of dita-generalized-topicid_mathml1.xml:
 &lt;/foreign&gt;
 </codeblock>
       <p>The contents of dita-generalized-topicid_mathml1.xml, the first exported file:</p>
-      <codeblock>&lt;foreign class="+ topic/foreign mathml-d/mathml "
+      <codeblock base="ci-xml">&lt;foreign class="+ topic/foreign mathml-d/mathml "
          xmlns:m="http://www.w3.org/1998/Math/MathML"&gt;
   &lt;m:math&gt;
     &lt;m:mi&gt;x&lt;/m:mi&gt;&lt;m:mo&gt;+&lt;/m:mo&gt;&lt;m:mn&gt;3&lt;/m:mn&gt;
@@ -88,7 +86,7 @@ Contents of dita-generalized-topicid_mathml1.xml:
 &lt;/foreign&gt;
 </codeblock>
       <p>The contents of dita-generalized-topicid_mathml2.xml, the second exported file:</p>
-      <codeblock>&lt;foreign class="+ topic/foreign mathml-d/mathml "
+      <codeblock base="ci-xml">&lt;foreign class="+ topic/foreign mathml-d/mathml "
          xmlns:m="http://www.w3.org/1998/Math/MathML"&gt;
   &lt;m:math&gt;
     &lt;m:mi&gt;y&lt;/m:mi&gt;&lt;m:mo&gt;-&lt;/m:mo&gt;&lt;m:mn&gt;2&lt;/m:mn&gt;


### PR DESCRIPTION
Fixes all examples so that they pass the validation step in #484 

* Any codeblock that is not valid XML needs `base="ci-skip"` which tells the processor to skip validation
* Any codeblock that is valid XML but not DITA needs `base="ci-xml"` which will ensure the sample is valid XML (for example, `<define>` RNG examples). Also used for code blocks that show theoretical specialized markup that is not part of the OASIS grammar.