### PR TITLE
Add revision marking for content moved from "Formatting conventions" topic

### DIFF
--- a/specification/common/reuse-w-lwdita/reuse-b.dita
+++ b/specification/common/reuse-w-lwdita/reuse-b.dita
@@ -6,7 +6,7 @@
     is used to draw a reader's attention to a phrase without otherwise
     adding meaning to the content.</shortdesc>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>b</xmlelement>
         element is typically rendered in a bold font.</p>

--- a/specification/common/reuse-w-lwdita/reuse-em.dita
+++ b/specification/common/reuse-w-lwdita/reuse-em.dita
@@ -5,7 +5,7 @@
     <shortdesc id="shortdesc" platform="dita lwdita">Emphasis indicates
     special meaning or particular importance.</shortdesc>
     <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">For Western languages, the content of the
           <xmlelement>em</xmlelement> element is typically rendered in an

--- a/specification/common/reuse-w-lwdita/reuse-i.dita
+++ b/specification/common/reuse-w-lwdita/reuse-i.dita
@@ -7,7 +7,7 @@
     quoting a speaker, to show which words the speaker
     stressed.</shortdesc>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>i</xmlelement>
         element is typically rendered in an italic font.</p>

--- a/specification/common/reuse-w-lwdita/reuse-note.dita
+++ b/specification/common/reuse-w-lwdita/reuse-note.dita
@@ -22,7 +22,8 @@
           how to process the value.</p>
             </div>
         </section>
-    <section id="rendering-expectations" platform="dita lwdita">
+    <section id="rendering-expectations" platform="dita lwdita"
+      rev="rendering">
       <title>Rendering expectations</title>
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> render a
         label for notes. The content of the label depends on the values of

--- a/specification/common/reuse-w-lwdita/reuse-strong.dita
+++ b/specification/common/reuse-w-lwdita/reuse-strong.dita
@@ -5,7 +5,7 @@
     <shortdesc id="shortdesc" platform="dita lwdita">Strong text is text
     that is of greater importance than the surrounding text. </shortdesc>
     <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>strong</xmlelement>
         element is typically rendered in a bold font.</p>

--- a/specification/common/reuse-w-lwdita/reuse-sub.dita
+++ b/specification/common/reuse-w-lwdita/reuse-sub.dita
@@ -6,7 +6,7 @@
     that is printed below the line. It is frequently used in chemical and
     mathematical formulas.</shortdesc>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>sub</xmlelement>
         element is typically rendered lower in relationship to the

--- a/specification/common/reuse-w-lwdita/reuse-tt.dita
+++ b/specification/common/reuse-w-lwdita/reuse-tt.dita
@@ -6,7 +6,7 @@
     that is displayed on a fixed-width display such as a teletype,
     text-only screen, or line printer.</shortdesc>
   <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>tt</xmlelement>
         element is typically rendered in a monospaced font.</p>

--- a/specification/common/reuse-w-lwdita/reuse-u.dita
+++ b/specification/common/reuse-w-lwdita/reuse-u.dita
@@ -5,7 +5,7 @@
    <shortdesc id="shortdesc" platform="dita lwdita">An underline, also
     called an underscore, is a line immediately below a portion of text. </shortdesc>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p platform="dita">The content of the <xmlelement>u</xmlelement>
         element is typically underlined.</p>

--- a/specification/dita-2.0-specification-subjectScheme.ditamap
+++ b/specification/dita-2.0-specification-subjectScheme.ditamap
@@ -61,6 +61,12 @@
     <subjectdef keys="review-s"/>
     <subjectdef keys="2.0"/>
     <subjectdef keys="tc-review"/>
+    <subjectdef keys="rendering">
+      <topicmeta>
+        <shortdesc>Used for base when we moved content from "Formatting
+          expectations" topic into "Rendering expectations" sections of
+          individual topics</shortdesc>
+      </topicmeta></subjectdef>
   </subjectdef>
   <subjectdef keys="values-product">
     <subjectdef keys="DITA-1.3"/>

