### PR TITLE
Fix attribute listings

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -163,27 +163,23 @@
         <p id="attr-exception-topicid" outputclass="attr-exception">For
           this element, the <xmlatt>id</xmlatt> attribute is required.</p>
       </div><p id="fig-attributes" platform="dita">The following attributes are available on this element: <ph
-                                        conkeyref="reuse-attributes/ref-universalatts"/> and <ph
-                                        conkeyref="reuse-attributes/ref-displayatts"/>.</p><p id="pre-attributes" platform="dita">The following attributes are available on this element: <ph
-                                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                                        conkeyref="reuse-attributes/ref-displayatts"/>, and  <xref
-                                        keyref="attributes-common/xmlspace"
-                                                ><xmlatt>xml:space</xmlatt></xref>.</p><p id="xref-attributes" platform="dita">The following attributes are
-        available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p><div id="fn-attributes" platform="dita">
+          conkeyref="reuse-attributes/ref-displayatts"/> and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="pre-attributes" platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p><p id="xref-attributes" platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p><div id="fn-attributes" platform="dita">
         <p>The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/> and the
           attribute defined below.</p>
         <!--<dl><dlentry id="callout"><dt id="attr-callout"><xmlatt>callout</xmlatt></dt><dd>Specifies the character that is used for the footnote link, for example, a number or an alphabetical character. The attribute can also specify a short string of characters.</dd></dlentry></dl>-->
       </div><div id="author-attributes" platform="dita">
         <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-            keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, and <ph
-            conkeyref="reuse-attributes/ref-linkatts"/>.</p>
+            conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </div><div id="standard-topicref-attributes" platform="dita">
                                 <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,

--- a/specification/common/reuse-w-lwdita/reuse-audio.dita
+++ b/specification/common/reuse-w-lwdita/reuse-audio.dita
@@ -37,13 +37,12 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p rev="review-a" platform="dita">The following attributes are
-        available on this element: <ph
+      <p rev="review-a" platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/attr-format"/>, <xref
-          keyref="attributes-common/attr-href"/>, <xref
-          keyref="attributes-common/attr-keyref"/>, <xref
-          keyref="attributes-common/attr-scope"/>, and the attributes
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
         defined below.</p>
       <p conkeyref="lwattr/audio" platform="lwdita"/>
       <dl platform="dita lwdita">

--- a/specification/common/reuse-w-lwdita/reuse-data.dita
+++ b/specification/common/reuse-w-lwdita/reuse-data.dita
@@ -53,12 +53,10 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this
-        element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-dataatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p>
+      <p platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-dataatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"
+        />, <ph conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <div conkeyref="lwattr/data" platform="lwdita"/>
     </section>
   </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-fig.dita
+++ b/specification/common/reuse-w-lwdita/reuse-fig.dita
@@ -19,8 +19,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/> and <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>.</p>
+          conkeyref="reuse-attributes/ref-displayatts"/> and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <div conkeyref="lwattr/example-fig" platform="lwdita"/>
     </section>
 </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -16,12 +16,11 @@
       <div platform="dita">
         <p>The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-            keyref="attributes-common/attr-href"/>, <xref
-            keyref="attributes-common/attr-format"/>, <xref
-            keyref="attributes-common/attr-scope"/>, <xref
-            keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, and the attributes defined
-          below.</p>
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
+          defined below.</p>
       </div>
       <p conkeyref="lwattr/image" platform="lwdita"/>
       <dl platform="dita lwdita">

--- a/specification/common/reuse-w-lwdita/reuse-keydef.dita
+++ b/specification/common/reuse-w-lwdita/reuse-keydef.dita
@@ -26,11 +26,10 @@
       <title>Attributes</title>
       <div id="keydef-attributes" platform="dita">
         <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
             conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-            conkeyref="reuse-attributes/ref-commonmapatts"/>, and <xref
-            keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>.</p>
+            conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </div>
       <div conkeyref="lwattr/keydef" platform="lwdita"/>
       <p id="attr-exception" outputclass="attr-exception">For this element:

--- a/specification/common/reuse-w-lwdita/reuse-map.dita
+++ b/specification/common/reuse-w-lwdita/reuse-map.dita
@@ -86,12 +86,12 @@
       <title>Attributes</title>
       <div>
         <p platform="dita">The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-architecturalatts"/>, <ph
             conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
