### PR TITLE
Rework of conditional processing topics

### DIFF
--- a/specification/archSpec/base/aboutconditionalprocessing.dita
+++ b/specification/archSpec/base/aboutconditionalprocessing.dita
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_xzh_h25_xsb">
+    <title>About conditional processing</title>
+    <shortdesc>The concepts described below are critical for a full understanding of conditional
+        processing.</shortdesc>
+    <body>
+        <dl>
+            <dlentry>
+                <dt>conditional processing</dt>
+                <dd>A process that determines whether content is rendered, excluded, or flagged
+                    based on the comparison of metadata attributes in the DITA source with rules set
+                    in one or more DITAVAL documents.</dd>
+            </dlentry>
+            <dlentry>
+                <dt>conditional processing attribute</dt>
+                <dd>DITA defines attributes that can be used to enable filtering and flagging
+                    individual elements. Those attributes include <ph
+                        conkeyref="reuse-general/propsAndSpecializations"/><p>In addition, the
+                            <xmlatt>rev</xmlatt> attribute is intended to enable flagging, but is
+                        not intended to enable filtering.</p></dd>
+            </dlentry>
+            <dlentry>
+                <dt>conditional processing profile</dt>
+                <dd>One or more DITAVAL documents used by a processor when rendering a set of DITA
+                    content.</dd>
+            </dlentry>
+            <dlentry>
+                <dt>DITAVAL document</dt>
+                <dd>A set of rules that defines which elements to include, exclude, or
+                        flag.<draft-comment author="rodaande" audience="spec-editors"
+                        time="18 March 2022">Do we need to / should we state here that this can be a
+                        file on the file system, a set of rules in memory, or any other way of
+                        storing filtering information that can be expressed using DITAVAL
+                        syntax?</draft-comment></dd>
+            </dlentry>
+            <dlentry>
+                <dt>filtering</dt>
+                <dd>Excluding content from processing or rendering, such as excluding a paragraph
+                    from a topic or a excluding a branch of topic references from a map.</dd>
+            </dlentry>
+            <dlentry>
+                <dt>flagging</dt>
+                <dd>Including extra text, images, or other formatting when rendering content.</dd>
+            </dlentry>
+        </dl>
+        <p>Processors <term outputclass="RFC-2119">SHOULD</term> be able to perform filtering and
+            flagging using the following attributes: <xmlatt>props</xmlatt>,
+                <xmlatt>audience</xmlatt>, <xmlatt>deliveryTarget</xmlatt>,
+                <xmlatt>platform</xmlatt>, <xmlatt>product</xmlatt>, and
+            <xmlatt>otherprops</xmlatt>.</p>
+        <p>The <xmlatt>props</xmlatt> attribute can be specialized to create new attributes, and
+            processors <term outputclass="RFC-2119">SHOULD</term> be able to perform conditional
+            processing on specializations of <xmlatt>props</xmlatt>.</p>
+    </body>
+</topic>

--- a/specification/archSpec/base/aboutconditionalprocessing.dita
+++ b/specification/archSpec/base/aboutconditionalprocessing.dita
@@ -22,8 +22,14 @@
             </dlentry>
             <dlentry>
                 <dt>conditional processing profile</dt>
-                <dd>One or more DITAVAL documents used by a processor when rendering a set of DITA
-                    content.</dd>
+                <dd>A set of rules provided to a processor when rendering content, based on one or
+                    more DITAVAL documents.<draft-comment author="rodaande" time="21 March 2022">I'm
+                        not certain "conditional processing profile" warrants a separate definition.
+                        I added it after going through some of the following topics, and seeing a
+                        distinctions between a DITAVAL document and a [set of conditions sent as
+                        input to a processor] – for example, DITA-OT or an editor can apply
+                        conditions from multiple DITAVAL documents as a single conditional
+                        processing profile.</draft-comment></dd>
             </dlentry>
             <dlentry>
                 <dt>DITAVAL document</dt>
@@ -52,5 +58,8 @@
         <p>The <xmlatt>props</xmlatt> attribute can be specialized to create new attributes, and
             processors <term outputclass="RFC-2119">SHOULD</term> be able to perform conditional
             processing on specializations of <xmlatt>props</xmlatt>.</p>
+        <p>Although metadata elements exist with similar names, such as the
+                <xmlelement>audience</xmlelement> element, the specification does not define any
+            mechanism for conditional processing using metadata elements.</p>
     </body>
 </topic>

--- a/specification/archSpec/base/aboutditavaldocuments.dita
+++ b/specification/archSpec/base/aboutditavaldocuments.dita
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="aboutditavaldocuments">
+    <title>About the DITAVAL document</title>
+    <shortdesc>A DITAVAL document specifies a set of rules that defines which elements to include,
+        exclude, or flag.</shortdesc>
+    <body>
+        <p>The markup for DITAVAL documents provides a standard way to define all conditional
+            processing associated with the DITA specification.</p>
+        <p>Each rule in a DITAVAL document does one of the following:<ul id="ul_z3h_cs5_xsb">
+                <li>Defines a rendering behavior for an attribute / value pair, such
+                        <codeph>audience="novice"</codeph>.</li>
+                <li>Defines a default behavior for a conditional processing attribute, such as
+                    defining a default rendering behavior of <keyword>exclude</keyword> for the
+                        <xmlatt>deliveryTarget</xmlatt>. With that default, any
+                        <xmlatt>deliveryTarget</xmlatt> value not otherwise defined in the document
+                    uses that default behavior of <keyword>exclude</keyword>.</li>
+                <li>Defines a default behavior for <b>all</b> conditional processing attributes,
+                    such as defining a default rendering behavior of <keyword>exclude</keyword>.
+                    With that default, any attribute or attribute value not otherwise defined in the
+                    document uses that default behavior of <keyword>exclude</keyword>.</li>
+            </ul></p>
+        <p>While the DITAVAL markup is not part of the DITA topic or map vocabulary (and cannot be
+            specialized), the XML itself is part of the specification; see <xref
+                href="../../langRef/containers/ditaval-elements.dita"/> for details.</p>
+    </body>
+</topic>

