### PR TITLE
Cleaning up alt text

### DIFF
--- a/specification/langRef/base/simpletable.dita
+++ b/specification/langRef/base/simpletable.dita
@@ -42,11 +42,10 @@
         <p>The simple table might be rendered <ph rev="review-e">in the
             following way:</ph></p>
         <image placement="break" href="../images/simpletable.jpg">
-          <alt>The image shows a two-column table. The first column lists
-            menu items, and the second column lists price. The header row
-            is shaded with green, and the text in the header row is bold.
-            The edges of the screen capture are tattered, to indicate that
-            the image is part of a larger document.</alt>
+          <alt>The image shows a two-column table. The first column lists menu items, and the second
+            column lists prices. The header row is shaded with green, and the text in the header row
+            is bold. The edges of the screen capture are tattered, to indicate that the image is
+            part of a larger document.</alt>
         </image>
         <!--<simpletable><sthead><stentry>Menu item</stentry><stentry>Price</stentry></sthead><strow><stentry>Apple pie</stentry><stentry>$7.00</stentry></strow><strow><stentry>Cheese sandwich</stentry><stentry>$10.00</stentry></strow><strow><stentry>Milk shake</stentry><stentry>$6.50</stentry></strow></simpletable>-->
       </fig>


### PR DESCRIPTION
Changes "price" to "prices", so that each column is consistent with singular vs plural (first column menu items, second column prices)