### PR TITLE
#397 remove obsolete object attrs

### DIFF
--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -1308,15 +1308,6 @@
                value
                           CDATA
                                     #IMPLIED
-               valuetype
-                          (data |
-                           object |
-                           ref |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               type
-                          CDATA
-                                    #IMPLIED
                keyref
                           CDATA
                                     #IMPLIED"

--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -1244,22 +1244,7 @@
                          (%foreign.unknown.incl;)*)"
 >
 <!ENTITY % object.attributes
-              "declare
-                          (declare)
-                                    #IMPLIED
-               classid
-                          CDATA
-                                    #IMPLIED
-               classidkeyref
-                          CDATA
-                                    #IMPLIED
-               codebase
-                          CDATA
-                                    #IMPLIED
-               codebasekeyref
-                          CDATA
-                                    #IMPLIED
-               data
+              "data
                           CDATA
                                     #IMPLIED
                datakeyref
@@ -1269,15 +1254,6 @@
                           CDATA
                                     #IMPLIED
                codetype
-                          CDATA
-                                    #IMPLIED
-               archive
-                          CDATA
-                                    #IMPLIED
-               archivekeyrefs
-                          CDATA
-                                    #IMPLIED
-               standby
                           CDATA
                                     #IMPLIED
                height

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -2247,19 +2247,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
             <attribute name="value"/>
           </optional>
           <optional>
-            <attribute name="valuetype">
-              <choice>
-                <value>data</value>
-                <value>object</value>
-                <value>ref</value>
-                <value>-dita-use-conref-target</value>
-              </choice>
-            </attribute>
-          </optional>
-          <optional>
-            <attribute name="type"/>
-          </optional>
-          <optional>
             <attribute name="keyref"/>
           </optional>
         </define>

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -2186,25 +2186,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
         </define>
         <define name="object.attributes">
           <optional>
-            <attribute name="declare">
-              <choice>
-                <value>declare</value>
-              </choice>
-            </attribute>
-          </optional>
-          <optional>
-            <attribute name="classid"/>
-          </optional>
-          <optional>
-            <attribute name="classidkeyref"/>
-          </optional>
-          <optional>
-            <attribute name="codebase"/>
-          </optional>
-          <optional>
-            <attribute name="codebasekeyref"/>
-          </optional>
-          <optional>
             <attribute name="data"/>
           </optional>
           <optional>
@@ -2215,15 +2196,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
           </optional>
           <optional>
             <attribute name="codetype"/>
-          </optional>
-          <optional>
-            <attribute name="archive"/>
-          </optional>
-          <optional>
-            <attribute name="archivekeyrefs"/>
-          </optional>
-          <optional>
-            <attribute name="standby"/>
           </optional>
           <optional>
             <attribute name="height">

--- a/specification/archSpec/base/processing-keyref-for-links.dita
+++ b/specification/archSpec/base/processing-keyref-for-links.dita
@@ -18,11 +18,9 @@
             contain a <xmlelement>topicmeta</xmlelement> subelement, empty elements that refer to
             the key (such as <codeph>&lt;link keyref="a"/></codeph> or <codeph>&lt;xref keyref="a"
                 href="fallback.dita"/></codeph>) are <ph >ignored</ph>.</p>
-        <p>The <xmlelement>object</xmlelement> element has additional key-referencing attributes
-                (<xmlatt>archivekeyrefs</xmlatt>, <xmlatt>classidkeyref</xmlatt>,
-                <xmlatt>codebasekeyref</xmlatt>, and <xmlatt>datakeyref</xmlatt>). Key names in
-            these attributes are resolved using the same processing that is described for the normal
-                <xmlatt>keyref</xmlatt> attribute.</p>
+        <p>The <xmlelement>object</xmlelement> element has an additional key-referencing attribute
+            named <xmlatt>datakeyref</xmlatt>. Key names in this attribute are resolved using the
+            same processing that is described for the normal <xmlatt>keyref</xmlatt> attribute.</p>
         <!--<p>For key references to undefined keys, if there is an @href attribute
 on         the referencing element, the value of the @href attribute
 is used as the         reference and the key reference element is

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -37,63 +37,12 @@
                     conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
                 below.</p>
             <dl>