--- a/specification/archSpec/base/conditional-processing-and-subject-schemes.dita
+++ b/specification/archSpec/base/conditional-processing-and-subject-schemes.dita
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="usage-of-conditional-processing-attributes" >
+  <title>Conditional processing and subject schemes</title>
+  <shortdesc>When a subject scheme defines controlled values for an attribute, a processor can make
+    use of that scheme for conditional processing.</shortdesc>
+  <conbody>
+    <draft-comment author="rodaande" audience="spec-editors" time="21 March 2022">Not sure if need
+      this topic. Started to fill in info but it would cover exactly what is in <xref
+        href="processing-controlled-attribute-values.dita"/> … don't want to duplicate information,
+      especially normative rules.</draft-comment>
+    <p/>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/conditonal-processing.ditamap
+++ b/specification/archSpec/base/conditonal-processing.ditamap
@@ -6,11 +6,18 @@
   <topicref href="aboutconditionalprocessing.dita"/>
   <topicref href="aboutditavaldocuments.dita"/>
   <topicref href="usage-of-conditional-processing-attributes.dita"/>
+  <topicref href="usage-of-conditional-processing-attribute-groups.dita"/>
+  <topicref href="conditional-processing-and-subject-schemes.dita"/>
   <topicref href="filtering.dita"/>
   <topicref href="flagging.dita"/>
   <topicref href="examples-of-conditional-processing.dita">
    <topicref href="example-setting-condproc-values.dita"/>
+   <topicref href="example-simple-ditaval.dita"/>
+   <topicref href="example-ditaval-default-exclude.dita"/>
+   <topicref href="example-flagging-outputclass.dita"/>
+   <topicref href="example-ditaval-groups.dita"/>
    <topicref href="evaluating-conditional-processing-attributes.dita"/>
+   <topicref href="example-ditaval-subjectscheme.dita"/>
       <topicref href="example-ditaval-with-conditions-for-groups.dita"/>
   </topicref>
  </topicref>

--- a/specification/archSpec/base/conditonal-processing.ditamap
+++ b/specification/archSpec/base/conditonal-processing.ditamap
@@ -3,10 +3,11 @@
 <map>
  <title>Conditional processing</title>
  <topicref href="condproc.dita" keys="conditional-processing">
+  <topicref href="aboutconditionalprocessing.dita"/>
+  <topicref href="aboutditavaldocuments.dita"/>
   <topicref href="usage-of-conditional-processing-attributes.dita"/>
   <topicref href="filtering.dita"/>
   <topicref href="flagging.dita"/>
-  <topicref href="conditional-processing-for-specific-output-types.dita"/>
   <topicref href="examples-of-conditional-processing.dita">
    <topicref href="example-setting-condproc-values.dita"/>
    <topicref href="evaluating-conditional-processing-attributes.dita"/>

--- a/specification/archSpec/base/condproc.dita
+++ b/specification/archSpec/base/condproc.dita
@@ -3,17 +3,9 @@
  "concept.dtd">
 <concept id="condproc" xml:lang="en-us">
     <title>Conditional processing (profiling)</title>
-    <shortdesc><ph
-conkeyref="reuse-general/conditional-processing-shortdesc"/></shortdesc>
+    <shortdesc><ph conkeyref="reuse-general/conditional-processing-shortdesc"/> Conditional
+        processing in DITA is based on metadata attributes in the DITA source.</shortdesc>
     <conbody>
-        <draft-comment author="rodaande" time="18 march 2022">The second sentence in the following
-            paragraph is a carry-over from old spec. I wonder if it's better to rephrase from
-            "processors are not required..." to something like "The specification does not define a
-            mechanism for conditional processing based on metadata elements."</draft-comment>
-        <p>Conditional processing in DITA is based on metadata attributes in the DITA source.
-            Although metadata elements exist with similar names, such as the
-                <xmlelement>audience</xmlelement> element, processors are not required to perform
-            conditional processing using metadata elements.</p>
     <draft-comment author="Kristen J Eberlein" time="13 March 2022">
       <p>The following content was in the container topic for the DITAVAL
         elements. I think it should be edited, rephrased as a normative

--- a/specification/archSpec/base/condproc.dita
+++ b/specification/archSpec/base/condproc.dita
@@ -6,21 +6,14 @@
     <shortdesc><ph
 conkeyref="reuse-general/conditional-processing-shortdesc"/></shortdesc>
     <conbody>
-<p>DITA defines attributes that can be used to enable filtering and flagging individual elements.
-<ph conkeyref="reuse-general/propsAndSpecializations"/> allow conditions to
-be assigned to elements so that the elements can be included, excluded, or flagged during
-processing. The <xmlatt>rev</xmlatt> flagging attribute allows values to be assigned to elements so
-that special formatting can be applied to those elements during processing. A conditional-processing
-profile specifies which elements to include, exclude, or flag. DITA defines a document type called
-DITAVAL for creating conditional-processing profiles.</p>
-        <p>Processors <term outputclass="RFC-2119">SHOULD</term> be able to perform filtering and
-            flagging using the following attributes:  <xmlatt>props</xmlatt>,
-                <xmlatt>audience</xmlatt>, <xmlatt>deliveryTarget</xmlatt>,
-                <xmlatt>platform</xmlatt>, <xmlatt>product</xmlatt>, and
-            <xmlatt>otherprops</xmlatt>.</p>
-        <p>The <xmlatt>props</xmlatt> attribute can be specialized to create new attributes, and
-            processors <term outputclass="RFC-2119">SHOULD</term> be able to perform conditional
-            processing on specializations of <xmlatt>props</xmlatt>.</p>
+        <draft-comment author="rodaande" time="18 march 2022">The second sentence in the following
+            paragraph is a carry-over from old spec. I wonder if it's better to rephrase from
+            "processors are not required..." to something like "The specification does not define a
+            mechanism for conditional processing based on metadata elements."</draft-comment>
+        <p>Conditional processing in DITA is based on metadata attributes in the DITA source.
+            Although metadata elements exist with similar names, such as the
+                <xmlelement>audience</xmlelement> element, processors are not required to perform
+            conditional processing using metadata elements.</p>
     <draft-comment author="Kristen J Eberlein" time="13 March 2022">
       <p>The following content was in the container topic for the DITAVAL
         elements. I think it should be edited, rephrased as a normative
@@ -29,9 +22,11 @@ DITAVAL for creating conditional-processing profiles.</p>
         attribute values encountered in content that do not have an action
         associated with them.</p>
     </draft-comment>
