### PR TITLE
DITAVAL RNG updated to match DITA patterns

### DIFF
--- a/doctypes/rng/ditaval/ditaval.rng
+++ b/doctypes/rng/ditaval/ditaval.rng
@@ -58,19 +58,19 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
   </moduleDesc>
 
   <start>
-    <ref name="val"/>
+    <ref name="val.element"/>
   </start>
 
-  <define name="val">
+  <define name="val.element">
     <element name="val">
       <ref name="attlist.val"/>
       <optional>
-        <ref name="style-conflict"/>
+        <ref name="style-conflict.element"/>
       </optional>
       <zeroOrMore>
         <choice>
-          <ref name="prop"/>
-          <ref name="revprop"/>
+          <ref name="prop.element"/>
+          <ref name="revprop.element"/>
         </choice>
       </zeroOrMore>
     </element>
@@ -79,7 +79,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     <empty/>
   </define>
 
-  <define name="style-conflict">
+  <define name="style-conflict.element">
     <element name="style-conflict">
       <ref name="attlist.style-conflict"/>
       <empty/>
@@ -94,14 +94,14 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     </optional>
   </define>
 
-  <define name="prop">
+  <define name="prop.element">
     <element name="prop">
       <ref name="attlist.prop"/>
       <optional>
-        <ref name="startflag"/>
+        <ref name="startflag.element"/>
       </optional>
       <optional>
-        <ref name="endflag"/>
+        <ref name="endflag.element"/>
       </optional>
     </element>
   </define>
@@ -136,11 +136,11 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     </optional>
   </define>
 
-  <define name="startflag">
+  <define name="startflag.element">
     <element name="startflag">
       <ref name="attlist.startflag"/>
       <optional>
-        <ref name="alt-text"/>
+        <ref name="alt-text.element"/>
       </optional>
     </element>
   </define>
@@ -150,11 +150,11 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     </optional>
   </define>
 
-  <define name="endflag">
+  <define name="endflag.element">
     <element name="endflag">
       <ref name="attlist.endflag"/>
       <optional>
-        <ref name="alt-text"/>
+        <ref name="alt-text.element"/>
       </optional>
     </element>
   </define>
@@ -164,7 +164,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     </optional>
   </define>
   
-  <define name="alt-text">
+  <define name="alt-text.element">
     <element name="alt-text">
       <ref name="attlist.alt-text"/>
       <text/>
@@ -174,14 +174,14 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
     <empty/>
   </define>
   
-  <define name="revprop">
+  <define name="revprop.element">
     <element name="revprop">
       <ref name="attlist.revprop"/>
       <optional>
-        <ref name="startflag"/>
+        <ref name="startflag.element"/>
       </optional>
       <optional>
-        <ref name="endflag"/>
+        <ref name="endflag.element"/>
       </optional>
     </element>
   </define>


### PR DESCRIPTION
Updating RNG definitions to follow patterns used in the rest of the DITA grammar files

Goal is to better enable scripts that are generating content based on our grammar files