### PR TITLE
Remove title att from reltable #397

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -436,10 +436,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                          (%relrow;)+)"
 >
 <!ENTITY % reltable.attributes
-              "title
-                          CDATA
-                                    #IMPLIED
-               %topicref-atts-for-reltable;
+              "%topicref-atts-for-reltable;
                %univ-atts;"
 >
 <!ELEMENT  reltable %reltable.content;>

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -607,9 +607,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         </oneOrMore>
       </define>
       <define name="reltable.attributes">
-        <optional>
-          <attribute name="title"/>
-        </optional>
         <ref name="topicref-atts-for-reltable"/>
         <ref name="univ-atts"/>
       </define>

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -65,19 +65,15 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-type"
-            ><xmlatt>type</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
-            ><xmlatt>scope</xmlatt></xref>, <xref keyref="attributes-common/attr-format"
-            ><xmlatt>format</xmlatt></xref>, and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
+          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-format"
+            ><xmlatt>format</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
+            ><xmlatt>scope</xmlatt></xref>, and <xref keyref="attributes-common/attr-type"
+            ><xmlatt>type</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>toc</xmlatt> attribute has a default
         value of <keyword>no</keyword>.</p>
-      <dl>
-        <dlentry>
-          <dt id="attr-title"><xmlatt>title</xmlatt></dt>
-          <dd>Specifies and identifying title for the element.</dd>
-        </dlentry>
-      </dl>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <draft-comment author="Kristen J Eberlein" time="22 November 2021">


### PR DESCRIPTION
Per #397 -- At the TC meeting on 24 May 2022, we decided to remove the title attribute on reltable element