### PR TITLE
Standardize examples

### DIFF
--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -4,13 +4,9 @@
  "reference.dtd">
 <reference id="abstract" xml:lang="en-us">
 <title><xmlelement>abstract</xmlelement></title>
-  <abstract>
-    <shortdesc>An abstract summarizes the content of the topic; it appears
-      at the start of the topic. It can contain multiple short
-      descriptions, as well as block-level content such as paragraphs,
-      lists, and tables. </shortdesc>
-    <!--<shortdesc>The <xmlelement>abstract</xmlelement> element occurs between the topic title and the topic body. It is presented as the initial content of a topic. The <xmlelement>abstract</xmlelement> can contain paragraph-level content as well as one or more <xmlelement>shortdesc</xmlelement> elements, which can be used for providing link previews.</shortdesc>-->
-  </abstract>
+  <shortdesc>An abstract summarizes the content of the topic; it appears at
+    the start of the topic. It can contain multiple short descriptions, as
+    well as block-level content such as paragraphs, lists, and tables. </shortdesc>
 	<prolog>
 		<metadata>
 			<keywords>
@@ -40,10 +36,10 @@
             facilitate conditional processing.</li>
         </ul>
       </div>
-      <!--<div rev="review-a"><p>The <xmlelement>abstract</xmlelement> element is designed for use when the initial paragraph of a topic is unsuitable as a link preview or hover text. This might occur in the following circumstances:</p><ul><li>The initial paragraph contains lists, tables, or other block-level elements.</li><li>Only a portion of the content of the initial paragraph is suitable for a link preview.</li><li>The initial paragraph contains multiple short descriptions.</li></ul></div>-->
-      <p>When the initial paragraph is suitable as a link preview, simply
-        place the content in a <xmlelement>shortdesc</xmlelement> element
-        rather than in an <xmlelement>abstract</xmlelement> element.</p>
+      <p>When the initial paragraph is suitable as a link preview, authors
+        should simply place the content in a
+          <xmlelement>shortdesc</xmlelement> element rather than in an
+          <xmlelement>abstract</xmlelement> element.</p>
 		</section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
@@ -70,12 +66,13 @@
         <title><xmlelement>abstract</xmlelement> with phrase-level short
           description</title>
         <p>The following code sample shows an
-            <xmlelement>abstract</xmlelement> element that contains
-          phrase-level content, in addition to a short description:</p>
-        <codeblock>&lt;abstract>
-  &lt;shortdesc>Use the wonderful Widget to automatically vacuum your house.
+            <xmlelement>abstract</xmlelement> element that contains a short
+          description, as well as additional phrase-level content:</p>
+        <codeblock><b>&lt;abstract></b>
+  &lt;shortdesc>
+      Use the wonderful Widget to automatically vacuum your house.
   &lt;/shortdesc> It requires a 1800 lithium ion battery.
-&lt;/abstract></codeblock>
+<b>&lt;/abstract></b></codeblock>
         <p>While the complete content of the
             <xmlelement>abstract</xmlelement> element is rendered as the
           first paragraph of the topic, only the content of the
@@ -86,18 +83,19 @@
         <title><xmlelement>abstract</xmlelement> with block-level short
           description</title>
         <p>The following code sample shows an
-            <xmlelement>abstract</xmlelement> element that contains
-          block-level content, in addition to a short description: </p>
-        <codeblock>&lt;abstract>
-  &lt;shortdesc>You have many options for arranging lodging in Brussels: 
-      hotels, bed and breakfasts, youth hostels, and flats. You can select
-      from a wide price range.&lt;/shortdesc>
+            <xmlelement>abstract</xmlelement> element that contains a short
+          description, as well as additional block-level content: </p>
+        <codeblock><b>&lt;abstract></b>
+  &lt;shortdesc>
+      You have many options for arranging lodging in Brussels: hotels, bed and
+      breakfasts, youth hostels, and flats. You can select from a wide price range.
+  &lt;/shortdesc>
   &lt;p>The following table explains the symbols that are used to indicate the price
      categories of the lodging options:&lt;/p>
   &lt;simpletable>
     &lt;! -- ... -->
   &lt;/simpletable>
-&lt;/abstract></codeblock>
+<b>&lt;/abstract></b></codeblock>
       </fig>
       <fig>
         <title><xmlelement>abstract</xmlelement> with multiple short
