### PR TITLE
Draft comment reminding us to define DITA processor

### DIFF
--- a/specification/archSpec/base/basic-dita-terminology.dita
+++ b/specification/archSpec/base/basic-dita-terminology.dita
@@ -4,6 +4,18 @@
     <title>Basic DITA terminology</title>
     <shortdesc>Certain terminology is used for basic DITA components.</shortdesc>
     <conbody>
+        <draft-comment author="rodaande" time="13 December 2022">Somewhere - likely in this topic -
+            we need a definition of "DITA Processor". Currently as used in the spec, that would
+            encompass any tool that processes DITA in any way – not just rendering tools that use
+            DITA as source, but any tools that work with DITA. For example, an editor is not
+            required to evaluate any DITA feature (such as a simple text editor). However a DITA
+            editor that resolves content references or keys inline is a DITA processor, which is
+            processing those features based on processor requirements in the spec. Similarly a CCMS
+            that evaluates content references falls under the umbrella of a DITA processor.<p>This
+                assumes that we retain current use of "DITA processor" as used in the specification.
+                Jarno noted that HTML5 uses producer/ consumer, where producer is aimed more at
+                rules for authors / creators of DITA content and consumer is a tool that acts upon
+                the content.</p></draft-comment>
         <dl>
             <dlentry>
                 <dt>DITA document</dt>


### PR DESCRIPTION
Prompted by a comment from Jarno, add a draft comment so we do not forget to add a definition of DITA processor - it's used in the spec and needs to have a clear definition in our terminology