### PR TITLE
Share outputclass info for prop/revprop

### DIFF
--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -300,6 +300,19 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
         For example, <codeph>"s(topic task strictTaskbody-c)"</codeph> indicates a strong
         constraint.</p>
     </section>
+    <section id="section_nw3_3pr_wsb">
+      <title>DITAVAL reuse material</title>
+      <div id="processing-outputclass">
+        <p>If one or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same
+          element, and the flagged element already specifies one or more values for the
+            <xmlatt>outputclass</xmlatt> attribute, processors treat the flagged element as if the
+          DITAVAL-based tokens are specified first.</p>
+        <p>If two or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same
+          element, processors treat the flagged element as if each value was specified for the
+            <xmlatt>outputclass</xmlatt> attribute. The order of the DITAVAL-provided tokens is
+          undefined.</p>
+      </div>
+    </section>
     <section id="processing-expectations-link-cascade" rev="review-h">
       <title>Processing expectations</title>
       <p>Attributes that cascade between topic references in a map<ph rev="review-j">, such as the

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -67,6 +67,7 @@
               <xmlatt>value</xmlatt></li>
         </ul>Processors <term outputclass="RFC-2119">MAY</term> provide an
         error or warning message for these error conditions.</p>
+      <div conkeyref="reuse-general/processing-outputclass"/>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/ditaval/ditaval-revprop.dita
+++ b/specification/langRef/ditaval/ditaval-revprop.dita
@@ -37,17 +37,7 @@
         implementation dependent. In such cases processors <term
           outputclass="RFC-2119">MAY</term> provide an error or warning
         message.</p>
-      <p>If one or more DITAVAL properties apply
-          <xmlatt>outputclass</xmlatt> flags to the same element, and the
-        flagged element already specifies one or more values for the
-          <xmlatt>outputclass</xmlatt> attribute, processors treat the
-        flagged element as if the DITAVAL-based tokens are specified
-        first.</p>
-      <p>If two or more DITAVAL properties apply
-          <xmlatt>outputclass</xmlatt> flags to the same element,
-        processors treat the flagged element as if each value was specified
-        for the <xmlatt>outputclass</xmlatt> attribute. The order of the
-        DITAVAL-provided tokens is undefined.</p>
+          <div conkeyref="reuse-general/processing-outputclass"/>
       <!--<p>[Details about processing expectations that should go elsewhere] If two or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same element, treat the flagged element as if each value was specified on that element's <xmlatt>outputclass</xmlatt> attribute; in that case, the order of those DITAVAL-based tokens is undefined. If the flagged element already specifies <xmlatt>outputclass</xmlatt>, treat the flagged element as if all DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</p>-->
         </section>
 <section id="attributes"><title>Attributes</title>


### PR DESCRIPTION
Move outputclass processing that applies to both `prop` and `revprop` into reuse file, use in both