@@ -106,14 +104,16 @@
             <xmlelement>abstract</xmlelement> element that contains
           multiple short descriptions, which will be filtered when the
           topic is processed:</p>
-        <codeblock>&lt;abstract>
-  &lt;shortdesc platform="free-version">The free version of the platform
-      provides a single e-mail list, storage for up to one gigabyte of
-      files, and will support up to 100 users.&lt;/shortdesc>
-  &lt;shortdesc platform="premium-version">The premium version of the platform
-      provides multiple e-mails lists, storage for up to 30 gigabytes of
-      files, and will support up to 400 users.&lt;/shortdesc>
-&lt;/abstract></codeblock>
+        <codeblock><b>&lt;abstract></b>
+  &lt;shortdesc platform="free-version">
+      The free version of the platform provides a single e-mail list, storage 
+      for up to one gigabyte of files, and will support up to 100 users.
+  &lt;/shortdesc>
+  &lt;shortdesc platform="premium-version">
+      The premium version of the platform provides multiple e-mails lists, 
+      storage for up to 30 gigabytes of files, and will support up to 400 users.
+  &lt;/shortdesc>
+<b>&lt;/abstract></b></codeblock>
       </fig>
     </example>
 </refbody>

--- a/specification/langRef/base/body.dita
+++ b/specification/langRef/base/body.dita
@@ -7,14 +7,15 @@
     <section conkeyref="reuse-body/attributes" id="attributes"/>
 <example id="example" otherprops="examples"><title>Example</title>
       
-      <p>The following code sample shows a DITA topic that contains a title and a body.</p>
-      <codeblock>&lt;topic id="styleguidebold"&gt;
-  &lt;title&gt;MyCompany Style Guide: the &lt;xmlelement&gt;b&lt;/xmlelement&gt; element&lt;/title&gt;
+      <p>The following code sample shows a DITA topic that contains a title
+        and a body:</p>
+      <codeblock><b>&lt;topic id="styleguide-bold"&gt;</b>
+  &lt;title&gt;Acme style guide: &lt;xmlelement&gt;b&lt;/xmlelement&gt; element&lt;/title&gt;
   &lt;body&gt;
-    &lt;p&gt;Use the bold tag &lt;b&gt;for visual emphasis only&lt;/b&gt;. Do not use it if another 
-phrase-level element better signifies the reason for the emphasis.
+    &lt;p&gt;Use the bold tag for visual emphasis only. Do not use it if another 
+       phrase-level element better signifies the reason for the emphasis.
     &lt;/p&gt;
   &lt;/body&gt;
-&lt;/topic&gt;</codeblock></example>
+<b>&lt;/topic></b></codeblock></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/bodydiv.dita
+++ b/specification/langRef/base/bodydiv.dita
@@ -17,8 +17,6 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The <xmlelement>bodydiv</xmlelement> element cannot contain a title. If a title is
-        required, use nested topics.</p>
       <p>The <xmlelement>bodydiv</xmlelement> element is often used to group a sequence of related
         elements for reuse, so that another topic can reference the entire set with a single
           <xmlatt>conref</xmlatt> or <xmlatt>conkeyref</xmlatt> attribute.</p>
@@ -27,6 +25,8 @@
         element allows <xmlelement>section</xmlelement>, it cannot be used within
           <xmlelement>section</xmlelement> elements. Use the <xmlelement>div</xmlelement> element to
         group content that might occur in both topic bodies and sections.</p>
+      <p>The <xmlelement>bodydiv</xmlelement> element cannot contain a
+        title. If a title is required, use nested topics.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>
@@ -34,21 +34,17 @@
     </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows how the <xmlelement>bodydiv</xmlelement> element can be