-        <p>Although metadata elements exist with similar names, such as the
-                <xmlelement>audience</xmlelement> element, processors are not required to perform
-            conditional processing using metadata elements. </p>
+        <draft-comment author="rodaande" time="28 March 2022">I'm less convinced it needs to be a
+            normative statement. I think it can be a helpful addition to a processor, but it can
+            also be a big annoyance. If anything about it is normative, I think it needs to be MAY,
+            allowing processors to choose whether such notification is appropriate for their use
+            cases.</draft-comment>
     </conbody>
 </concept>
 

--- a/specification/archSpec/base/evaluating-conditional-processing-attributes.dita
+++ b/specification/archSpec/base/evaluating-conditional-processing-attributes.dita
@@ -2,8 +2,8 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="evaluating-conditional-processing-attributes">
  <title>Example: Filtering and flagging topic content</title>
- <shortdesc>A publisher might want to flag information that applies to administrators and exclude
-    information that applies to the extended product.</shortdesc>
+ <shortdesc>In this scenario, a publisher wants to flag information that applies to administrators
+    and exclude information that applies to the extended product.</shortdesc>
  <conbody>
   <p>Consider the following DITA source fragment and conditional processing profile:</p>
     <fig>
@@ -29,6 +29,8 @@
   <p>When the content is rendered, the paragraph is flagged, and the first list item is excluded
       (since it applies to extendedProd). The second list item is still included; even though it
       does apply to extendedProd, it also applies to basicProd, which was not excluded.</p>
+    <draft-comment author="rodaande" time="21 March 2022">Probably want the following bit to become
+      a screen capture</draft-comment>
   <p>The result will look something like the following: <fig>
         <p><b>ADMIN</b> Set the configuration options: <ul>
             <li>Set your blink rate</li>

--- a/specification/archSpec/base/example-ditaval-default-exclude.dita
+++ b/specification/archSpec/base/example-ditaval-default-exclude.dita
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="example-condproc-values">
+  <title>Example: Changing the default behavior to "exclude"</title>
+  <shortdesc>In this scenario, a simple DITAVAL document resets the default behavior for unspecified
+    values to "exclude".</shortdesc>
+  <conbody>
+    <p>The following code sample illustrates a simple DITAVAL document that resets the default
+      behavior to "exclude", and then defines two rules to include content.</p>
+    <codeblock>&lt;val>
+  <b>&lt;prop action="exclude"/></b>
+  &lt;prop action="include" att="audience" val="novice"/>
+  &lt;prop action="include" att="product" val="myProductPrime"/>
+&lt;/val></codeblock>
+    <p>Based on those rules:<ol id="ol_klp_n54_ysb">
+        <li>Any element with <codeph>audience="novice"</codeph> will be included and will appear in
+          the rendered content.</li>
+        <li>Any element with <codeph>product="myProductPrime"</codeph> will be included and will
+          appear in the rendered content.</li>
+        <li>All other values in conditional processing attributes evaluate to
+            <keyword>exclude</keyword>.</li>
+      </ol></p>
+    <p>As a result, any element with conditional processing attributes that do not match either
+        <codeph>audience="novice"</codeph> or <codeph>product="myProductPrime"</codeph> will be
+      filtered and will not appear in the rendered content.</p>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/example-ditaval-groups.dita
+++ b/specification/archSpec/base/example-ditaval-groups.dita
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="example_ditaval_groups">
+    <title>Example: Filtering based on groups</title>
+    <shortdesc>In this scenario, groups are used for filtering within a conditional processing
+        attribute.</shortdesc>
+    <conbody>
+        <p>The following code sample illustrates a list item that applies to two different types of
+            product. It applies to one application server and two database
+            applications:<codeblock id="groupcodesample">&lt;ol>
+  &lt;li>Common step&lt;/li>
+  &lt;li product="appServer(mySERVER) database(dbOne dbOther)">
+    &lt;ph>Do something special for databases dbTwo or dbOther when installing on mySERVER&lt;/ph>
+  &lt;/li>
+  &lt;!-- additional list items -->
+&lt;/ol></codeblock></p>
+        <p>If a publisher decides to exclude the application server <keyword>mySERVER</keyword>,
+            then the <codeph>appServer()</codeph> group evaluates to exclude. This can be done by
+            setting <codeph>product="mySERVER"</codeph> to exclude <i>or</i> by setting
+                <codeph>appServer="mySERVER"</codeph> to exclude. This means the item is excluded,
+            regardless of how the values <keyword>dbOne</keyword> or <keyword>dbOther</keyword>
+            evaluate. If a rule is specified for both <codeph>product="mySERVER"</codeph> and
+                <codeph>appServer="mySERVER"</codeph>, the rule for the more specific group name
+            "appServer" takes precedence.</p>
+        <p>Similarly, if both <keyword>dbOne</keyword> and <keyword>dbOther</keyword> evaluate to
+            exclude, then the <codeph>database()</codeph> group evaluates to exclude and the element
+            is excluded regardless of how the "mySERVER" value is set.</p>
+        <p>In more advanced usage, a DITAVAL can be used to specify a rule for a group name. For
+            example, an author could create a DITAVAL rule that sets
+                <codeph>product="database"</codeph> to "exclude". This is equivalent to setting a
+            default of "exclude" for any individual value in a <codeph>database()</codeph> group; it
+            also excludes the more common usage of "database" as a single value within the
+                <xmlatt>product</xmlatt> attribute. Thus when "myDB" appears in a
+                <codeph>database()</codeph> group within the <xmlatt>product</xmlatt> attribute, the
+            full precedence for determining whether to include or exclude the value is as
+                follows:<ol id="ol_dpb_tz4_ysb">
+                <li>Check for a DITAVAL rule for <codeph>database="dbOne"</codeph></li>
+                <li>Check for a DITAVAL rule for <codeph>product="dbOne"</codeph></li>
+                <li>Check for a DITAVAL rule for <codeph>product="database"</codeph> (default for
+                    the database group)</li>
+                <li>Check for a DITAVAL rule for "product" (default for the <xmlatt>product</xmlatt>
+                    attribute)</li>
+                <li>Check for a default rule for all conditions (default of include or exclude for
+                    all attributes)</li>
+                <li>Otherwise, evaluate to "include"</li>
+            </ol></p>
+    </conbody>
+</concept>