-            conkeyref="reuse-attributes/ref-architecturalatts"/>, <xref
-            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
+            conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
             keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
-            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>
+            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>
       </div>
       <div conkeyref="lwattr/map-topic" platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-media-source.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-source.dita
@@ -25,9 +25,10 @@
       <div platform="dita">
         <p rev="review-a">The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-            keyref="attributes-common/attr-format"/>, <xref keyref="attributes-common/attr-href"/>,
-            <xref keyref="attributes-common/attr-keyref"/>, and <xref
-            keyref="attributes-common/attr-scope"/>.</p>
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>.</p>
         <p id="attr-exception" outputclass="attr-exception" rev="review-a" platform="dita">For this
           element, the <xmlatt>href</xmlatt> attribute specifies the URI of the track resource.</p>
       </div>

--- a/specification/common/reuse-w-lwdita/reuse-media-track.dita
+++ b/specification/common/reuse-w-lwdita/reuse-media-track.dita
@@ -16,29 +16,13 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this
-        element: <ph><xref
-            href="../../langRef/attributes/universalAttributes.dita"
-            >universal attributes<desc>Universal attributes include:
-                <xmlatt>audience</xmlatt>, <xmlatt>base</xmlatt>,
-                <xmlatt>class</xmlatt>, <xmlatt>conaction</xmlatt>,
-                <xmlatt>conkeyref</xmlatt>, <xmlatt>conref</xmlatt>,
-                <xmlatt>conrefend</xmlatt>,
-              <xmlatt>deliveryTarget</xmlatt>, <xmlatt>dir</xmlatt>,
-                <xmlatt>id</xmlatt>, <xmlatt>importance</xmlatt>,
-                <xmlatt>otherprops</xmlatt>, <xmlatt>outputclass</xmlatt>,
-                <xmlatt>platform</xmlatt>, <xmlatt>product</xmlatt>,
-                <xmlatt>props</xmlatt>, <xmlatt>rev</xmlatt>,
-                <xmlatt>status</xmlatt>, <xmlatt>translate</xmlatt>, and
-                <xmlatt>xml:lang</xmlatt></desc></xref></ph>, <xref
-          href="../../langRef/attributes/commonAttributes.dita#common-atts/attr-format"
-        />, <xref
-          href="../../langRef/attributes/commonAttributes.dita#common-atts/attr-href"
-        />, <xref
-          href="../../langRef/attributes/commonAttributes.dita#common-atts/attr-keyref"
-        />, <xref
-          href="../../langRef/attributes/commonAttributes.dita#common-atts/attr-scope"
-        />, and the attributes defined below.</p>
+      <p platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
+        defined below.</p>
       <p platform="lwdita">The following attributes are available on this
         element: <ph><xref
             href="../../langRef/attributes/attribute-groups.dita#attribute-groups/id-attributes"

--- a/specification/common/reuse-w-lwdita/reuse-pre.dita
+++ b/specification/common/reuse-w-lwdita/reuse-pre.dita
@@ -24,9 +24,9 @@
       <section id="attributes">
          <title>Attributes</title>
          <p platform="dita">The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>, and <xref
-          keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
+                    conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+                    keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
       <div conkeyref="lwattr/pre" platform="lwdita"/>
       </section>
 </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-simpletable.dita
+++ b/specification/common/reuse-w-lwdita/reuse-simpletable.dita
@@ -32,9 +32,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>, and  <ph
-          conkeyref="reuse-attributes/ref-simpletableatts"/>.</p>
+          conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+          conkeyref="reuse-attributes/ref-simpletableatts"/>, and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <div conkeyref="lwattr/block-elements"
         platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-title.dita
+++ b/specification/common/reuse-w-lwdita/reuse-title.dita
@@ -8,8 +8,11 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> (without the metadata attribute group), <xref
-          keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, and <xref
+        <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, 
+            <ph conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
+                keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
+                    keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
+                        keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, and <xref
           keyref="attributes-universal/attr-rev"><xmlatt>rev</xmlatt></xref>.</p>
       <div conkeyref="lwattr/body-keytext-navtitle-title" platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-topic.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topic.dita
@@ -7,7 +7,9 @@
 <refbody>
   <section id="attributes">
    <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-architecturalatts"/>.</p>
