### PR TITLE
Remove xnal from resources list #898

### DIFF
--- a/specification/introduction/non-normative-references.dita
+++ b/specification/introduction/non-normative-references.dita
@@ -24,14 +24,6 @@
                 Materials</xref></ph></cite>,
           https://webstore.ansi.org/Standards/NEMA/ansiz5352011r2017-1668876.</dd>
       </dlentry>
-      <dlentry platform="tcdita">
-        <dt>[ciq-v3.0]</dt>
-        <dd>OASIS Committee Specification 02, <cite>Customer Information
-            Quality Specifications Version 3.0. Name (xNL), Address (xAL),
-            Name and Address (xNAL) and Party (xPIL)</cite>, <xref
-            href="http://www.oasis-open.org/committees/download.php/29877/OASIS%20CIQ%20V3.0%20CS02.zip"
-            format="html" scope="external"/>, 20 September 2008.</dd>
-      </dlentry>
       <dlentry rev="2.0">
         <dt>[HTML5]</dt>
         <dd><cite><ph><xref href="https://html.spec.whatwg.org/"


### PR DESCRIPTION
XNAL is being removed from the 2.0 spec, so it is not needed in the references list.