-        used to group a sequence of elements for reuse:</p><codeblock>&lt;topic id="sample" xml:lang="en">
- &lt;title>Sample for bodydiv&lt;/title>
- &lt;body>
-  &lt;bodydiv id="reuse">
-   &lt;p>This set of information is reusable as a group.&lt;/p>
-   &lt;p>Lists of three contain three items.&lt;/p>
-   &lt;ul>
-    &lt;li>This is one item.&lt;/li>
-    &lt;li>This is another item.&lt;/li>
-    &lt;li>This is the third item.&lt;/li>
-   &lt;/ul>
-  &lt;/bodydiv>
-  &lt;p>This concludes my topic.&lt;/p>
- &lt;/body>
-&lt;/topic></codeblock></example>
+        used to group a sequence of elements for reuse:</p><codeblock>&lt;body>
+  <b>&lt;bodydiv id="mp-23475"></b>
+    &lt;p>The maintenance pack includes the following items:&lt;/p>
+    &lt;ul>
+      &lt;li>Gloves&lt;/li>
+      &lt;li>Small screwdriver&lt;/li>
+      &lt;li>Part #23475&lt;/li>
+    &lt;/ul>
+  <b>&lt;/bodydiv></b>
+  &lt;!-- ... -->
+&lt;/body></codeblock></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -9,7 +9,7 @@
       <title>Usage information</title>
       <p rev="review-a">The ditabase document type is a container topic
         that can manage any sequence of any type of topic. It can be used
-        to hold elements designed for reuse; it is also useful as an
+        to hold elements designed for reuse, and it is also useful as an
         intermediate output for conversion operations.</p>
       <p>The <xmlelement>dita</xmlelement> element cannot be specialized.
         Topic nesting rules can be configured in the document-type
@@ -28,7 +28,7 @@
         <xmlelement>concept</xmlelement>,
           <xmlelement>reference</xmlelement>, and
           <xmlelement>task</xmlelement> elements are all specializations of
-          <xmlelement>topic</xmlelement>.</p><codeblock>&lt;dita&gt;
+          <xmlelement>topic</xmlelement>.</p><codeblock><b>&lt;dita&gt;</b>
   &lt;concept id="batintro"&gt;
     &lt;title>Intro to bats&lt;/title>
     &lt;conbody>
@@ -48,6 +48,6 @@
     &lt;/refbody>
   &lt;/reference&gt;
       &lt;!-- ... -->
-&lt;/dita></codeblock></example>
+<b>&lt;/dita></b></codeblock></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -42,15 +42,15 @@
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows how the
           <xmlelement>related-link</xmlelement> element <ph rev="review-a"
           >is used to specify stable links to external and local
-          information:</ph></p><codeblock>&lt;related-links>
+          information:</ph></p><codeblock><b>&lt;related-links></b>
   &lt;link href="http://www.example.org" scope="external" format="html">
-    &lt;linktext>Example 1&lt;/linktext>
+    &lt;linktext>Example #1&lt;/linktext>
   &lt;/link>
   &lt;link href="additional-details.dita">
-    &lt;!-- Link to a local topic for more detail, with link text
-         automated based on the target's title                 -->
+    &lt;!-- Link to a local topic for more detail. The link text is generated
+         based on the title of the topic. -->
   &lt;/link>
-&lt;/related-links></codeblock></example>
+<b>&lt;/related-links></b></codeblock></example>
 </refbody>
 </reference>
 

--- a/specification/langRef/base/shortdesc.dita
+++ b/specification/langRef/base/shortdesc.dita
@@ -31,7 +31,16 @@
         <title>Short description in a topic</title>
         <p>The following code sample shows how a <xmlelement>shortdesc</xmlelement> element can be
           used in a topic:</p>
-        <codeblock conkeyref="reuse-general/concept-codeblock" id="shortdesc-in-concept"/>
+        <codeblock id="shortdesc-in-concept">&lt;topic id="intro-to-bird-calling"&gt;
+  &lt;title&gt;Introduction to bird calling&lt;/title&gt;
+  &lt;<b>shortdesc&gt;</b>If you want to attract more birds to your Acme Bird Feeder, learn the art of 
+      bird calling. Bird calling is an efficient way to alert more birds to the presence of 
+      your bird feeder.
+  <b>&lt;/shortdesc&gt;</b>
+ &lt;body&gt;
+   &lt;!-- ... -->
+ &lt;/body&gt;
+&lt;/topic&gt;</codeblock>
       </fig>
       <fig>
         <title>Short description in a map</title>
@@ -41,30 +50,18 @@
           for the American Birding Association is generated.</p>
         <codeblock>&lt;map>
   &lt;title>Enjoying birds&lt;/title>
-    &lt;!-- ... -->
     &lt;topicref href="birds-in-colorado.dita"/>
     &lt;topicref href="bird-calling.dita"/>
     &lt;topicref href="https://www.birding.example.com/" format="external" type="html">
       &lt;topicmeta>