-                <dlentry id="archive">
-                    <dt id="attr-archive"><xmlatt>archive</xmlatt></dt>
-                    <dd>Specifies a space-separated list of URIs indicating resources needed by the
-                        object. These resources might include those URIs specified by the
-                            <xmlatt>classid</xmlatt> and <xmlatt>data</xmlatt> attributes.
-                        Preloading these resources usually results in faster load times for objects.
-                        The URIs in the list should be relative to the URI specified in the
-                            <xmlatt>codebase</xmlatt> attribute.</dd>
-                </dlentry>
-                <dlentry id="archivekeyrefs">
-                    <dt id="attr-archivekeyrefs"><xmlatt>archivekeyrefs</xmlatt></dt>
-                    <dd>Specifies key references to one or more archives, as for
-                            <xmlatt>archive</xmlatt>. The value is a space-separated list of key
-                        names. Each resolvable key reference is treated as a URI as though it had
-                        been specified on the <xmlatt>archive</xmlatt> attribute. When specified,
-                        and at least one key name is resolvable, the key-provided archive list is
-                        used. If <xmlatt>archive</xmlatt> is specified, it is used as a fallback
-                        when no key names can be resolved to a URI. </dd>
-                </dlentry>
-                <dlentry id="classid">
-                    <dt id="attr-classid"><xmlatt>classid</xmlatt></dt>
-                    <dd>Contains a URI that specifies the location of an object&apos;s
-                        implementation. It can be used together with the <xmlatt>data</xmlatt>
-                        attribute which is specified relative to the value of the
-                            <xmlatt>codebase</xmlatt> attribute. </dd>
-                </dlentry>
-                <dlentry id="classidkeyref">
-                    <dt id="attr-classidkeyref"><xmlatt>classidkeyref</xmlatt></dt>
-                    <dd>Specifies a key reference to the URI that specifies the location of an
-                        object's implementation, as for <xmlatt>classid</xmlatt>. When specified,
-                        and the key is resolvable, the key-provided class ID URI is used. If
-                            <xmlatt>classid</xmlatt> is specified, it is used as a fallback when the
-                        key cannot be resolved to a URI. </dd>
-                </dlentry>
-                <dlentry id="codebase">
-                    <dt id="attr-codebase"><xmlatt>codebase</xmlatt></dt>
-                    <dd>Specifies the base URI used for resolving the relative URI values given for
-                            <xmlatt>classid</xmlatt>, <xmlatt>data</xmlatt>, and
-                            <xmlatt>archive</xmlatt> attributes. If <xmlatt>codebase</xmlatt> is not
-                        set, the default is the base URI of the current element.</dd>
-                </dlentry>
-                <dlentry id="codebasekeyref">
-                    <dt id="attr-codebasekeyref"><xmlatt>codebasekeyref</xmlatt></dt>
-                    <dd>Specifies a key reference to the base URI used for resolving other
-                        attributes, as for <xmlatt>codebase</xmlatt>. When specified, and the key is
-                        resolvable, the key-provided code base URI is used. If
-                            <xmlatt>codebase</xmlatt> is specified, it is used as a fallback if the
-                        key cannot be resolved to a URI. If no URI results from processing
-                            <xmlatt>codebasekeyref</xmlatt> and <xmlatt>codebase</xmlatt> is not
-                        specified, the default is the base URL of the current element.</dd>
-                </dlentry>
                 <dlentry id="data">
                     <dt id="attr-data"><xmlatt>data</xmlatt></dt>
                     <dd>Contains a reference to the location of an object&apos;s data. If this
-                        attribute is a relative URL, it is specified relative to the value of the
-                            <xmlatt>codebase</xmlatt> attribute. If this attribute is set, the
-                            <xmlatt>type</xmlatt> attribute should also be set.</dd>
+                        attribute is a relative URL, it is specified relative to the document
+                        containing the <xmlelement>object</xmlelement> element. If this attribute is
+                        set, the <xmlatt>type</xmlatt> attribute should also be set.</dd>
                 </dlentry>
                 <dlentry id="datakeyref">
                     <!-- KJE: Modified to be parallel to the desciption of  @datakeyref in the audio and video topics-->
@@ -104,14 +53,6 @@
                             <xmlatt>data</xmlatt> is specified, it is used as a fallback when the
                         key cannot be resolved to a resource.</dd>
                 </dlentry>
-                <dlentry id="declare">
-                    <dt id="attr-declare"><xmlatt>declare</xmlatt></dt>
-                    <dd>Specifies whether the current object definition is only a declaration. When
-                        this attribute is set to "declare", the current object definition is a
-                        declaration only. The object must be instantiated by a later nested object
-                        definition referring to this declaration. The only allowable value is
-                        "declare".</dd>
-                </dlentry>
                 <dlentry conkeyref="reuse-attributes/image-height" id="height">
                     <dt/>
                     <dd/>
