### PR TITLE
Typo fix, remove extra comma

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -158,7 +158,7 @@
         available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="universal-outputclass-name" platform="dita">The following attributes
         are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-common/name"><xmlatt>name</xmlatt></xref>.</p><p id="universal-keyref" platform="dita">The following attributes are
         available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref


### PR DESCRIPTION
Comma left over from when the section had 3 items