### PR TITLE
Remove enumeration for scale, apart from table #397

### DIFF
--- a/doctypes/dtd/base/commonElements.mod
+++ b/doctypes/dtd/base/commonElements.mod
@@ -423,23 +423,8 @@
                %foreign.unknown.incl; |
                %txt.incl;"
 >
-<!ENTITY % display-atts
-              "scale
-                          (50 |
-                           60 |
-                           70 |
-                           80 |
-                           90 |
-                           100 |
-                           110 |
-                           120 |
-                           140 |
-                           160 |
-                           180 |
-                           200 |
-                           -dita-use-conref-target)
-                                    #IMPLIED
-               frame
+<!ENTITY % frame-expanse-atts
+              "frame
                           (all |
                            bottom |
                            none |
@@ -455,6 +440,33 @@
                            textline |
                            -dita-use-conref-target)
                                     #IMPLIED"
+>
+<!ENTITY % display-atts
+              "scale
+                          NMTOKEN
+                                    #IMPLIED
+               %frame-expanse-atts;"
+>
+<!ENTITY % table-scale-att
+              "scale
+                          (50 |
+                           60 |
+                           70 |
+                           80 |
+                           90 |
+                           100 |
+                           110 |
+                           120 |
+                           140 |
+                           160 |
+                           180 |
+                           200 |
+                           -dita-use-conref-target)
+                                    #IMPLIED"
+>
+<!ENTITY % simpletable-display-atts
+              "%table-scale-att;
+               %frame-expanse-atts;"
 >
 <!ENTITY % props-attribute-extensions
               ""
@@ -1324,7 +1336,7 @@
                keycol
                           NMTOKEN
                                     #IMPLIED
-               %display-atts;
+               %simpletable-display-atts;
                %univ-atts;"
 >
 <!ELEMENT  simpletable %simpletable.content;>

--- a/doctypes/dtd/base/tblDecl.mod
+++ b/doctypes/dtd/base/tblDecl.mod
@@ -147,21 +147,7 @@
                            norowheader |
                            -dita-use-conref-target)
                                     #IMPLIED
-               scale
-                          (50 |
-                           60 |
-                           70 |
-                           80 |
-                           90 |
-                           100 |
-                           110 |
-                           120 |
-                           140 |
-                           160 |
-                           180 |
-                           200 |
-                           -dita-use-conref-target)
-                                    #IMPLIED
+               %table-scale-att;
                %univ-atts;"
 >
 <!ENTITY % dita.tgroup.attributes

--- a/doctypes/rng/base/commonElementsMod.rng
+++ b/doctypes/rng/base/commonElementsMod.rng
@@ -818,26 +818,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
   </div>
   <div>
     <a:documentation>COMMON ATTRIBUTE SETS</a:documentation>
-    <define name="display-atts">
-      <optional>
-        <attribute name="scale">
-          <choice>
-            <value>50</value>
-            <value>60</value>
-            <value>70</value>
-            <value>80</value>
-            <value>90</value>
-            <value>100</value>
-            <value>110</value>
-            <value>120</value>
-            <value>140</value>
-            <value>160</value>
-            <value>180</value>
-            <value>200</value>
-            <value>-dita-use-conref-target</value>
-          </choice>
-        </attribute>
-      </optional>
+    <define name="frame-expanse-atts">
       <optional>
         <attribute name="frame">
           <choice>
@@ -862,6 +843,39 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
           </choice>
         </attribute>
       </optional>
+    </define>
+    <define name="display-atts">
+      <optional>
+        <attribute name="scale">
+          <data type="NMTOKEN"/>
+        </attribute>
+      </optional>
+      <ref name="frame-expanse-atts"/>
+    </define>
+    <define name="table-scale-att">
+      <optional>
+        <attribute name="scale">
+          <choice>
+            <value>50</value>
+            <value>60</value>
+            <value>70</value>
+            <value>80</value>
+            <value>90</value>
+            <value>100</value>
+            <value>110</value>
+            <value>120</value>
+            <value>140</value>
+            <value>160</value>
+            <value>180</value>
+            <value>200</value>
+            <value>-dita-use-conref-target</value>
+          </choice>
+        </attribute>
+      </optional>
+    </define>
+    <define name="simpletable-display-atts">
+      <ref name="table-scale-att"/>
+      <ref name="frame-expanse-atts"/>
     </define>
 
     <define name="props-attribute-extensions">
@@ -2281,7 +2295,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
               <data type="NMTOKEN"/>
             </attribute>
           </optional>
-          <ref name="display-atts"/>
+          <ref name="simpletable-display-atts"/>
           <ref name="univ-atts"/>
         </define>
         <define name="simpletable.element">

--- a/doctypes/rng/base/tblDeclMod.rng
+++ b/doctypes/rng/base/tblDeclMod.rng
@@ -206,25 +206,7 @@ For <entry>, add:
         </choice>
       </attribute>
     </optional>
-    <optional>
-      <attribute name="scale">
-        <choice>
-          <value>50</value>
-          <value>60</value>
-          <value>70</value>
-          <value>80</value>
-          <value>90</value>
-          <value>100</value>
-          <value>110</value>
-          <value>120</value>
-          <value>140</value>
-          <value>160</value>
-          <value>180</value>
-          <value>200</value>
-          <value>-dita-use-conref-target</value>
-        </choice>
-      </attribute>
-    </optional>
+    <ref name="table-scale-att"/>
     <ref name="univ-atts"/>
   </define>
   <define name="dita.tgroup.attributes">

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -712,23 +712,19 @@
         </dlentry>
         <dlentry id="scale">
           <dt id="attr-scale"><xmlatt>scale</xmlatt> (display attributes)</dt>