+      <p platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-architecturalatts"/> and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <div conkeyref="lwattr/map-topic" platform="lwdita"/>
     <p id="attr-exception" outputclass="attr-exception"
         platform="dita lwdita">For this element, the <xmlatt>id</xmlatt>

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -10,36 +10,23 @@
 <refbody>
   <section id="attributes">
    <title>Attributes</title>
-      <div platform="dita">The following attributes are available on this
-        element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed
-        definition of <xmlatt>href</xmlatt>, given below), <ph
-          conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
-          keyref="attributes-common/attr-keys"
-        ><xmlatt>keys</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-keys"
-          ><xmlatt>keyref</xmlatt></xref>.<draft-comment author="robander"
-          time="15 May 2021">Most attribute sections with one-off narrowing
-          or clarification have been converted to a paragraph – "On this
-          element, href does xyz", while the actual definition still
-          applies. We plan to convert this into an attribute-exception
-          paragraph, reminding that topicref is meant to refer to
-          topic-level elements, but before doing that, need to make sure
-          the href topic is updated with the same info in arch
-          spec.</draft-comment><dl>
-          <dlentry id="href-on-topicref">
-            <dt id="attr-href"><xmlatt>href</xmlatt></dt>
-            <dd>Points to the resource that is represented by the
-                <xmlelement>topicref</xmlelement>. See <xref
-                keyref="attributes-href"/> for detailed information on
-              supported values and processing implications. References to
-              DITA content cannot be below the topic level: that is, you
-              cannot reference individual elements inside a topic.
-              References to content other than DITA topics should use the
-                <xmlatt>format</xmlatt> attribute to identify the kind of
-              resource being referenced.</dd>
-          </dlentry>
-        </dl></div>
+      <div platform="dita">
+        <p>The following attributes are available on this element: <ph
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
+            conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+            keyref="attributes-common/attr-keys"><xmlatt>keyref</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>.</p>
+        <draft-comment author="robander" time="27 Sept 2022">Updated style here to match the common
+          attribute style, but still need to make sure the href topic is updated with the same info
+          in arch spec.</draft-comment>
+        <p>For this element, the <xmlatt>href</xmlatt> attribute references the resource that is
+          represented by the <xmlelement>topicref</xmlelement>. See <xref keyref="attributes-href"/>
+          for detailed information on supported values and processing implications. References to
+          DITA content cannot be below the topic level: that is, you cannot reference individual
+          elements inside a topic. References to content other than DITA topics should use the
+            <xmlatt>format</xmlatt> attribute to identify the kind of resource being referenced.</p>
+      </div>
       <div conkeyref="lwattr/topicref" platform="lwdita"/>
   </section>
  </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-video.dita
+++ b/specification/common/reuse-w-lwdita/reuse-video.dita
@@ -56,12 +56,12 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p platform="dita">The following attributes are available on this
-        element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
-          <xref keyref="attributes-common/attr-format"/>, <xref
-          keyref="attributes-common/attr-href"/>, <xref
-          keyref="attributes-common/attr-keyref"/>, <xref
-          keyref="attributes-common/attr-scope"/>, and the attributes
+      <p platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
         defined below.</p>
       <p conkeyref="lwattr/video" platform="lwdita"/>
       <dl platform="dita lwdita">
@@ -115,8 +115,8 @@
         </dlentry>
       </dl>
       <div platform="dita lwdita">
-        <p id="attr-exception" outputclass="attr-exception" rev="review-a"
-          >For this element, the following considerations apply: </p>
+        <p id="attr-exception" outputclass="attr-exception" rev="review-a">For this element, the
+          following considerations apply:</p>
         <ul>
           <li>The <xmlatt>format</xmlatt> attribute specifies the MIME type
             for the resource. This attribute enables processors to avoid

--- a/specification/common/reuse-w-lwdita/reuse-xref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-xref.dita
@@ -10,11 +10,10 @@
     <refbody>
         <section id="attributes">
             <title>Attributes</title>