--- a/specification/archSpec/base/example-ditaval-subjectscheme.dita
+++ b/specification/archSpec/base/example-ditaval-subjectscheme.dita
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="example-condproc-values">
+  <title>Example: Simple DITAVAL document</title>
+  <shortdesc>A DITAVAL document can reference tokens that pull in additional topics from a subject
+    scheme.</shortdesc>
+  <conbody>
+    <draft-comment author="rodaande">Show a ditaval doc and subject scheme - for example, ditaval
+      that excludes "windows" and subject scheme that makes that cover "win2000 / winvista" etc. Or
+      maybe we should just conref in the full example from <xref
+        href="processing-controlled-attribute-values.dita"/></draft-comment>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/example-ditaval-with-conditions-for-groups.dita
+++ b/specification/archSpec/base/example-ditaval-with-conditions-for-groups.dita
@@ -2,7 +2,8 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="example-ditaval-with-conditions-for-groups">
     <title>Example: DITAVAL with conditions for groups</title>
-    <shortdesc></shortdesc>
+    <shortdesc>In this advanced scenario, grouped values are used for filtewring within a
+    conditional processing attribute.</shortdesc>
     <refbody>
     <example>
       <fig>

--- a/specification/archSpec/base/example-flagging-outputclass.dita
+++ b/specification/archSpec/base/example-flagging-outputclass.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="example-condproc-values">
+  <title>Example: Flagging with <xmlatt>outputclass</xmlatt></title>
+  <shortdesc>In this scenario, the <xmlatt>outputclass</xmlatt> attribute in a DITAVAL document is
+    used for CSS based flagging.</shortdesc>
+  <conbody>
+    <p>The following code sample illustrates a simple DITAVAL document that sets up two rules for
+      flagging using <xmlatt>outputclass</xmlatt>.</p>
+    <codeblock>&lt;val>
+  &lt;prop action="flag" att="product" val="myProduct" outputclass="myProductToken"/>
+  &lt;prop action="flag" att="product" val="myOtherProduct" outputclass="myOtherProductToken"/>
+&lt;/val></codeblock>
+    <p>Now, assume the following DITA content is processed using the rules from that DITAVAL
+      document:<codeblock>&lt;ol>
+  &lt;li>This list item applies to all content&lt;/li>
+  &lt;li product="myProduct">This list item is specific to my product&lt;/li>
+  &lt;li product="myProduct" outputclass="example">This list item is an example of an edge case&lt;/li>
+  &lt;li product="myOtherProduct">This list item is specific to my OTHER product&lt;/li>
+  &lt;li product="myProduct myOtherProduct">This list item is specific to both of my products&lt;/li>
+&lt;/ol></codeblock></p>
+    <p>Based on the rules from that DITAVAL document, the topic content is handled as follows:<ol
+        id="ol_lqn_3w4_ysb">
+        <li>The first item does not specify any conditional processing attributes, and is handled
+          normally.</li>
+        <li>The second item specifies <codeph>product="myProduct"</codeph>. Based on the DITAVAL
+          document, this results in a setting on <codeph>outputclass="myProductToken"</codeph>. The
+          content is processed as if the original element was: <codeph>&lt;li product="myProduct"
+            outputclass="myProductToken"></codeph>. A processor that uses
+            <xmlatt>outputclass</xmlatt> values for CSS based styling can now use CSS to style
+          anything flagged with this value.</li>
+        <li>The third item specifies <codeph>product="myProduct"</codeph>. Based on the DITAVAL
+          document, this results in a setting on <codeph>outputclass="myProductToken"</codeph>. The
+          content is processed as if the original element was: <codeph>&lt;li product="myProduct"
+            outputclass="myOtherProductToken example"></codeph>. The value supplied by the DITAVAL
+          document is placed before any value already in the attribute.</li>
+        <li>The fourth item specifies <codeph>product="myOtherProduct"</codeph>. Based on the
+          DITAVAL document, this results in a setting on
+            <codeph>outputclass="myOtherProductToken"</codeph>. The content is processed as if the
+          original element was: <codeph>&lt;li product="myOtherProduct"
+            outputclass="myOtherProductToken"></codeph>.</li>
+        <li>The fifth item specifies both products with <codeph>product="myProduct
+            myOtherProduct"</codeph>. Based on the DITAVAL document, this results in settings of
+            <codeph>outputclass="myProductToken"</codeph> and
+            <codeph>outputclass="myOtherProductToken</codeph>. The content is processed as if the
+          original element was: <codeph>&lt;li product="myProduct myOtherProduct"
+            outputclass="myProductToken myOtherProductToken"></codeph>. Because the order of
+          DITAVAL-based tokens is not defined, this could also result in a value of
+            <codeph>outputclass="myOtherProductToken myProductToken"</codeph></li>
+      </ol></p>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/example-setting-condproc-values.dita
+++ b/specification/archSpec/base/example-setting-condproc-values.dita
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="example-condproc-values">
-  <title>Example: Setting conditional processing values and groups</title>
-  <shortdesc >Conditional processing attributes can be used to classify content
-    using either individual values or using groups.</shortdesc>
+  <title>Example: Setting conditional processing values</title>
+  <shortdesc>In this scenario, conditional processing attributes are set in DITA
+    content.</shortdesc>
   <conbody>
-    <example id="example" otherprops="examples">
-      <title>Example: Simple product values</title>
-      <p>In the following example, the first configuration option applies only to the "extendedProd"
-        product, while the second option applies to both "extendedProd" and to "baseProd". The
-        entire <xmlelement>p</xmlelement> element containing the list applies to an audience of
-        "administrator".</p>
-      <codeblock>&lt;p audience="administrator">Set the configuration options:
+    <p>The following code sample illustrates how conditional processing attributes are set in DITA
+      content.<codeblock>&lt;p audience="administrator">Set the configuration options:
   &lt;ul>
     &lt;li product="extendedProd">Set foo to bar&lt;/li>
     &lt;li product="basicProd extendedProd">Set your blink rate&lt;/li>
@@ -19,20 +14,17 @@
     &lt;li>Do a special thing for Linux&lt;/li>
   &lt;/ul>
 &lt;/p>