--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -11,7 +11,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p>The content of the <xmlelement>cite</xmlelement>element is
         typically rendered in a way that distinguishes it from the

--- a/specification/langRef/base/line-through.dita
+++ b/specification/langRef/base/line-through.dita
@@ -22,7 +22,7 @@
         purpose; it is not intended to be used for indicating
         revisions.</p>
     </section>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p>The content of the <xmlelement>line-through</xmlelement> element
         is rendered with a line struck through.. <ph rev="review-b">It is

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -15,8 +15,8 @@
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve the
         line breaks and spaces that are present in the content of a
           <xmlelement>lines</xmlelement> element.</p>
-      <p>The contents of the <xmlelement>lines</xmlelement> element is
-        typically rendered in a non-monospaced font.</p>
+      <p rev="rendering">The contents of the <xmlelement>lines</xmlelement>
+        element is typically rendered in a non-monospaced font.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/lq.dita
+++ b/specification/langRef/base/lq.dita
@@ -12,7 +12,7 @@
         <indexterm>quotations<indexterm>long</indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p>The contents of the <xmlelement>lq</xmlelement> element is
         typically rendered as an indented block.</p>

--- a/specification/langRef/base/note.dita
+++ b/specification/langRef/base/note.dita
@@ -8,15 +8,10 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-        <section conkeyref="reuse-note/usage-information" id="usage-information"><title/><p/></section>
-    <section id="rendering-expectations">
-      <title>Rendering expectations</title>
-      <p>Processors <term outputclass="RFC-2119">SHOULD</term> render a
-        label for notes. The content of the label depends on the values of
-        the <xmlatt>type</xmlatt> attribute.</p>
-      <p>A note is typically rendered in a way that stands out from the
-        surrounding content.</p>
-    </section>
+        <section conkeyref="reuse-note/usage-information"
+      id="usage-information"><title/><p/></section>
+    <section conkeyref="reuse-note/rendering-expectations"
+      ><title/><p/></section>
         <section conkeyref="reuse-note/attributes" id="attributes"/>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/base/overline.dita
+++ b/specification/langRef/base/overline.dita
@@ -14,7 +14,7 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="rendering-expectations">
+    <section id="rendering-expectations" rev="rendering">
       <title>Rendering expectations</title>
       <p>The content of the <xmlelement>overline</xmlelement> element is
         typically rendered with a line above it.</p>

--- a/specification/langRef/base/sup.dita
+++ b/specification/langRef/base/sup.dita
@@ -9,7 +9,7 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-    <section conkeyref="reuse-sup/rendering-expectations"
+    <section conkeyref="reuse-sup/rendering-expectations" rev="rendering"
       ><title/><p/></section>
 <section conkeyref="reuse-sup/specialization-hierarchy"
       id="specialization-hierarchy"/>

--- a/specification/langRef/base/u.dita
+++ b/specification/langRef/base/u.dita
@@ -8,12 +8,10 @@
 </keywords>
 </metadata></prolog>
 <refbody>
-    <section id="rendering-expectations">
-      <title>Rendering expectations</title>
-      <p>The content of the <xmlelement>u</xmlelement> element is typically
-        underlined.</p>
-    </section>
-      <section conkeyref="reuse-u/specialization-hierarchy" id="specialization-hierarchy"/>
+    <section conkeyref="reuse-u/rendering-expectations"
+      ><title/><p/></section>
+      <section conkeyref="reuse-u/specialization-hierarchy"
+      id="specialization-hierarchy"/>
       <section conkeyref="reuse-u/attributes" id="attributes"/>
 <example id="example" otherprops="examples"><title>Example</title>
          <p>The following code sample shows underlining used to provide emphasis in a marketing


### PR DESCRIPTION
- Emphasis and highlighting domain
- cite, lines, lq, and note topics