-            <p platform="dita">The following attributes are available on
-        this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>,
-          <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p>
+            <p platform="dita">The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+                    keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <div conkeyref="lwattr/xref" platform="lwdita"/>
       <!--<div id="xref-2"><p>The following attributes are available on this element:</p><dl><dlentry><dt>Link relationship attributes</dt><dd><dl><dlentry conkeyref="attributes-common/format"><dt/><dd/></dlentry><dlentry conkeyref="attributes-common/href"><dt/><dd/></dlentry><dlentry conkeyref="attributes-common/scope"><dt/><dd/></dlentry></dl></dd></dlentry><dlentry><dt>Localization attributes</dt><dd><dl><dlentry conkeyref="attributes-universal/dir"><dt/><dd/></dlentry><dlentry conkeyref="attributes-universal/translate"><dt/><dd/></dlentry><dlentry conkeyref="attributes-universal/xml-lang"><dt/><dd/></dlentry></dl></dd></dlentry><dlentry><dt>Universal attributes</dt><dd><dl><dlentry conkeyref="attributes-universal/class"><dt/><dd/></dlentry><dlentry conkeyref="attributes-universal/outputclass"><dt/><dd/></dlentry></dl></dd></dlentry><dlentry conkeyref="attributes-common/keyref"><dt/><dd/></dlentry><dlentry conkeyref="attributes-universal/props"><dt/><dd/></dlentry></dl></div>-->
         </section>

--- a/specification/langRef/attributes/universalAttributes.dita
+++ b/specification/langRef/attributes/universalAttributes.dita
@@ -30,9 +30,8 @@
       <dl>
         <dlentry id="universalatts">
           <dt>Universal attributes</dt>
-          <dd>Includes <xmlatt>class</xmlatt> and
-              <xmlatt>outputclass</xmlatt>, along with every attribute in
-            the ID,localization, and metadata attribute groups.</dd>
+          <dd>Includes <xmlatt>class</xmlatt> and <xmlatt>outputclass</xmlatt>, along with every
+            attribute in the ID, localization, and metadata attribute groups.</dd>
         </dlentry>
         <dlentry id="idatts">
           <dt>ID attributes</dt>

--- a/specification/langRef/base/colspec.dita
+++ b/specification/langRef/base/colspec.dita
@@ -19,23 +19,18 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/> (without the
-        metadata attribute group), <xref
-          keyref="attributes-common/attr-align"
-          ><xmlatt>align</xmlatt></xref>, <xref
-          keyref="attributes-universal/attr-base"
-          ><xmlatt>base</xmlatt></xref>,  <xref
-          keyref="attributes-common/attr-char"
-        ><xmlatt>char</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-charoff"
-          ><xmlatt>charoff</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-colsep"
-          ><xmlatt>colsep</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-rowheader"
-            ><xmlatt>rowheader</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-rowsep"
-          ><xmlatt>rowsep</xmlatt></xref>, and the attributes defined
-        below.</p>
+          conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph
+          conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
+          keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-char"><xmlatt>char</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-charoff"><xmlatt>charoff</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowheader"><xmlatt>rowheader</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, and the attributes
+        defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-colnum"><xmlatt>colnum</xmlatt></dt>

--- a/specification/langRef/base/created.dita
+++ b/specification/langRef/base/created.dita
@@ -15,8 +15,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-dateatts"/>, and the attribute defined below.</p>
+          conkeyref="reuse-attributes/ref-dateatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="date">
           <dt id="attr-date"><xmlatt>date</xmlatt>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -55,12 +55,12 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-keys"
-            ><xmlatt>keys</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
-            ><xmlatt>processing-role</xmlatt></xref>, and <xref keyref="attributes-common/attr-toc"
-            ><xmlatt>toc</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
+        and <xref keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/draft-comment.dita
+++ b/specification/langRef/base/draft-comment.dita
@@ -24,8 +24,6 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
-      <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>translate</xmlatt> attribute has a
-        default value of <keyword>no</keyword>.</p>
       <dl>
         <dlentry id="author">
           <dt id="attr-author"><xmlatt>author</xmlatt></dt>
@@ -40,6 +38,8 @@
           <dd>Specifies when the draft comment was created.</dd>
         </dlentry>
       </dl>
+      <p id="attr-exception" outputclass="attr-exception">For this element, the
+          <xmlatt>translate</xmlatt> attribute has a default value of <keyword>no</keyword>.</p>
     </section>
 <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -16,13 +16,14 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref keyref="attributes-universal/attr-status"