@@ -119,10 +60,6 @@
                 <dlentry id="name">
                     <dt id="attr-name"><xmlatt>name</xmlatt></dt>
                     <dd>Defines a unique name for the object.</dd>
-                </dlentry>
-                <dlentry id="standby">
-                    <dt id="attr-standby"><xmlatt>standby</xmlatt></dt>
-                    <dd>Contains a message to be displayed while an object is loading.</dd>
                 </dlentry>
                 <dlentry id="tabindex">
                     <dt id="attr-tabindex"><xmlatt>tabindex</xmlatt></dt>
@@ -205,8 +142,6 @@
           be used to reference the main content for an
             <xmlelement>object</xmlelement>:</p>
                 <codeblock>&lt;object id="cutkey370"
-    <b>classidkeyref="video_classid"</b>
-    <b>codebasekeyref="video_codebase"</b>
     <b>datakeyref="cutkey370"</b>
     height="280"
     width="370">
@@ -218,25 +153,14 @@
 &lt;/object></codeblock>
                 <p>In this scenario, the keys could be defined as follows:<codeblock>&lt;map>
   &lt;!-- ... -->
-  &lt;!-- NOTE: Using @scope="external" because the class ID is a URI
-       that is not intended to be directly resolved. -->
-  &lt;keydef keys="video_classid"
-    href="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
-    scope="external" />
 
-  &lt;!-- NOTE: Using @scope="external" to avoid systems trying to
-             download this file when they don't need to. -->
-  &lt;keydef keys="video_codebase"
-    href="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,0,0"
-    format="shockwave"
-    scope="external" />
-
-  &lt;!-- Using @scope="external" here because the referenced URL is not intended
-       to be resolved in isolation but relative to the codebase URI. -->
+  &lt;!-- Using @scope="external" here because the referenced URL is external. -->
   &lt;keydef keys="cutkey370"
-    href="cutkey370.swf"
+    href="https://www.example.com/cutkey370.swf"
     type="application/x-shockwave-flash"
+    format="swf"
     scope="external" />
+
   &lt;!-- ... -->
 &lt;/map></codeblock></p>
             </fig>

--- a/specification/langRef/base/param.dita
+++ b/specification/langRef/base/param.dita
@@ -29,55 +29,24 @@
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>
-      <p>The <xmlatt>keyref</xmlatt> and <xmlatt>valuetype</xmlatt>
-        attributes on <xmlelement>param</xmlelement> have the following <ph
-          rev="review-c">expectations</ph>:<ul id="ul_evg_2gj_nrb">
-          <li>If <xmlatt>valuetype</xmlatt> is specified but is not set to
-            "ref", the <xmlatt>keyref</xmlatt> attribute is ignored.</li>
-          <li>When <xmlatt>valuetype</xmlatt> is not specified and
-              <xmlatt>keyref</xmlatt> is specified, it implies a setting of
-              <codeph>valuetype="ref"</codeph>.</li>
-          <li>When <xmlatt>keyref</xmlatt> is specified and the effective
-            value of <xmlatt>valuetype</xmlatt> is
-              <keyword>ref</keyword>:<ol id="ol_tvg_2c2_z1b">
-              <li>When the key specified by <xmlatt>keyref</xmlatt> is
-                resolvable and has an associated URI, that URI is used as
-                the value of this element (overriding
-                  <xmlatt>value</xmlatt>, if that is specified).</li>
-              <li>When the key specified by <xmlatt>keyref</xmlatt> is
-                resolvable and has no associated resource (only link text),
-                the <xmlatt>keyref</xmlatt> attribute is considered to be
-                unresolvable for this element. If <xmlatt>value</xmlatt> is
-                specified, it is used as <ph rev="review-c">a
-                fallback</ph>.</li>
-              <li>When the key specified by <xmlatt>keyref</xmlatt> is not
-                resolvable, the value of the <xmlatt>value</xmlatt>
-                attribute is used as a fallback target for the
-                  <xmlelement>param</xmlelement> element.</li>
-            </ol></li>
-        </ul></p>
-      <p>In addition, the following expectations apply to the
-          <xmlatt>type</xmlatt> attribute:<ol id="ol_svg_2c2_z1b">
-          <li>When <xmlatt>valuetype</xmlatt> is set to "ref", the
-              <xmlatt>type</xmlatt> attribute directly specifies the
-            content type of the resource designated by
-              <xmlatt>value</xmlatt>.</li>
-          <li>Otherwise, if <xmlatt>type</xmlatt> is specified and
-              <xmlatt>keyref</xmlatt> is specified and resolvable, this
-            attribute specifies the content type of the resource designated
-            by <xmlatt>keyref</xmlatt>.</li>
-          <li>Otherwise, if <xmlatt>type</xmlatt> is not specified and
-              <xmlatt>keyref</xmlatt> is specified and is resolvable, the
-            effective type value specified for the key that is named by the
-              <xmlatt>keyref</xmlatt> attribute is used as the value of the
-              <xmlatt>type</xmlatt> attribute.</li>
+      <p>The <xmlatt>keyref</xmlatt> attribute on <xmlelement>param</xmlelement> has the following
+          <ph rev="review-c">expectations</ph>:<ol id="ol_tvg_2c2_z1b">
+          <li>When the key specified by <xmlatt>keyref</xmlatt> is resolvable and has an associated
+            URI, that URI is used as the value of this element (overriding <xmlatt>value</xmlatt>,
+            if that is specified).</li>
+          <li>When the key specified by <xmlatt>keyref</xmlatt> is resolvable and has no associated
+            resource (only link text), the <xmlatt>keyref</xmlatt> attribute is considered to be
+            unresolvable for this element. If <xmlatt>value</xmlatt> is specified, it is used as <ph
+              rev="review-c">a fallback</ph>.</li>
+          <li>When the key specified by <xmlatt>keyref</xmlatt> is not resolvable, the value of the
+              <xmlatt>value</xmlatt> attribute is used as a fallback target for the
+              <xmlelement>param</xmlelement> element.</li>
         </ol></p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/> and the
