### PR TITLE
Remove MAY NOT rule, which is not an RFC term

### DIFF
--- a/specification/archSpec/base/specialization-vocabulary-modules.dita
+++ b/specification/archSpec/base/specialization-vocabulary-modules.dita
@@ -50,9 +50,8 @@
       module names must be unique within the scope of a given specialization hierarchy. The short
       name must be a valid XML name token. </p>
     <p>Structural modules based on topic <term outputclass="RFC-2119">MAY</term> define additional
-      topic types that are then allowed to occur as subordinate topics within the top-level topic.
-      However, such subordinate topic types <term outputclass="RFC-2119">MAY NOT</term> be used as
-      the root elements of conforming DITA documents.</p>
+      topic types that are then allowed to occur as subordinate topics within the top-level
+      topic.</p>
     <p otherprops="examples">For example, a top-level topic type might require the use of
       subordinate topic types that would only ever be meaningful in the context of their containing
       type and thus would never be candidates for standalone authoring or aggregation using maps. In


### PR DESCRIPTION
The removed rule used `MAY NOT` which is not actually a valid RFC term. The rule itself is extraneous and can be removed - if someone has defined a nested topic type in their document, the spec cannot prevent them from using it as a root topic in a document. Worst case, their own tools for working with the specialization might not handle it as expected, but the spec cannot keep someone from doing that + is not the right place to try and prevent that scenario.