-            ><xmlatt>status</xmlatt></xref>, <xref keyref="attributes-universal/attr-base"
-            ><xmlatt>base</xmlatt></xref>, <xref keyref="attributes-universal/outputclass"
-            ><xmlatt>outputclass</xmlatt></xref>, <xref keyref="attributes-universal/attr-translate"
-            ><xmlatt>translate</xmlatt></xref>, <xref keyref="attributes-universal/class"
-            ><xmlatt>class</xmlatt></xref>, and <xref keyref="attributes-common/attr-name"
-            ><xmlatt>name</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
+          keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
+          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>, <xref
+          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>, and <xref
+          keyref="attributes-universal/attr-translate"><xmlatt>translate</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element,
         the following considerations apply:<ul id="ul_ddp_51l_ppb">
           <li>The <xmlatt>name</xmlatt> attribute is required. It specifies

--- a/specification/langRef/base/entry.dita
+++ b/specification/langRef/base/entry.dita
@@ -16,25 +16,19 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/> (without the
-        metadata attribute group), <xref
-          keyref="attributes-common/attr-align"
-          ><xmlatt>align</xmlatt></xref>, <xref
-          keyref="attributes-universal/attr-base"
-          ><xmlatt>base</xmlatt></xref>,  <xref
-          keyref="attributes-common/attr-char"
-        ><xmlatt>char</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-charoff"
-          ><xmlatt>charoff</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-colsep"
-          ><xmlatt>colsep</xmlatt></xref>, <xref
-          keyref="attributes-universal/attr-rev"
-          ><xmlatt>rev</xmlatt></xref>,  <xref
-          keyref="attributes-common/attr-rowsep"
-          ><xmlatt>rowsep</xmlatt></xref>,  <xref
-          keyref="attributes-common/attr-valign"
-          ><xmlatt>valign</xmlatt></xref>, and the attributes defined
-        below.</p>
+          conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph
+          conkeyref="reuse-attributes/ref-localizationatts"/>, <xref
+          keyref="attributes-common/attr-align"><xmlatt>align</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-char"><xmlatt>char</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-charoff"><xmlatt>charoff</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-colsep"><xmlatt>colsep</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-rev"><xmlatt>rev</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-rowsep"><xmlatt>rowsep</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-valign"><xmlatt>valign</xmlatt></xref>, and the attributes
+        defined below.</p>
       <dl>
         <dlentry>
           <dt id="attr-colname"><xmlatt>colname</xmlatt></dt>

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -116,14 +116,10 @@
             <title>Attributes</title>
             <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
-          keyref="attributes-universal/attr-status"
-          ><xmlatt>status</xmlatt></xref>, <xref
-          keyref="attributes-universal/attr-base"
-          ><xmlatt>base</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"
-            ><xmlatt>outputclass</xmlatt></xref>, and <xref
-          keyref="attributes-universal/class"
-        ><xmlatt>class</xmlatt></xref>.</p>
+          keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
+          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and <xref
+          keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>.</p>
         </section>
         <example>
             <title>Example</title>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -40,17 +40,16 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
             keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref></ph>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and the attributes
         defined below.</p>
-      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>href</xmlatt> specifies an image.</p>
       <dl>
+        <dlentry conkeyref="reuse-attributes/image-align">
+          <dt/>
+          <dd/>
+        </dlentry>
         <dlentry conkeyref="reuse-attributes/image-height">
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-width">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-align">
+        <dlentry conkeyref="reuse-attributes/image-placement">
           <dt/>
           <dd/>
         </dlentry>
@@ -62,11 +61,13 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-placement">
+        <dlentry conkeyref="reuse-attributes/image-width">
           <dt/>
           <dd/>
         </dlentry>
       </dl>
+      <p id="attr-exception" outputclass="attr-exception">For this element, <xmlatt>href</xmlatt>
+        specifies an image.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample defines a hazard statement that

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -59,9 +59,9 @@ are presented instead.</p>
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <ph
-                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph
                     conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph
-                    conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
+                    conkeyref="reuse-attributes/ref-linkatts"/>,  <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
                     keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -18,8 +18,8 @@ space within the <xmlelement>lines</xmlelement> element.</p>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                    conkeyref="reuse-attributes/ref-displayatts"/>, and  <xref
+                    conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
                     keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples" rev="review-c">

