### PR TITLE
Fix attribute list, per dita-ot/dita-ot#3905

### DIFF
--- a/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -60,6 +60,9 @@
 >
 <!ENTITY % change-historylist.attributes
               "%univ-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED
                mapkeyref
                           CDATA
                                     #IMPLIED"

--- a/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -113,6 +113,9 @@ PUBLIC "-//OASIS//ENTITIES DITA Release Management Domain//EN"
         <optional>
           <attribute name="mapkeyref"/>
         </optional>
+        <optional>
+          <attribute name="outputclass"/>
+        </optional>
       </define>
       <define name="change-historylist.element">
         <element name="change-historylist" dita:longName="Change History List"

--- a/doctypes/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/doctypes/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
@@ -134,6 +134,7 @@
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
       <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="outputclass" type="xs:string"/>
       <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>

--- a/doctypes/schema/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/doctypes/schema/technicalContent/xsd/releaseManagementDomain.xsd
@@ -134,6 +134,7 @@
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
       <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="outputclass" type="xs:string"/>
       <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>


### PR DESCRIPTION
As noted in this ticket - https://github.com/dita-ot/dita-ot/issues/3905

The following commit fixed the attribute list for change history list, but it introduced its own issue; univ-atts has `@outputclass` in DITA 2.0, but not in 1.3, so swapping the old entity for univ-atts actually dropped that attribute:
https://github.com/oasis-tcs/dita/commit/38893d11c6e7676cbb68fecfbfec34dde65add1c

This fix restores it to the element in the hotfix branch