-</codeblock>
-    </example>
-    <example id="groupexample"  otherprops="examples">
-      <title>Example: Grouped values on an attribute</title>
-      <p>The following example indicates that a step applies to one application server and two
-        databases. Specifically, this step only applies when it is taken on the server "mySERVER";
-        likewise, it only applies when used with the databases "ABC" or "dbOtherName". </p>
-      <codeblock id="groupcodesample">&lt;steps>
-  &lt;step>&lt;cmd>Common step&lt;/cmd>&lt;/step>
-  &lt;step product="appserver(mySERVER) database(ABC dbOtherName)">
-    &lt;cmd>Do something special for databases ABC or OtherName when installing on mySERVER&lt;/cmd>
-  &lt;/step>
-  &lt;!-- additional steps -->
-&lt;/steps></codeblock>
-    </example>
+</codeblock></p>
+    <p>In the example, <ul id="ul_jg5_k1p_ysb">
+        <li>The entire paragraph and list of options applies to an audience of
+            <keyword>administrator</keyword>.</li>
+        <li>The first configuration item applies only to the <keyword>extendedProd</keyword>
+          product.</li>
+        <li>The second configuration option applies to both the <keyword>baseProd</keyword> and
+            <keyword>extendedProd</keyword> products.</li>
+      </ul>
+    </p>
+    <p>When combined with a DITAVAL document, these attributes can be used as a way to filter or
+      flag the content when it is rendered.</p>
   </conbody>
 </concept>

--- a/specification/archSpec/base/example-simple-ditaval.dita
+++ b/specification/archSpec/base/example-simple-ditaval.dita
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="example-condproc-values">
+  <title>Example: Simple DITAVAL document</title>
+  <shortdesc>In this scenario, a simple DITAVAL document sets up rules for filtering and flagging
+    based on conditional processing attributes.</shortdesc>
+  <conbody>
+    <p>The following code sample illustrates a simple DITAVAL document that sets up two rules for
+      filtering, and two rules for flagging.</p>
+    <codeblock>&lt;val>
+  &lt;prop action="exclude" att="audience" val="advanced"/>
+  &lt;prop action="exclude" att="product" val="myProductPrime"/>
+  &lt;prop action="flag" att="product" val="myProduct" backcolor="purple"/>
+  &lt;revprop action="flag" val="v1.2" backcolor="yellow"/>
+&lt;/val></codeblock>
+    <p>Based on those rules:<ol id="ol_klp_n54_ysb">
+        <li>Any element with <codeph>audience="advanced"</codeph> will be filtered and will not
+          appear in the rendered content.</li>
+        <li>Any element with <codeph>product="myProductPrime"</codeph> will be filtered and will not
+          appear in the rendered content.</li>
+        <li>Any element with <codeph>product="myProduct"</codeph> will be flagged with a purple
+          background color.</li>
+        <li>Any element with <codeph>rev="v1.2"</codeph> will be flagged with a yellow background
+          color.</li>
+        <li>All other content will be rendered normally, because any other conditional processing
+          attribute values default to <keyword>include</keyword>.</li>
+      </ol></p>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/filtering.dita
+++ b/specification/archSpec/base/filtering.dita
@@ -42,48 +42,10 @@ attribute is treated as "include", because an omitted attribute cannot evaluate 
    <li>If <b>any single attribute</b> evaluates to <keyword>exclude</keyword>, the element is
     filtered.</li>
   </ol>
-  <!--<draft-comment author="Kristen Eberlein" time="8 February 2014">We need to make this wording more precise and less ambiguous. Is the following content what was intended?<ul><li>(For an attribute with a single value) If the attribute value is set to "exclude", the element is excluded.</li><li>(For an attribute with multiple values) If all the attribute values are set to "exclude", the element is excluded</li><li>(For an attribute with a single group of values) If all the attribute values in the group are set to "exclude", the element is excluded.</li></ul>I'm not sure I understand what is meant by "When deciding whether to include or exclude a particular element, a processor should evaluate each attribute, and then evaluate the set of attributes." What's the difference between evaluating each attribute and evaluating a set of attributes?</draft-comment><draft-comment author="robander" time="21 April 2014">I think that is resolved now. I've tweaked the wording a bit - the list in the previous draft comment was not correct.</draft-comment>-->
   <p>For example, if a paragraph applies to three products and the publisher has chosen to exclude
    all of them, the processor will exclude the paragraph. This is true even if the paragraph applies
    to an audience or platform that is not excluded. But if the paragraph applies to an additional
    product that has not been excluded, then its content is still relevant for the intended output
    and is preserved.</p>
-  <draft-comment author="rodaande" time="2021-09-14">Think maybe we should probably rework the
-   example below to not use steps, given that the steps element is not part of the base
-   spec?</draft-comment>
-  <p>Similarly, with groups, a step might apply to one application server and two database
-   applications:<codeblock id="groupcodesample">&lt;steps>
-  &lt;step>&lt;cmd>Common step&lt;/cmd>&lt;/step>
-  &lt;step product="appServer(mySERVER) database(ABC dbOtherName)">
-    &lt;cmd>Do something special for databases ABC or OtherName when installing on mySERVER&lt;/cmd>
-  &lt;/step>
-  &lt;!-- additional steps -->
-&lt;/steps></codeblock></p>
-  <p>If a publisher decides to exclude the application server mySERVER, then the appServer() group
-   evaluates to exclude. This can be done by setting <codeph>product="mySERVER"</codeph> to exclude
-    <i>or</i> by setting <codeph>appServer="mySERVER"</codeph> to exclude. This means the step is
-   excluded, regardless of how the values "ABC" or "dbOtherName" evaluate. If a rule is specified
-   for both <codeph>product="mySERVER"</codeph> and <codeph>appServer="mySERVER"</codeph>, the rule
-   for the more specific group name "appServer" takes precedence.</p>
-  <p>Similarly, if both "ABC" and "dbOtherName" evaluate to exclude, then the database() group
-   evaluates to exclude and the element is excluded regardless of how the "mySERVER" value is
-   set.</p>
-  <p>In more advanced usage, a DITAVAL can be used to specify a rule for a group name. For example,
-   an author could create a DITAVAL rule that sets <codeph>product="database"</codeph> to "exclude".
-   This is equivalent to setting a default of "exclude" for any individual value in a database()
-   group; it also excludes the more common usage of "database" as a single value within the
-    <xmlatt>product</xmlatt> attribute. Thus when "myDB" appears in a database() group within the
-    <xmlatt>product</xmlatt> attribute, the full precedence for determining whether to include or
-   exclude the value is as follows:<ol>
-    <li>Check for a DITAVAL rule for <codeph>database="myDB"</codeph></li>
-    <li>Check for a DITAVAL rule for <codeph>product="myDB"</codeph></li>
-    <li>Check for a DITAVAL rule for <codeph>product="database"</codeph> (default for the database
-     group)</li>
-    <li>Check for a DITAVAL rule for "product" (default for the <xmlatt>product</xmlatt>
-     attribute)</li>
-    <li>Check for a default rule for all conditions (default of include or exclude for all
-     attributes)</li>
-    <li>Otherwise, evaluate to "include"</li>
-   </ol></p>
  </conbody>
 </concept>