--- a/specification/langRef/base/link.dita
+++ b/specification/langRef/base/link.dita
@@ -25,14 +25,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>,  <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref
-          keyref="attributes-common/attr-otherrole"
-            ><xmlatt>otherrole</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-role"
-        ><xmlatt>role</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-role"><xmlatt>role</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows a simple collection of links in a

--- a/specification/langRef/base/longdescref.dita
+++ b/specification/langRef/base/longdescref.dita
@@ -16,7 +16,9 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -48,11 +48,11 @@
       <title>Attributes</title>
       <div id="mapref-attributes">
         <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
             conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref keyref="attributes-common/attr-keyref"
-              ><xmlatt>keyref</xmlatt></xref>, and <xref keyref="attributes-common/attr-keys"
-              ><xmlatt>keys</xmlatt></xref>.</p>
+            conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>.</p>
         <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>format</xmlatt> attribute has a default
           value of <keyword>ditamap</keyword>.</p>
       </div>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -28,14 +28,11 @@
         <section id="attributes">
           <title>Attributes</title>
           <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-          conkeyref="reuse-attributes/ref-commonmapatts"/> (excluding
-          <xmlatt>chunk</xmlatt> and <xmlatt>collection-type</xmlatt>),
-          <xref keyref="attributes-common/attr-keys"
-          ><xmlatt>keys</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-commonmapatts"/> (excluding <xmlatt>chunk</xmlatt> and
+          <xmlatt>collection-type</xmlatt>), <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>processing-role</xmlatt> attribute has a
         default value of <keyword>resource-only</keyword>.</p>
         </section>

--- a/specification/langRef/base/no-topic-nesting.dita
+++ b/specification/langRef/base/no-topic-nesting.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attribute is available on this element: <xref
-          keyref="attributes-universal/class"/>.</p>
+                    keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <!--<p><i>This element is not intended to be used in source files.</i></p>-->

--- a/specification/langRef/base/othermeta.dita
+++ b/specification/langRef/base/othermeta.dita
@@ -25,15 +25,16 @@
    <title>Attributes</title>
    <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
    <dl>
+        <dlentry id="content">
+          <dt id="attr-content"><xmlatt>content</xmlatt>
+            <ph conkeyref="reuse-attributes/required-attr"/></dt>
+          <dd>Specifies the value for the property named in the <xmlatt>name</xmlatt> attribute.
+          </dd>
+        </dlentry>
     <dlentry id="name">
      <dt id="attr-name"><xmlatt>name</xmlatt>
       <ph conkeyref="reuse-attributes/required-attr"/></dt>
      <dd>Specifies the name of the metadata property. </dd>
-    </dlentry>
-    <dlentry id="content">
-     <dt id="attr-content"><xmlatt>content</xmlatt>
-      <ph conkeyref="reuse-attributes/required-attr"/></dt>
-     <dd>Specifies the value for the property named in the <xmlatt>name</xmlatt> attribute. </dd>
     </dlentry>
     <dlentry id="translate-content">
      <dt id="attr-translate-content"><xmlatt>translate-content</xmlatt></dt>

--- a/specification/langRef/base/publisher.dita
+++ b/specification/langRef/base/publisher.dita
@@ -16,7 +16,9 @@
     <!--<section id="usage-information"><title>Usage information</title><p>The <xmlelement>publisher</xmlelement> element is equivalent to the <xmlelement>Publisher</xmlelement> element in Dublin Core.</p></section>-->
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
+            <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
                     keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -31,11 +31,13 @@
       ><title/><p/></section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-format"><xmlatt>scope</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-format"><xmlatt>type</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-role"><xmlatt>role</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-role"><xmlatt>role</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>scope</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-format"><xmlatt>type</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows how the
           <xmlelement>related-link</xmlelement> element <ph rev="review-a"

--- a/specification/langRef/base/relcell.dita
+++ b/specification/langRef/base/relcell.dita
@@ -25,10 +25,12 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <ph conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt>),
-          <xref keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt>), <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p rev="review-c">See <xref keyref="elements-reltable/example"
             ><xmlelement>reltable</xmlelement></xref>.</p></example>

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -66,12 +66,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-commonmapatts"/> (without <xmlatt>keyscope</xmlatt> or
-          <xmlatt>collection-type</xmlatt>), <xref keyref="attributes-common/attr-format"
-            ><xmlatt>format</xmlatt></xref>, <xref keyref="attributes-common/attr-scope"
-            ><xmlatt>scope</xmlatt></xref>, and <xref keyref="attributes-common/attr-type"
-            ><xmlatt>type</xmlatt></xref>.</p>
+          <xmlatt>collection-type</xmlatt>), <ph conkeyref="reuse-attributes/ref-universalatts"/>,
+          <xref keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>toc</xmlatt> attribute has a default
         value of <keyword>no</keyword>.</p>
     </section>