-        attributes defined below.</p>
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
@@ -90,48 +59,9 @@
           <dd>Specifies the name of the parameter.</dd>
         </dlentry>
         <dlentry>
-          <dt id="attr-type"><xmlatt>type</xmlatt></dt>
-          <dd>Specifies for a user agent the type of values that will be
-            found at the URI designated by <xmlatt>value</xmlatt>. <ph
-              conkeyref="reuse-attributes/nonstandard-type"/></dd>
-        </dlentry>
-        <dlentry>
           <dt id="attr-value"><xmlatt>value</xmlatt></dt>
           <dd>Specifies the value of a run-time parameter that is described
             by the <xmlatt>name</xmlatt> attribute.</dd>
-        </dlentry>
-        <dlentry>
-          <dt id="attr-valuetype"><xmlatt>valuetype</xmlatt></dt>
-          <dd>Specifies the type of the <xmlatt>value</xmlatt> attribute.
-            Allowed values are: <dl>
-              <dlentry>
-                <dt>data </dt>
-                <dd>A value of <keyword>data</keyword> means that the value
-                  will be evaluated and passed to the object&apos;s
-                  implementation as a string. </dd>
-              </dlentry>
-              <dlentry>
-                <dt>ref </dt>
-                <dd>A value of <keyword>ref</keyword> indicates that the
-                  value of the <xmlatt>value</xmlatt> attribute is a URL
-                  that designates a resource where run-time values are
-                  stored. This allows support tools to identify URLs that
-                  are given as parameters.</dd>
-              </dlentry>
-              <dlentry>
-                <dt>object</dt>
-                <dd>A value of <keyword>object</keyword> indicates that the
-                  value of the <xmlatt>value</xmlatt> attribute is an
-                  identifier that refers to an object declaration in the
-                  document. The identifier must be the value of the
-                    <xmlatt>id</xmlatt> attribute set for the declared
-                    <xmlelement>object</xmlelement> element. </dd>
-              </dlentry>
-              <dlentry conkeyref="reuse-attributes/ditauseconref">
-                <dt/>
-                <dd/>
-              </dlentry>
-            </dl></dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -557,7 +557,7 @@ for this?</draft-comment>-->
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>standby</xmlatt></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>ol</xmlelement></stentry>


### PR DESCRIPTION
Per TC meeting February 15 2022, we will remove attributes from the `<object>` element which are deprecated in the HTML5 version of the element: https://lists.oasis-open.org/archives/dita/202202/msg00023.html

Based on the current HTML5 docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object

Removing:
* archive and archivekeyrefs
* classid and classidkeyref
* codebase and codebasekeyref
* declare
* standby

Based on emails in the thread that prompted this update, the deprecated attributes `type` and `valuetype` will also be removed from the `<param>` element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param