--- a/specification/archSpec/base/filtering.dita
+++ b/specification/archSpec/base/filtering.dita
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="filtering">
- <title>Filtering</title>
- <shortdesc>At processing time, a conditional processing profile can be used to specify profiling
-  attribute values that determine whether an element with those values is included or
-  excluded.</shortdesc>
+ <title>Filtering based on metadata attributes</title>
+ <shortdesc>When rendering content, a conditional processing profile can be used to specify whether
+  an element's content is filtered based on its conditional processing attributes.</shortdesc>
  <conbody>
-  <p>By default, values in conditional processing attributes that are not defined in a DITAVAL
-   profile evaluate to "include". For example, if the value audience="novice" is used on a
-   paragraph, but this value is not defined in a DITAVAL profile, the attribute evaluates to
-   "include".</p>
-  <p>However, the DITAVAL profile can change this default to "exclude", so that any value not
-   explicitly defined in the DITAVAL profile will evaluate to "exclude". The DITAVAL profile also
-   can be used to change the default for a single attribute; for example, it can declare that values
-   in the <xmlatt>platform</xmlatt> attribute default to "exclude", while those in the
-    <xmlatt>product</xmlatt> attribute default to include. See <xref
-    href="../../langRef/containers/ditaval-elements.dita"/> for information on how to set up a
-   DITAVAL profile and how to change default behaviors.</p>
+  <p>To determine whether content is filtered, a processor compares the conditional processing
+   attributes on a DITA element to rules specified in a conditional processing profile. If any one
+   of the conditional processing attributes evaluates as <keyword>exclude</keyword>, that content is
+   filtered.</p>
+  <p>Within a DITAVAL document, it is possible to specify a default action for conditional
+   processing attributes. When no default is specified, the processing default for any attribute or
+   value not otherwise listed is <keyword>include</keyword>. <ph otherprops="examples">For example,
+    if no default action is provided for <xmlatt>audience</xmlatt> and the value
+     <keyword>novice</keyword> for that attribute is not defined, that attribute value will have a
+    processing default of <keyword>include</keyword>.</ph></p>
   <p>When deciding whether to include or exclude a particular element, a processor evaluates each
    attribute independently:</p>
   <ol>
@@ -24,21 +22,25 @@
 <li >If the attribute is empty, or contains only empty groups, it is equivalent
 to omitting the attribute from the element. If evaluated for the purposes of filtering, the
 attribute is treated as "include", because an omitted attribute cannot evaluate to "exclude".</li>
-     <li>If the attribute value does not contain any groups, then if any token in the attribute
-      value evaluates to "include", the element evaluates to "include"; otherwise it evaluates to
-      "exclude". In other words, the attribute evaluates to "exclude" only when <b>all</b> the
-      values in that attribute evaluate to "exclude".</li>
-     <li >If the attribute value does include groups, evaluate as
-      follows, treating ungrouped tokens together as a group: <ol>
-       <li>For each group (including the group of ungrouped tokens), if any token inside the group
-        evaluates to "include", the group evaluates to "include"; otherwise it evaluates to
-        "exclude". In other words, a group evaluates to "exclude" only when every token in that
-        group evaluates to "exclude".</li>
-       <li>If any group within an attribute evaluates to "exclude", that attribute evaluates to
-        "exclude"; otherwise it evaluates to "include".</li>
+     <li>If the attribute value does not contain any groups, then if any string token in the
+      attribute value evaluates to <keyword>include</keyword>, the element evaluates to
+       <keyword>include</keyword>. In other words, the attribute evaluates to
+       <keyword>exclude</keyword> only when <b>all</b> string tokens in that attribute evaluate to
+       <keyword>exclude</keyword>.</li>
+     <li>If the attribute value does include groups, evaluate as follows, treating ungrouped tokens
+      together as an implicit group:<ol>
+       <li>For each group (including any implicit group), if any string token inside the group
+        evaluates to <keyword>include</keyword>, the group evaluates to <keyword>include</keyword>.
+        In other words, a group evaluates to <keyword>exclude</keyword> only when <b>all</b> string
+        tokens in that group evaluate to <keyword>exclude</keyword>.</li>
+       <li>If any group within an attribute evaluates to <keyword>exclude</keyword>, that attribute
+        evaluates to <keyword>exclude</keyword>. In other words, the attribute evaluates to
+         <keyword>include</keyword> only when <b>all</b> groups in that attribute evaluate to
+         <keyword>include</keyword>.</li>
       </ol></li>
     </ul></li>
-   <li>If <b>any single attribute</b> evaluates to exclude, the element is excluded.</li>
+   <li>If <b>any single attribute</b> evaluates to <keyword>exclude</keyword>, the element is
+    filtered.</li>
   </ol>
   <!--<draft-comment author="Kristen Eberlein" time="8 February 2014">We need to make this wording more precise and less ambiguous. Is the following content what was intended?<ul><li>(For an attribute with a single value) If the attribute value is set to "exclude", the element is excluded.</li><li>(For an attribute with multiple values) If all the attribute values are set to "exclude", the element is excluded</li><li>(For an attribute with a single group of values) If all the attribute values in the group are set to "exclude", the element is excluded.</li></ul>I'm not sure I understand what is meant by "When deciding whether to include or exclude a particular element, a processor should evaluate each attribute, and then evaluate the set of attributes." What's the difference between evaluating each attribute and evaluating a set of attributes?</draft-comment><draft-comment author="robander" time="21 April 2014">I think that is resolved now. I've tweaked the wording a bit - the list in the previous draft comment was not correct.</draft-comment>-->
   <p>For example, if a paragraph applies to three products and the publisher has chosen to exclude

--- a/specification/archSpec/base/flagging.dita
+++ b/specification/archSpec/base/flagging.dita
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="flagging">
- <title>Flagging</title>
- <shortdesc>Flagging is the application of text, images, or formatting
-    during rendering. Flagging can highlight the fact that content applies
-    to a specific audience or operating system, for example. Flagging can
-    also draw a reader's attention to content that has been marked as being
-    revised.</shortdesc>
+ <title>Flagging based on metadata attributes</title>
+ <shortdesc>When rendering content, a conditional processing profile can be used to specify whether
+  an element's content is flagged based on its conditional processing
+  attributes.<!--Flagging is the application of text, images, or formatting during rendering. --></shortdesc>
  <conbody>