--- a/specification/langRef/base/required-cleanup.dita
+++ b/specification/langRef/base/required-cleanup.dita
@@ -40,8 +40,6 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
-      <p>For this element, the <xmlatt>translate</xmlatt> attribute has a default value of
-          <keyword>no</keyword>.</p>
       <p>
         <dl id="dl_yl4_524_qpb">
           <dlentry>
@@ -52,6 +50,8 @@
           </dlentry>
         </dl>
       </p>
+      <p>For this element, the <xmlatt>translate</xmlatt> attribute has a default value of
+          <keyword>no</keyword>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>In the following example, an HTML document that used the <xmlelement>center</xmlelement>

--- a/specification/langRef/base/revised.dita
+++ b/specification/langRef/base/revised.dita
@@ -14,7 +14,9 @@
 <refbody>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-dateatts"/>, and the attribute defined below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-dateatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and the attribute defined below.</p>
       <dl>
         <dlentry id="modified">
           <dt id="attr-modified"><xmlatt>modified</xmlatt>

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -21,10 +21,10 @@
       <title>Attributes</title>
       <div id="standard-topicref-attributes">
         <p>The following attributes are available on this element: <ph
-                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                        conkeyref="reuse-attributes/ref-linkatts"/>, <xref
-                        keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
-                        keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+            conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>.</p>
         <p id="attr-exception" outputclass="attr-exception">For this
           element, the following considerations apply:<ul
             id="ul_pz3_w3r_ppb">

--- a/specification/langRef/base/source.dita
+++ b/specification/langRef/base/source.dita
@@ -30,9 +30,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element,
         the <xmlatt>href</xmlatt> attribute provides a reference to a
         resource from which the topic is derived.</p>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -30,11 +30,12 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/attr-processing-role"
-          ><xmlatt>processing-role</xmlatt></xref>, <xref keyref="attributes-common/attr-toc"
-            ><xmlatt>toc</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
-            ><xmlatt>collection-type</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>. </p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
+          <xref keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
+        and <xref keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>,. </p>
       <p id="attr-exception" outputclass="attr-exception">For this element,
         the following considerations apply:<ul id="ul_pz3_w3r_ppb">
           <li>The <xmlatt>collection-type</xmlatt> attribute has an

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -20,15 +20,12 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-architecturalatts"/>, <ph
           conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
-          conkeyref="reuse-attributes/ref-architecturalatts"/>, <xref
-          keyref="attributes-common/attr-type"
-        ><xmlatt>type</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-scope"
-          ><xmlatt>scope</xmlatt></xref>, and  <xref
-          keyref="attributes-common/attr-format"
-          ><xmlatt>format</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element,
         the following considerations apply:<ul id="ul_nwz_4kr_ppb">
           <li>The <xmlatt>processing-role</xmlatt> attribute has a default

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -31,21 +31,15 @@
                 </section>
                 <section id="attributes">
                         <title>Attributes</title>
-                        <p>The following attributes are available on this
-        element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref
-          keyref="attributes-common/attr-collection-type"
-            ><xmlatt>collection-type</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-keys"
-        ><xmlatt>keys</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-linking"
-          ><xmlatt>linking</xmlatt></xref>,  <xref
-          keyref="attributes-common/attr-processing-role"
-            ><xmlatt>processing-role</xmlatt></xref>, and <xref
-          keyref="attributes-common/attr-toc"
-        ><xmlatt>toc</xmlatt></xref>.</p>
+                        <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
+          <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
+        and <xref keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>.</p>
                 </section>
     <example id="example">
       <title>Examples</title>