-          <dd>Specifies the percentage by which fonts are resized in
-            relation to the normal text size. The following values are
-            valid: <keyword>50</keyword>, <keyword>60</keyword>,
-              <keyword>70</keyword>, <keyword>80</keyword>,
-              <keyword>90</keyword>, <keyword>100</keyword>,
-              <keyword>110</keyword>, <keyword>120</keyword>,
-              <keyword>140</keyword>, <keyword>160</keyword>,
-              <keyword>180</keyword>, <keyword>200</keyword>, and <xref
-              keyref="attributes-useconreftarget"
-              >-dita-use-conref-target</xref>. <p>This attribute is
-              primarily useful for print-oriented display. Some processors
-              might not support all values.</p><p>If the
-                <xmlatt>scale</xmlatt> attribute is specified on an element
-              that contains an image, the image is not scaled. The image is
-              scaled <b>only</b> if a scaling property is explicitly
-              specified for the <xmlelement>image</xmlelement>
-            element.</p><!--<draft-comment author="robander" time="Dec 28 2021">Just noting that we seem to repeat ourselves here, saying this is 1) primarily for print-oriented, 2) primarily for print accommodation, and 3) some processors (implementations) might not support all values. Also feels really odd to say it's "an acknowledged style-based property", I think we can just delete that sentence? It doesn't add anything except to suggest we might be embarassed to have this attribute?</draft-comment>--><!--<draft-comment author="Kristen J Eberlein" time="29 December 2021"><p>I've made some edits, including some that I think eliminated the repetition.</p><p>Is <xmlatt>scale</xmlatt> used on elements other than fig, simpletable, and table? Note that we do not mention <xmlelement>simpletable</xmlelement> above ...</p><p>Maybe the paragraph about image should be moved to the <xmlelement>image</xmlelement> topic? Or covered in the topics for elements that support <xmlatt>scale</xmlatt>?</p><p>Do we need to discuss processing expectations about scaling elsewhere? It's buried here. Putting it in a more prominent place might improve the likelihood that processors would support it.</p><p>Based on a quick test, DITA-OT PDF: <ul><li>Supports <xmlatt>scale</xmlatt> on table but not <xmlelement>simpletable</xmlelement></li><li>Scales the image contained in a table when the <xmlatt>scale</xmlatt> attribute is set</li></ul> .</p></draft-comment>--></dd>
+          <dd>Specifies the percentage by which fonts are resized in relation to the normal text
+            size. The value of this attribute is a positive integer. When used on
+              <xmlelement>table</xmlelement> or <xmlelement>simpletable</xmlelement>, the following
+            values are valid: <keyword>50</keyword>, <keyword>60</keyword>, <keyword>70</keyword>,
+              <keyword>80</keyword>, <keyword>90</keyword>, <keyword>100</keyword>,
+              <keyword>110</keyword>, <keyword>120</keyword>, <keyword>140</keyword>,
+              <keyword>160</keyword>, <keyword>180</keyword>, <keyword>200</keyword>, and <xref
+              keyref="attributes-useconreftarget">-dita-use-conref-target</xref>. <p>This attribute
+              is primarily useful for print-oriented display. Some processors might not support all
+              values.</p><p>If the <xmlatt>scale</xmlatt> attribute is specified on an element that
+              contains an image, the image is not scaled. The image is scaled <b>only</b> if a
+              scaling property is explicitly specified for the <xmlelement>image</xmlelement>
+              element.</p><!--<draft-comment author="robander" time="Dec 28 2021">Just noting that we seem to repeat ourselves here, saying this is 1) primarily for print-oriented, 2) primarily for print accommodation, and 3) some processors (implementations) might not support all values. Also feels really odd to say it's "an acknowledged style-based property", I think we can just delete that sentence? It doesn't add anything except to suggest we might be embarassed to have this attribute?</draft-comment>--><!--<draft-comment author="Kristen J Eberlein" time="29 December 2021"><p>I've made some edits, including some that I think eliminated the repetition.</p><p>Is <xmlatt>scale</xmlatt> used on elements other than fig, simpletable, and table? Note that we do not mention <xmlelement>simpletable</xmlelement> above ...</p><p>Maybe the paragraph about image should be moved to the <xmlelement>image</xmlelement> topic? Or covered in the topics for elements that support <xmlatt>scale</xmlatt>?</p><p>Do we need to discuss processing expectations about scaling elsewhere? It's buried here. Putting it in a more prominent place might improve the likelihood that processors would support it.</p><p>Based on a quick test, DITA-OT PDF: <ul><li>Supports <xmlatt>scale</xmlatt> on table but not <xmlelement>simpletable</xmlelement></li><li>Scales the image contained in a table when the <xmlatt>scale</xmlatt> attribute is set</li></ul> .</p></draft-comment>--></dd>
         </dlentry>
         <dlentry id="scope">
           <dt id="attr-scope"><xmlatt>scope</xmlatt> (link-relationship attributes)</dt>


### PR DESCRIPTION
Per recent TC discussion, as noted in #397 , remove enumeration from `@scale` attribute apart from the definitions on simpletable / table.