-  <p>At processing time, a conditional processing profile can be used to specify profiling attribute
-   values that determine whether an element with those values is flagged.</p>
+  <p otherprops="examples">For example, flagging can be used to highlight the fact that content
+   applies to a specific audience or operating system. Flagging can also draw a reader's attention
+   to content that has been marked as being revised.</p>
   <p>When deciding whether to flag a particular element, a processor evaluates each value. Wherever
    an attribute value that has been set as flagged appears (for example,
     <codeph>audience="administrator"</codeph>), the processor adds the flag. When multiple flags

--- a/specification/archSpec/base/usage-of-conditional-processing-attribute-groups.dita
+++ b/specification/archSpec/base/usage-of-conditional-processing-attribute-groups.dita
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept xml:lang="en-us" id="usage-of-conditional-processing-attributes" >
+  <title>Conditional processing attribute values with groups</title>
+  <shortdesc>For more advanced needs, groups can be used to organize metadata into subcategories
+    within a conditional processing attribute.</shortdesc>
+  <conbody>
+    <p>Grouped values are intended to support situations where a metadata attribute applies to
+      multiple specialized subcategories. <ph otherprops="examples">For example, if content is
+        classified into two distinct types of product, those distinct types can become named groups
+        within the <xmlatt>product</xmlatt> attribute.</ph> The grouping syntax exactly matches the
+      syntax used for generalized attributes, making it valid inside <ph
+        conkeyref="reuse-general/propsAndSpecializations"/>.</p>
+<p>The following rules apply to groups within conditional processing attributes:</p>
+    <ul >
+      <li>Groups consist of a name immediately followed by a parenthetical group of zero or more
+        space-delimited string values. For example, <codeph>"groupName(valueOne
+        valueTwo)"</codeph>.</li>
+      <li>Groups cannot be nested.</li>
+      <li>If two groups with the same name are found in a single attribute, they are treated as if
+        all values are specified in the same group. The following values for the
+          <xmlatt>otherprops</xmlatt> attribute are
+        equivalent:<codeblock>otherprops="groupA(a b) groupA(c) groupZ(APPNAME)"
+otherprops="groupA(a b c) groupZ(APPNAME)"</codeblock></li>
+      <li>If both grouped values and ungrouped values are found in a single attribute, the ungrouped
+        values belong to an implicit group; the name of that group matches the name of the
+        attribute. Therefore, the following values for the <xmlatt>product</xmlatt> attribute are
+        equivalent:
+        <codeblock>product="a database(dbA dbB) b appserver(mySERVER) c"
+product="product(a b c) database(dbA dbB) appserver(mySERVER)"</codeblock></li>
+    </ul>
+    <p>An empty group within an attribute is equivalent to omitting that group from the attribute.
+      For example, <codeph>&lt;ph product="database() A"></codeph> is equivalent to <codeph>&lt;ph
+        product="A"></codeph>. Similarly, <codeph>&lt;ph product="operatingSystem()"></codeph> is
+      equivalent to <codeph>&lt;ph product=""></codeph>, which in turn is equivalent to
+        <codeph>&lt;ph></codeph>.</p>
+    <p>If two groups with the same name exist on different attributes, a rule specified for that
+      group will evaluate the same way on each attribute. For example, if the group "sample" is
+      specified within both <xmlatt>platform</xmlatt> and <xmlatt>otherprops</xmlatt>, a DITAVAL
+      rule for <codeph>sample="value"</codeph> will evaluate the same in each attribute.
+      <!--Subject schemes can be used to define a group differently for two different attributes, but for the purposes of DITAVAL filtering or flagging, there is no way to distinguish.-->
+      If there is a need to distinguish between similarly named groups on different attributes, the
+      best practice is to use more specific group names such as <varname>platformGroupname</varname>
+      and <varname>productGroupname</varname>. Alternatively, DITAVAL rules can be specified based
+      on the attribute name rather than the group name.</p>
+    <p>If the same group name is used in different attributes, a complex scenario could be created
+where different defaults are specified for different attributes, with no rule set for a group or
+individual value. In this case a value might end up evaluating differently in the different
+attributes. For example, a DITAVAL can set a default of "exclude" for <xmlatt>platform</xmlatt> and
+a default of "flag" for <xmlatt>product</xmlatt>. If no rules are specified for group
+<codeph>oddgroup()</codeph>, or for the value <codeph>oddgroup="edgecase"</codeph>, the attribute
+<codeph>platform="oddgroup(edgecase)"</codeph> will evaluate to "exclude" while
+<codeph>product="oddgroup(edgecase)"</codeph> will resolve to "flag". See <xref
+href="../../langRef/containers/ditaval-elements.dita"/> for information on how to change default
+behaviors in DITAVAL profile.</p>
+  </conbody>
+</concept>

--- a/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
+++ b/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
@@ -5,60 +5,14 @@
   <shortdesc>Conditional processing attributes classify elements with metadata. The metadata is
     specified using space-delimited string values or grouped values.</shortdesc>
   <conbody>
+    <draft-comment author="rodaande" time="21 March 2022">Need to rework the short description to
+      avoid confusing this with classification, per call with Kris</draft-comment>
     <p>The simplest and most common way to specify metadata on a conditional processing attribute is
       using individual string values. <ph otherprops="examples">For example, the values
           <keyword>basic</keyword> and <keyword>deluxe</keyword> within <codeph>&lt;p product="basic
           deluxe"></codeph> indicate that the paragraph applies to the basic and deluxe
         products.</ph></p>
