### PR TITLE
Restore commented-out <xref> elements that used "mailto:"

### DIFF
--- a/specification/common/conref-cover-pages.dita
+++ b/specification/common/conref-cover-pages.dita
@@ -11,23 +11,26 @@
     <section id="chair">
       <title>Chair</title>
       <sl>
-        <sli>Kristen James Eberlein
-          (<!--<xref format="mailto" href="mailto:kris@eberleinconsulting.com" scope="external">kris@eberleinconsulting.com</xref>-->),
-            <xref href="http://eberleinconsulting.com/" format="html"
+        <sli>Kristen James Eberlein (<xref format="mailto"
+            href="mailto:kris@eberleinconsulting.com" scope="external"
+            >kris@eberleinconsulting.com</xref>), <xref
+            href="http://eberleinconsulting.com/" format="html"
             scope="external">Eberlein Consulting LLC</xref></sli>
       </sl>
     </section>
     <section id="editors">
       <title>Editors</title>
       <sl>
-        <sli>Kristen James Eberlein
-          (<!--<xref format="mailto" href="mailto:kris@eberleinconsulting.com" scope="external">kris@eberleinconsulting.com</xref>-->),
-            <xref href="http://eberleinconsulting.com/" format="html"
+        <sli>Kristen James Eberlein (<xref format="mailto"
+            href="mailto:kris@eberleinconsulting.com" scope="external"
+            >kris@eberleinconsulting.com</xref>), <xref
+            href="http://eberleinconsulting.com/" format="html"
             scope="external">Eberlein Consulting LLC</xref></sli>
-        <sli>Robert D. Anderson
-          (<!--<xref format="mailto" href="mailto:robert.dan.anderson@oracle.com" scope="external">robert.dan.anderson@oracle.com</xref>-->),
-            <xref href="http://www.oracle.com" format="html"
-            scope="external">Oracle</xref></sli>
+        <sli>Robert D. Anderson (<xref format="mailto"
+            href="mailto:robert.dan.anderson@oracle.com" scope="external"
+            >robert.dan.anderson@oracle.com</xref>), <xref
+            href="http://www.oracle.com" format="html" scope="external"
+            >Oracle</xref></sli>
       </sl>
     </section>
     <section id="section-1">


### PR DESCRIPTION
Restore commented-out <xref> elements that used "mailto:"