### PR TITLE
Add ci-skip as valid token in base attribute

### DIFF
--- a/specification/dita-2.0-specification-subjectScheme.ditamap
+++ b/specification/dita-2.0-specification-subjectScheme.ditamap
@@ -6,6 +6,7 @@
   <title>Subject scheme: DITA 2.0 specification</title>
   <subjectdef keys="values-base">
     <subjectdef keys="ci-xml"/>
+    <subjectdef keys="ci-skip"/>
   </subjectdef>
   <subjectdef keys="values-audience-draft-comment">
     <subjectdef keys="spec-editors"/>


### PR DESCRIPTION
The `ci-skip` token in the `@base` attribute can be used for code blocks when the CI validation should not try to validate the code as DITA or XML.