-    <p>For more advanced needs, groups can be used to organize metadata into subcategories within an
-      attribute. This is intended to support situations where a predefined metadata attribute
-      applies to multiple specialized subcategories. <ph otherprops="examples">For example, if
-        content is classified into two distinct types of product, those distinct types can become
-        named groups within the <xmlatt>product</xmlatt> attribute.</ph> The grouping syntax exactly
-      matches the syntax used for generalized attributes, making it valid inside <ph
-        conkeyref="reuse-general/propsAndSpecializations"/>.</p>
-<p>The following rules apply to groups within conditional processing attributes:</p>
-    <ul >
-      <li>Groups consist of a name immediately followed by a parenthetical group of zero or more
-        space-delimited string values. For example, <codeph>"groupName(valueOne
-        valueTwo)"</codeph>.</li>
-      <li>Groups cannot be nested.</li>
-      <li>If two groups with the same name are found in a single attribute, they are treated as if
-        all values are specified in the same group. The following values for the
-          <xmlatt>otherprops</xmlatt> attribute are
-        equivalent:<codeblock>otherprops="groupA(a b) groupA(c) groupZ(APPNAME)"
-otherprops="groupA(a b c) groupZ(APPNAME)"</codeblock></li>
-      <li>If both grouped values and ungrouped values are found in a single attribute, the ungrouped
-        values belong to an implicit group; the name of that group matches the name of the
-        attribute. Therefore, the following values for the <xmlatt>product</xmlatt> attribute are
-        equivalent:
-        <codeblock>product="a database(dbA dbB) b appserver(mySERVER) c"
-product="product(a b c) database(dbA dbB) appserver(mySERVER)"</codeblock></li>
-    </ul>
-    <p >Setting a conditional processing attribute to an empty value,
-      such as <codeph>product=""</codeph>, is equivalent to omitting that attribute from the
-      element. An empty group within an attribute is equivalent to omitting that group from the
-      attribute. For example, <codeph>&lt;ph product="database() A"></codeph> is equivalent to
-        <codeph>&lt;ph product="A"></codeph>. Combining both rules into one example, <codeph>&lt;ph
-        product="operatingSystem()"></codeph> is equivalent to <codeph>&lt;ph></codeph>.</p>
-    <p>If two groups with the same name exist on different attributes, a rule specified for that
-      group will evaluate the same way on each attribute. For example, if the group "sample" is
-      specified within both <xmlatt>platform</xmlatt> and <xmlatt>otherprops</xmlatt>, a DITAVAL
-      rule for <codeph>sample="value"</codeph> will evaluate the same in each attribute.
-      <!--Subject schemes can be used to define a group differently for two different attributes, but for the purposes of DITAVAL filtering or flagging, there is no way to distinguish.-->
-      If there is a need to distinguish between similarly named groups on different attributes, the
-      best practice is to use more specific group names such as <varname>platformGroupname</varname>
-      and <varname>productGroupname</varname>. Alternatively, DITAVAL rules can be specified based
-      on the attribute name rather than the group name.</p>
-    <p>If the same group name is used in different attributes, a complex scenario could be created
-where different defaults are specified for different attributes, with no rule set for a group or
-individual value. In this case a value might end up evaluating differently in the different
-attributes. For example, a DITAVAL can set a default of "exclude" for <xmlatt>platform</xmlatt> and
-a default of "flag" for <xmlatt>product</xmlatt>. If no rules are specified for group
-<codeph>oddgroup()</codeph>, or for the value <codeph>oddgroup="edgecase"</codeph>, the attribute
-<codeph>platform="oddgroup(edgecase)"</codeph> will evaluate to "exclude" while
-<codeph>product="oddgroup(edgecase)"</codeph> will resolve to "flag". See <xref
-href="../../langRef/containers/ditaval-elements.dita"/> for information on how to change default
-behaviors in DITAVAL profile.</p>
+    <p>Setting a conditional processing attribute to an empty value, such as
+        <codeph>product=""</codeph>, is equivalent to omitting that attribute from the element. </p>
   </conbody>
 </concept>

--- a/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
+++ b/specification/archSpec/base/usage-of-conditional-processing-attributes.dita
@@ -1,27 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="usage-of-conditional-processing-attributes" >
-  <title>Conditional processing values and groups</title>
+  <title>Conditional processing attribute values</title>
   <shortdesc>Conditional processing attributes classify elements with metadata. The metadata is
-    specified using space-delimited string values <ph >or grouped
-      values.</ph></shortdesc>
+    specified using space-delimited string values or grouped values.</shortdesc>
   <conbody>
-    <p otherprops="examples">For example, the string values within <xmlatt>product</xmlatt> in
-<codeph>&lt;p product="basic deluxe"></codeph> indicate that the paragraph applies to the
-<q>basic</q> product and to the <q>deluxe</q> product. </p>
-<p>Groups can be used to organize classification metadata into subcategories. This is intended to
-support situations where a predefined metadata attribute applies to multiple specialized
-subcategories. The grouping syntax exactly matches the syntax used for generalized attributes,
-making it valid inside <ph conkeyref="reuse-general/propsAndSpecializations"
-/>.</p>
-<p otherprops="examples"> For example, the <xmlatt>product</xmlatt> attribute can be used to
-classify an element based on both related databases and related application servers. Using groups
-for these subcategories allows each category to be processed independently; when filter conditions
-exclude all applicable databases within a group, the element can be safely excluded, regardless of
-any other <xmlatt>product</xmlatt> conditions.</p>
-<p>Groups can be used within <ph
-conkeyref="reuse-general/propsAndSpecializations"/>. The following rules
-apply:</p>
+    <p>The simplest and most common way to specify metadata on a conditional processing attribute is
+      using individual string values. <ph otherprops="examples">For example, the values
+          <keyword>basic</keyword> and <keyword>deluxe</keyword> within <codeph>&lt;p product="basic
+          deluxe"></codeph> indicate that the paragraph applies to the basic and deluxe
+        products.</ph></p>
+    <p>For more advanced needs, groups can be used to organize metadata into subcategories within an
+      attribute. This is intended to support situations where a predefined metadata attribute
+      applies to multiple specialized subcategories. <ph otherprops="examples">For example, if
+        content is classified into two distinct types of product, those distinct types can become
+        named groups within the <xmlatt>product</xmlatt> attribute.</ph> The grouping syntax exactly
+      matches the syntax used for generalized attributes, making it valid inside <ph
+        conkeyref="reuse-general/propsAndSpecializations"/>.</p>
+<p>The following rules apply to groups within conditional processing attributes:</p>
     <ul >
       <li>Groups consist of a name immediately followed by a parenthetical group of zero or more
         space-delimited string values. For example, <codeph>"groupName(valueOne


### PR DESCRIPTION
In-progress (not ready for merging) updates to conditional processing section.

* Make the container into an actual container
* New lead-in topic for the section about core concepts - define our terms, filtering, flagging, etc
* New topic to describe DITAVAL documents
* Rework the "conditional processing values and groups" to focus on syntax of the attributes
* Edits to filtering, flagging topics
* Remove "multiple deliverable types" topic, which could be an example but doesn't need to be a topic

Still to do: some editing not quite complete but most remaining work is around examples - creating new ones, and moving extended examples from the content topics into new example topics