### PR TITLE
Wording fix and added comment

### DIFF
--- a/specification/archSpec/base/definition-of-ditamaps.dita
+++ b/specification/archSpec/base/definition-of-ditamaps.dita
@@ -33,18 +33,23 @@ the sequential order of the topics; and the relationships that exist
 among             those topics. Because DITA maps provide this context
 for topics, the topics themselves             can be relatively context-free;
 they can be used and reused in multiple different             contexts.</p>
-<p>DITA maps often represent a single deliverable, for example, a
-specific Web site, a             printed publication, or the online
-help for a product. DITA maps also can be             subcomponents
-for a single deliverable, for example, a DITA map might contain the
-            content for a chapter in a printed publication or the
-troubleshooting information for an             online help system.
-The DITA specification provides specialized map types; book maps 
-           represent printed publications, subject scheme maps represent
-taxonomic or ontological             classifications, and learning
-maps represent formal units of instruction and assessment.       
-     However, these map types are only a starter set of map types
-reflecting well-defined             requirements.</p>
+<p>DITA maps often represent a single deliverable, for example, a specific Web site, a printed
+                        publication, or the online help for a product. DITA maps also can be
+                        subcomponents for a single deliverable, for example, a DITA map might
+                        contain the content for a chapter in a printed publication or the
+                        troubleshooting information for an online help system. The DITA
+                        specification provides specialized map types; book maps represent printed
+                        publications, and subject scheme maps represent taxonomic or ontological
+                        classifications. However, these map types are only a starter set of map
+                        types reflecting well-defined requirements.<draft-comment author="robander"
+                                time="7 April 2023">Updated to remove "learning" as a type of map
+                                the spec provides.<p>With tech comm becoming a separate spec, is it
+                                        really correct to say "The DITA specification
+                                        provides...book maps"? We could say "The DITA specifications
+                                        provide" (plural)? That seems simpler for an overview topic
+                                        than trying to explain "This package has one specialization
+                                        and another package [out later] has book
+                                maps"</p></draft-comment></p>
 <p>DITA maps establish relationships through the nesting of <xmlelement>topicref</xmlelement>
                         elements and the application of the <xmlatt>collection-type</xmlatt>
                         attribute. Relationship tables also <ph >can</ph> be


### PR DESCRIPTION
Removes "learning and training" from a list of map specializations provided by the spec, as that's not part of DITA 2.0.

Also adds a comment with some wording suggestions, we need to tweak how we refer to book maps as they are no longer part of this specific specification.