--- a/specification/langRef/base/tm.dita
+++ b/specification/langRef/base/tm.dita
@@ -13,6 +13,15 @@
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry>
+          <dt id="attr-tmclass"><xmlatt>tmclass</xmlatt></dt>
+          <dd>Specifies the classification of the trademark. This can be used to differentiate
+            different groupings of trademarks.</dd>
+        </dlentry>
+        <dlentry>
+          <dt id="attr-tmowner"><xmlatt>tmowner</xmlatt></dt>
+          <dd>Specifies the trademark owner, for example &quot;OASIS&quot;.</dd>
+        </dlentry>
+        <dlentry>
           <dt id="attr-tmtype"><xmlatt>tmtype</xmlatt>
             <ph conkeyref="reuse-attributes/required-attr"/></dt>
           <dd>Specifies the trademark type. Allowable values are: <dl>
@@ -37,15 +46,6 @@
         <dlentry>
           <dt id="attr-trademark"><xmlatt>trademark</xmlatt></dt>
           <dd>Specifies the trademarked term.</dd>
-        </dlentry>
-        <dlentry>
-          <dt id="attr-tmowner"><xmlatt>tmowner</xmlatt></dt>
-          <dd>Specifies the trademark owner, for example &quot;OASIS&quot;.</dd>
-        </dlentry>
-        <dlentry>
-          <dt id="attr-tmclass"><xmlatt>tmclass</xmlatt></dt>
-          <dd>Specifies the classification of the trademark. This can be used to differentiate
-            different groupings of trademarks.</dd>
         </dlentry>
       </dl>
     </section><example id="example" otherprops="examples"><title>Example</title>

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -51,8 +51,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
+          conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
           keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>

--- a/specification/langRef/base/topichead.dita
+++ b/specification/langRef/base/topichead.dita
@@ -50,8 +50,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
+          conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
           keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -94,6 +94,10 @@
                 <dd>The window dimensions specified on this element are
                   relative to the calling window.</dd>
               </dlentry>
+              <dlentry conkeyref="reuse-attributes/ditauseconref">
+                <dt/>
+                <dd/>
+              </dlentry>
             </dl></dd>
         </dlentry>
         <dlentry>
@@ -111,10 +115,6 @@
           <dd>Specifies the width of the window. <ph
               conref="../../common/conref-attribute.dita#conref-attribute/height-width-units"
             /></dd>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/ditauseconref">
-          <dt/>
-          <dd/>
         </dlentry>
       </dl>
     </section>

--- a/specification/langRef/ditaval/ditaval-prop.dita
+++ b/specification/langRef/ditaval/ditaval-prop.dita
@@ -106,26 +106,19 @@
             </dl>
           </dd>
         </dlentry>
-      </dl>
-      <dl>
         <dlentry>
           <dt id="attr-att"><xmlatt>att</xmlatt></dt>
-          <dd>Specifies the conditional-processing attribute that is
-            targeted. The value is the literal attribute name or the name
-            of a group within one of those attributes, with the group name
-            specified using the generalized attribute syntax. If the
-              <xmlatt>att</xmlatt> attribute is absent, then the
-              <xmlelement>prop</xmlelement> element declares a default
-            behavior for anything not explicitly specified in the DITAVAL
-            document.</dd>
+          <dd>Specifies the conditional-processing attribute that is targeted. The value is the
+            literal attribute name or the name of a group within one of those attributes, with the
+            group name specified using the generalized attribute syntax. If the <xmlatt>att</xmlatt>
+            attribute is absent, then the <xmlelement>prop</xmlelement> element declares a default
+            behavior for anything not explicitly specified in the DITAVAL document.</dd>
         </dlentry>
         <dlentry>
           <dt id="attr-val"><xmlatt>val</xmlatt></dt>
-          <dd>Specifies the attribute value <ph rev="review-m">that is
-              targeted</ph>. If the <xmlatt>val</xmlatt> attribute is
-            absent, then the <xmlelement>prop</xmlelement> element declares
-            a default behavior for any value in the specified
-            attribute.</dd>
+          <dd>Specifies the attribute value <ph rev="review-m">that is targeted</ph>. If the
+              <xmlatt>val</xmlatt> attribute is absent, then the <xmlelement>prop</xmlelement>
+            element declares a default behavior for any value in the specified attribute.</dd>
         </dlentry>
       </dl>
       <p conkeyref="reuse-attributes/ditaval-flagging-attr-intro"/>


### PR DESCRIPTION
* List attribute groups alphabetically
* List attributes alphabetically
* Move 'Attribute exception' sections after any element-specific attributes
* Replace some `xref/@href` attribute links with `@keyref`
* Fix typos