-        &lt;shortdesc>The American Birding Association is the only organization 
-        in North America that specifically caters to recreational birders.
-        Its mission is to "inspire all people to enjoy and protect wild birds."
+        <b>&lt;shortdesc></b>The American Birding Association is the only organization 
+            in North America that specifically caters to recreational birders.
+            Its mission is to "inspire all people to enjoy and protect wild birds."
+        <b>&lt;/shortdesc></b>
       &lt;/topicmeta>
     &lt;/topicref>
-    &lt;!-- ... -->
 &lt;/map>
-<!--<topicref href="myThing.dita">
-  <topicmeta>
-    <navtitle>Navigation title for my topic</navtitle>
-    <shortdesc>A description of myThing that is specific to this context.</shortdesc>
-  </topicmeta>
-</topicref>
-<topicref href="http://www.example.org" scope="external">
-  <topicmeta>
-    <navtitle>Example website</navtitle>
-    <shortdesc>The example.org address is often used in examples</shortdesc>
-  </topicmeta>
-</topicref>--></codeblock>
+</codeblock>
       </fig>
     </example>
   </refbody>

--- a/specification/langRef/base/title.dita
+++ b/specification/langRef/base/title.dita
@@ -19,11 +19,11 @@
       <p>The following code sample shows how titles are used for both the topic and a figure within
         the topic:</p>
    <codeblock>&lt;topic id="topicid">
-  &lt;title>Monitoring your heart rate with ThisDevice&lt;/title>
+  <b>&lt;title>Monitoring your heart rate&lt;/title></b>
   &lt;body>
     &lt;!-- ... -->
-    &lt;fig id="adjust-the-monitor">
-      &lt;title>Adjusting your monitor&lt;/title>
+    &lt;fig>
+      <b>&lt;title>Adjusting your monitor&lt;/title></b>
       &lt;p>If the monitor is not reporting, follow the directions
          in the video to adjust your equipment.&lt;/p>
       &lt;!-- ... -->

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -138,7 +138,7 @@
         <codeblock>&lt;map>
   &lt;title>Publication title&lt;/title>
   &lt;topicmeta>
-    &lt;titlealt title-role="subtitle">Publication subtitle&lt;/titlealt>
+    <b>&lt;titlealt title-role="subtitle">Publication subtitle&lt;/titlealt></b>
   &lt;/topicmeta>
 &lt;/map></codeblock>
         <p rev="review-c">An identical result could be achieved by using
@@ -152,9 +152,9 @@
           can specify several alternative titles:</p>
                 <codeblock>&lt;topicref keys="about" href="about.dita">
   &lt;topicmeta>
-    &lt;titlealt title-role="linking navigation">About the product&lt;/titlealt>
+    <b>&lt;titlealt title-role="linking navigation">About the product&lt;/titlealt>
     &lt;titlealt title-role="search">About&lt;/titlealt>
-    &lt;titlealt title-role="hint">About the Acme TextMax 5000&lt;/titlealt>
+    &lt;titlealt title-role="hint">About the Acme TextMax 5000&lt;/titlealt></b>
   &lt;/topicmeta>
 &lt;/topicref></codeblock>
                 <ol>

--- a/specification/langRef/base/topic.dita
+++ b/specification/langRef/base/topic.dita
@@ -6,8 +6,9 @@
 <refbody>
   <section conkeyref="reuse-topic/attributes" id="attributes"/>
 <example id="example" otherprops="examples">       <title>Example</title>
-   <p>The following code sample shows the primary structural components of a topic: title, short
-        description, prolog, body, and related links.</p><codeblock rev="review-a">&lt;topic id="topic">
+   <p>The following code sample shows the primary structural components of
+        a topic: title, short description, prolog, body, and related
+        links:</p><codeblock rev="review-a"><b>&lt;topic id="topic"></b>
   &lt;title>The basic structure of a topic&lt;/title>
   &lt;shortdesc>A topic has a well-established structure. &lt;/shortdesc>
   &lt;prolog>
@@ -19,7 +20,7 @@
      &lt;related-links>
        &lt;!--Related links can be defined directly in a topic or by using 
            a relationship table.-->&lt;/related-links>
-&lt;/topic></codeblock></example>
+<b>&lt;/topic></b></codeblock></example>
 </refbody>
 </reference>
 


### PR DESCRIPTION
 - Correct indentation
 - Add bold highlighting to emphasize the focus element