### PR TITLE
Add error condition metadata

### DIFF
--- a/specification/archSpec/base/branch-filtering-handling-conflicts.dita
+++ b/specification/archSpec/base/branch-filtering-handling-conflicts.dita
@@ -5,16 +5,19 @@
     <shortdesc>It is possible to construct a root map where the branch filtering mechanism results
         in resource name conflicts.</shortdesc>
     <conbody>
-        <p>It is an error if <xmlelement>ditavalref</xmlelement>-driven branch cloning results in
-            multiple copies of a topic that have the same resolved name. Processors <term
-                outputclass="RFC-2119">SHOULD</term> report an error in such cases. Processors <term
-                outputclass="RFC-2119">MAY</term> recover by using an alternate naming scheme for
-            the conflicting topics.</p>
-        <p>In rare cases, a single topic might appear in different branches that set different
-            conditions, yet still produce the same result. For example, a topic might appear in both
-            the admin and novice copies of a branch but not contain content that is tailored to
-            either audience; in that case, the filtered copies would match. A processor <term
-                outputclass="RFC-2119">MAY</term> consider this form of equivalence when determining
-            if two references to the same resource should be reported as an error.</p>
+        <div outputclass="errorcondition">
+            <p>It is an error if <xmlelement>ditavalref</xmlelement>-driven branch cloning results
+                in multiple copies of a topic that have the same resolved name. Processors <term
+                    outputclass="RFC-2119">SHOULD</term> report an error in such cases. Processors
+                    <term outputclass="RFC-2119">MAY</term> recover by using an alternate naming
+                scheme for the conflicting topics.</p>
+            <p>In rare cases, a single topic might appear in different branches that set different
+                conditions, yet still produce the same result. For example, a topic might appear in
+                both the admin and novice copies of a branch but not contain content that is
+                tailored to either audience; in that case, the filtered copies would match. A
+                processor <term outputclass="RFC-2119">MAY</term> consider this form of equivalence
+                when determining if two references to the same resource should be reported as an
+                error.</p>
+        </div>
     </conbody>
 </concept>

--- a/specification/archSpec/base/cascading-of-roles-in-specialized-maps.dita
+++ b/specification/archSpec/base/cascading-of-roles-in-specialized-maps.dita
@@ -61,18 +61,14 @@
       processed as if they are <xmlelement>mapref</xmlelement> elements. The <xmlatt>class</xmlatt>
       attribute from the <xmlelement>mapref</xmlelement> element (<codeph>"+ map/topicref
         mapgroup-d/mapref "</codeph>) does not cascade to the referenced map.</p>
-  <p>In some cases, preserving the role of the referencing element might
-      result in out-of-context content. For example, a
-        <xmlelement>chapter</xmlelement> element that references a bookmap
-      might pull in <xmlelement>part</xmlelement> elements that contain
-      nested <xmlelement>chapter</xmlelement> elements. Treating the
-        <xmlelement>part</xmlelement> element as a
-        <xmlelement>chapter</xmlelement> will result in a chapter that
-      nests other chapters, which is not valid in bookmap and might not be
-      understandable by processors. The result is implementation
-        specific<ph rev="review-k">. P</ph>rocessors <term
-        outputclass="RFC-2119">MAY</term> choose to treat this as an error,
-      issue a warning, or simply assign new roles to the problematic
-      elements.</p>
+  <p outputclass="errorcondition">In some cases, preserving the role of the referencing element
+      might result in out-of-context content. For example, a <xmlelement>chapter</xmlelement>
+      element that references a bookmap might pull in <xmlelement>part</xmlelement> elements that
+      contain nested <xmlelement>chapter</xmlelement> elements. Treating the
+        <xmlelement>part</xmlelement> element as a <xmlelement>chapter</xmlelement> will result in a
+      chapter that nests other chapters, which is not valid in bookmap and might not be
+      understandable by processors. The result is implementation specific<ph rev="review-k">.
+      P</ph>rocessors <term outputclass="RFC-2119">MAY</term> choose to treat this as an error,
+      issue a warning, or simply assign new roles to the problematic elements.</p>
  </conbody>
 </concept>

--- a/specification/archSpec/base/generalization-attributes.dita
+++ b/specification/archSpec/base/generalization-attributes.dita
@@ -51,9 +51,10 @@
       <codeblock base="ci-xml">&lt;p person="jobrole(programmer)" jobrole="admin">
     &lt;!-- ... -->
 &lt;/p></codeblock>
+      <p>This is an error condition, since it means the document has been only partially
+        generalized, or that the document has been generalized and then edited using a specialized
+        document type. </p>
     </div>
-    <p>This is an error condition, since it means the document has been only partially generalized,
-      or that the document has been generalized and then edited using a specialized document type. </p>
   </conbody>
 </concept>
 

--- a/specification/archSpec/base/generalization-processor-expectations.dita
+++ b/specification/archSpec/base/generalization-processor-expectations.dita
@@ -60,11 +60,11 @@
     <stentry>Check whether the <xmlatt>class</xmlatt> attribute contains the target module. If it
      does contain the target, rename the element to the value associated with the target module.
      Otherwise, ignore the element.</stentry>
-    <stentry>It is an error if the root element matches a specified source but its
-      <xmlatt>class</xmlatt> attribute does not contain the target. If the root element matches a
-     specified source module and its <xmlatt>class</xmlatt> attribute does contain the target
-     module, generalize to the target module. Otherwise, ignore the structural type instance unless
-     it has domains to generalize.</stentry>
+    <stentry outputclass="errorcondition">It is an error if the root element matches a specified
+     source but its <xmlatt>class</xmlatt> attribute does not contain the target. If the root
+     element matches a specified source module and its <xmlatt>class</xmlatt> attribute does contain
+     the target module, generalize to the target module. Otherwise, ignore the structural type
+     instance unless it has domains to generalize.</stentry>
    </strow>
   </simpletable>
   <p>For each element in a candidate structural type instance:</p>
@@ -87,11 +87,12 @@
     <stentry>Check whether the <xmlatt>class</xmlatt> attribute contains the target module; rename
      the element to the value associated with the target module if it does contain the target,
      otherwise ignore the element.</stentry>
-    <stentry>It is an error if the last value in the <xmlatt>class</xmlatt> attribute matches a
-     specified source but the previous values do not include the target. If the last value in the
-      <xmlatt>class</xmlatt> attribute matches a specified source module and the previous values do
-     include the target module, rename the element to the value associated with the target module.
-     Otherwise, ignore the element.</stentry>
+    <stentry outputclass="errorcondition">It is an error if the last value in the
+      <xmlatt>class</xmlatt> attribute matches a specified source but the previous values do not
+     include the target. If the last value in the <xmlatt>class</xmlatt> attribute matches a
+     specified source module and the previous values do include the target module, rename the
+     element to the value associated with the target module. Otherwise, ignore the
+     element.</stentry>
    </strow>
   </simpletable>
   <p>When renaming elements during round-trip generalization, the generalization processor <term

--- a/specification/archSpec/base/impose-topicref-role.dita
+++ b/specification/archSpec/base/impose-topicref-role.dita
@@ -69,15 +69,16 @@
       simplify references to other maps. It does not force the content in other maps to be treated
       as <xmlelement>mapref</xmlelement> - no special role is created for the referenced content.
       For this reason, it is defined in the grammar file with a fixed value of <keyword>keeptarget</keyword>.</p>
-  <p>In some cases, preserving the role of a referencing element might result in out-of-context
-      content. For example, a <xmlelement>chapter</xmlelement> element in one bookmap could pull in
-      a <xmlelement>part</xmlelement> element from another bookmap, where that referenced
-        <xmlelement>part</xmlelement> also contains nested <xmlelement>chapter</xmlelement>
-      elements. Treating the <xmlelement>part</xmlelement> element as a
-        <xmlelement>chapter</xmlelement> will result in a chapter that nests other chapters, which
-      is not valid in bookmap and might not be understandable by processors. The result is
-      implementation specific. Processors <term outputclass="RFC-2119">MAY</term> choose to treat
-      this as an error, issue a warning, or simply assign new roles to the problematic elements.</p>
+  <p outputclass="errorcondition">In some cases, preserving the role of a referencing element might
+      result in out-of-context content. For example, a <xmlelement>chapter</xmlelement> element in
+      one bookmap could pull in a <xmlelement>part</xmlelement> element from another bookmap, where
+      that referenced <xmlelement>part</xmlelement> also contains nested
+        <xmlelement>chapter</xmlelement> elements. Treating the <xmlelement>part</xmlelement>
+      element as a <xmlelement>chapter</xmlelement> will result in a chapter that nests other
+      chapters, which is not valid in bookmap and might not be understandable by processors. The
+      result is implementation specific. Processors <term outputclass="RFC-2119">MAY</term> choose
+      to treat this as an error, issue a warning, or simply assign new roles to the problematic
+      elements.</p>
     <example>
       <title>Defining a fixed role for a specialized element</title>
       <p>In the Bookmap specialization from the OASIS DITA Technical Communications specializations,

--- a/specification/archSpec/base/index-redirection.dita
+++ b/specification/archSpec/base/index-redirection.dita
@@ -16,49 +16,51 @@
             reader should use <i>instead of</i> the current one, whereas the
                 <xmlelement>index-see-also</xmlelement> element contains text for an index entry
             that the reader should use <i>in addition to</i> the current one.</p>
-        <p>Generated index entries should not contain both locators and redirections. Therefore, it
-            is an error if the following conditions occur:</p>
-        <dl>
-            <dlentry>
-                <dt>An <xmlelement>indexterm</xmlelement> contains
-                        <xmlelement>index-see</xmlelement>, and the publication contains other
-                        <xmlelement>indexterm</xmlelement> with matching content</dt>
-                <dd>
-                    <p>An <xmlelement>indexterm</xmlelement> element contains an
-                            <xmlelement>index-see</xmlelement> element, and the publication contains
-                        one or more <xmlelement>indexterm</xmlelement> elements with matching
-                        textual content.</p>
-                    <p>For example, topics referenced by the master map include the following
-                        markup:</p>
-                    <codeblock>&lt;!-- Topic A -->
+        <div outputclass="errorcondition">
+            <p>Generated index entries should not contain both locators and redirections. Therefore,
+                it is an error if the following conditions occur:</p>
+            <dl id="dl_sct_jmr_pyb">
+                <dlentry>
+                    <dt>An <xmlelement>indexterm</xmlelement> contains
+                            <xmlelement>index-see</xmlelement>, and the publication contains other
+                            <xmlelement>indexterm</xmlelement> with matching content</dt>
+                    <dd>
+                        <p>An <xmlelement>indexterm</xmlelement> element contains an
+                                <xmlelement>index-see</xmlelement> element, and the publication
+                            contains one or more <xmlelement>indexterm</xmlelement> elements with
+                            matching textual content.</p>
+                        <p>For example, topics referenced by the master map include the following
+                            markup:</p>
+                        <codeblock id="codeblock_tct_jmr_pyb">&lt;!-- Topic A -->
 &lt;indexterm>memory stick
   &lt;index-see>USB drive&lt;/index-see>
 &lt;/indexterm>
 
 &lt;!-- Topic B -->
 &lt;indexterm>memory stick&lt;/indexterm></codeblock>
-                </dd>
-            </dlentry>
-            <dlentry>
-                <dt>An <xmlelement>indexterm</xmlelement> contains
-                        <xmlelement>index-see</xmlelement> and
-                        <xmlelement>index-see-also</xmlelement></dt>
-                <dd>
-                    <p>An <xmlelement>indexterm</xmlelement> element contains both an
-                            <xmlelement>index-see</xmlelement> element and an
-                            <xmlelement>index-see-also</xmlelement> element.</p>
-                    <p>For example, a topic contains the following
-                            <xmlelement>indexterm</xmlelement> element:</p>
-                    <codeblock>&lt;indexterm>
+                    </dd>
+                </dlentry>
+                <dlentry>
+                    <dt>An <xmlelement>indexterm</xmlelement> contains
+                            <xmlelement>index-see</xmlelement> and
+                            <xmlelement>index-see-also</xmlelement></dt>
+                    <dd>
+                        <p>An <xmlelement>indexterm</xmlelement> element contains both an
+                                <xmlelement>index-see</xmlelement> element and an
+                                <xmlelement>index-see-also</xmlelement> element.</p>
+                        <p>For example, a topic contains the following
+                                <xmlelement>indexterm</xmlelement> element:</p>
+                        <codeblock id="codeblock_uct_jmr_pyb">&lt;indexterm>
   memory stick
     &lt;index-see>USB drive&lt;/index-see>
     &lt;index-see-also>flash stick&lt;/index-see-also>
 &lt;/indexterm></codeblock>
-                </dd>
-            </dlentry>
-        </dl>
-        <p>A processor <term outputclass="RFC-2119">MAY</term> give an error message when it
-            encounters the following error conditions:<ul>
+                    </dd>
+                </dlentry>
+            </dl>
+        </div>
+        <p outputclass="errorcondition">A processor <term outputclass="RFC-2119">MAY</term> give an
+            error message when it encounters the following error conditions:<ul>
                 <li rev="review-1">An <xmlelement>indexterm</xmlelement> element contains an
                         <xmlelement>index-see</xmlelement> element, and the publication contains one
                     or more <xmlelement>indexterm</xmlelement> elements with matching textual

--- a/specification/archSpec/base/processing-key-references-general.dita
+++ b/specification/archSpec/base/processing-key-references-general.dita
@@ -56,9 +56,9 @@ content references, including the special processing for the <xmlatt>xml:lang</x
         </section>
         <section id="error-conditions">
             <title>Error conditions</title>
-            <p>If a referencing element contains a key reference with an undefined key, it is
-                processed as if there were no key reference, and the value of the
-                    <xmlatt>href</xmlatt> attribute is used as the reference. If the
+            <p outputclass="errorcondition">If a referencing element contains a key reference with
+                an undefined key, it is processed as if there were no key reference, and the value
+                of the <xmlatt>href</xmlatt> attribute is used as the reference. If the
                     <xmlatt>href</xmlatt> attribute is not specified, the element is not treated as
                 a navigation link. If it is an error for the element to be empty, an implementation
                     <term outputclass="RFC-2119">MAY</term> give an error message; it also <term

--- a/specification/archSpec/base/theconactionattribute.dita
+++ b/specification/archSpec/base/theconactionattribute.dita
@@ -93,9 +93,9 @@
         priority over those on the referenced element. The exception is that if the source element
         does not specify an ID, the ID on the referenced element remains; if the source element does
         specify an ID then that replaces the ID on the referenced element.</p>
-      <p>It is an error for two source topics to replace the same element. Applications <term
-          outputclass="RFC-2119">MAY</term> warn users if more than one element
-        attempts to replace a single target.</p>
+      <p outputclass="errorcondition">It is an error for two source topics to replace the same
+        element. Applications <term outputclass="RFC-2119">MAY</term> warn users if more than one
+        element attempts to replace a single target.</p>
     </section>
 <section id="pushing-content">
       <title>Pushing content before or after another element</title>
@@ -205,11 +205,11 @@ was not addressed in the original proposal.-->
         on an element that also uses the <xmlatt>conaction</xmlatt> attribute, the
           <xmlatt>conkeyref</xmlatt> attribute is used to determine the target of the conref push
         (as it would normally be used to determine the target of <xmlatt>conref</xmlatt>).</p>
-      <p>The conref push function does not provide the ability to push a range of elements, so it is
-        an error to specify the <xmlatt>conrefend</xmlatt> attribute together with the
-          <xmlatt>conaction</xmlatt> attribute. If the two are specified together an application can
-        recover by warning the user, ignoring the <xmlatt>conrefend</xmlatt> attribute, or with some
-        other implementation strategy.</p>
+      <p outputclass="errorcondition">The conref push function does not provide the ability to push
+        a range of elements, so it is an error to specify the <xmlatt>conrefend</xmlatt> attribute
+        together with the <xmlatt>conaction</xmlatt> attribute. If the two are specified together an
+        application can recover by warning the user, ignoring the <xmlatt>conrefend</xmlatt>
+        attribute, or with some other implementation strategy.</p>
     </section>
 </refbody>
 </reference>

--- a/specification/archSpec/base/theconrefendattribute.dita
+++ b/specification/archSpec/base/theconrefendattribute.dita
@@ -233,7 +233,7 @@
         </ul>
       </fig>
     </example>
-    <section id="error-conditions">
+    <section id="error-conditions" outputclass="errorcondition">
       <title>Error conditions</title>
       <p>When encountering an error condition, an implementation can issue an error message.</p>
       <table>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -323,18 +323,14 @@
                                 <dlentry id="image-scale">
                                         <dt id="attr-scale"><xmlatt>scale</xmlatt></dt>
                                         <dd>Specifies a percentage as an unsigned integer by which
-                                                to scale the image in the absence of any specified
-                                                image height or width; a value of 100 implies that
-                                                the image should be presented at its intrinsic size.
-                                                If a value has been specified for the
-                                                  <xmlatt>height</xmlatt> or <xmlatt>width</xmlatt>
-                                                attribute (or both), the <xmlatt>scale</xmlatt>
-                                                attribute is ignored.<p>It is an error if the value
-                                                  of this attribute is not an unsigned integer. In
-                                                  this case, the implementation might give an error
-                                                  message and might recover by ignoring this
-                                                  attribute. </p>
-                                        </dd>
+            to scale the image in the absence of any specified image height or width; a value of 100
+            implies that the image should be presented at its intrinsic size. If a value has been
+            specified for the <xmlatt>height</xmlatt> or <xmlatt>width</xmlatt> attribute (or both),
+            the <xmlatt>scale</xmlatt> attribute is ignored.<p outputclass="errorcondition">It is an
+              error if the value of this attribute is not an unsigned integer. In this case, the
+              implementation might give an error message and might recover by ignoring this
+              attribute. </p>
+          </dd>
                                 </dlentry>
                                 <dlentry id="image-scalefit"
           platform="dita">

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -282,14 +282,13 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
 <ph id="groupdefn">The attribute can also include groups of values specified using the same syntax as generalized attributes within <xmlatt>props</xmlatt>; see <xref href="../archSpec/base/generalization-attributes.dita"/> for details on grouping syntax.</ph>
 <ph id="dateformat">The date is specified using the ISO 8601 format: <varname>YYYY</varname>-<varname>MM</varname>-<varname>DD</varname>, where <varname>YYYY</varname> is the year, <varname>MM</varname> is the month (01 to 12), and <varname>DD</varname> is the day (01-31).</ph></lines>
                 </section>
-                <section id="section-9"><title>Reused error conditions</title><ph id="index-sort-as">When located
-                                within the <xmlelement>indexterm</xmlelement> element, the
-                                        <xmlelement>sort-as</xmlelement> element is equivalent to
-                                        <xmlelement>index-sort-as</xmlelement>. It is an error for
-                                an <xmlelement>indexterm</xmlelement> element to directly contain
-                                both <xmlelement>sort-as</xmlelement> and
-                                        <xmlelement>index-sort-as</xmlelement>
-                        elements.</ph></section>
+                <section id="section-9"><title>Reused error conditions</title><ph id="index-sort-as"
+        outputclass="errorcondition">When located within the <xmlelement>indexterm</xmlelement>
+        element, the <xmlelement>sort-as</xmlelement> element is equivalent to
+          <xmlelement>index-sort-as</xmlelement>. It is an error for an
+          <xmlelement>indexterm</xmlelement> element to directly contain both
+          <xmlelement>sort-as</xmlelement> and <xmlelement>index-sort-as</xmlelement>
+      elements.</ph></section>
     <section id="section-10">
       <title>Constraints material</title>
       <ul id="dtd-domains-contribution">

--- a/specification/common/reuse-w-lwdita/reuse-section.dita
+++ b/specification/common/reuse-w-lwdita/reuse-section.dita
@@ -27,11 +27,12 @@
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <p platform="dita">Processors <term outputclass="RFC-2119">SHOULD</term> treat the presence of
-        more than one <xmlelement>title</xmlelement> element in a <xmlelement>section</xmlelement>
-        element as an error.</p>
-      <p platform="lwdita">Processors <term outputclass="RFC-2119">SHOULD</term> treat the presence
-        of more than one title component in a section component as an error.</p>
+      <p platform="dita" outputclass="errorcondition">Processors <term outputclass="RFC-2119"
+          >SHOULD</term> treat the presence of more than one <xmlelement>title</xmlelement> element
+        in a <xmlelement>section</xmlelement> element as an error.</p>
+      <p platform="lwdita" outputclass="errorcondition">Processors <term outputclass="RFC-2119"
+          >SHOULD</term> treat the presence of more than one title component in a section component
+        as an error.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -780,8 +780,9 @@
                     referenced XML document is selected. Any grammar processing should be performed
                     during resolution, such that default attribute values are explicitly populated.
                     Prolog content must be discarded.</p>
-                  <p>It is an error to use <codeph>parse="xml"</codeph> anywhere other than within
-                      <xmlelement>foreign</xmlelement> or a specialization thereof.</p>
+                  <p outputclass="errorcondition">It is an error to use <codeph>parse="xml"</codeph>
+                    anywhere other than within <xmlelement>foreign</xmlelement> or a specialization
+                    thereof.</p>
                 </dd>
               </dlentry>
             </dl><p>Processors may support other values for the <xmlatt>parse</xmlatt> attribute

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -94,13 +94,13 @@
         Limitations.</draft-comment>
       <p>The following limitations apply when using the <xmlelement>ditavalref</xmlelement> element;
         these limitations cannot be enforced in a DTD or other XML grammar files.</p>
-      <p>When the use of the <xmlelement>ditavalref</xmlelement> element results in multiple copies
-        of a branch, resource names within that branch can be controlled with sub-elements of the
-        effective <xmlelement>ditavalref</xmlelement>. For situations where resource names are
-        relevant, it is an error condition for multiple <xmlelement>ditavalref</xmlelement> elements
-        to result in conflicting resource names for different content. For example, the following
-        map fragment would result in two distinct copies of  the <filepath>c.dita</filepath> topic
-        with the same file
+      <p outputclass="errorcondition">When the use of the <xmlelement>ditavalref</xmlelement>
+        element results in multiple copies of a branch, resource names within that branch can be
+        controlled with sub-elements of the effective <xmlelement>ditavalref</xmlelement>. For
+        situations where resource names are relevant, it is an error condition for multiple
+          <xmlelement>ditavalref</xmlelement> elements to result in conflicting resource names for
+        different content. For example, the following map fragment would result in two distinct
+        copies of the <filepath>c.dita</filepath> topic with the same file
         name:<codeblock>&lt;topicref href="c.dita">
   &lt;ditavalref href="one.ditaval"/>
   &lt;ditavalref href="two.ditaval"/>

--- a/specification/langRef/base/index-sort-as.dita
+++ b/specification/langRef/base/index-sort-as.dita
@@ -54,12 +54,12 @@ index entry would be sorted.</shortdesc>
                                         <xmlelement>index-sort-as</xmlelement> element but different
                                 base sort phrases will sort in the appropriate order, and will not
                                 merge into a single index entry.</p>
-                        <p id="multiple-index-sort-as">It is an error if there is more than one
-                                        <xmlelement>index-sort-as</xmlelement> child for a given
-                                        <xmlelement>indexterm</xmlelement>. An implementation might
-                                give an error message, and might recover from this error condition
-                                by ignoring all but the last
-                                <xmlelement>index-sort-as</xmlelement>.</p>
+                        <p id="multiple-index-sort-as" outputclass="errorcondition">It is an error
+                                if there is more than one <xmlelement>index-sort-as</xmlelement>
+                                child for a given <xmlelement>indexterm</xmlelement>. An
+                                implementation might give an error message, and might recover from
+                                this error condition by ignoring all but the last
+                                        <xmlelement>index-sort-as</xmlelement>.</p>
                         <p><ph conkeyref="reuse-general/index-sort-as"
                                         id="sort-as-error"/></p>
                 </section>

--- a/specification/langRef/base/topicgroup.dita
+++ b/specification/langRef/base/topicgroup.dita
@@ -37,10 +37,10 @@
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <p>When a map that contains a <xmlelement>topicgroup</xmlelement> element with a navigation
-        title is used to generate publication output, processors <term outputclass="RFC-2119"
-          >MUST</term> ignore the navigation title and <term outputclass="RFC-2119">MAY</term> issue
-        an error message.</p>
+      <p outputclass="errorcondition">When a map that contains a <xmlelement>topicgroup</xmlelement>
+        element with a navigation title is used to generate publication output, processors <term
+          outputclass="RFC-2119">MUST</term> ignore the navigation title and <term
+          outputclass="RFC-2119">MAY</term> issue an error message.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/ditaval/prop.dita
+++ b/specification/langRef/ditaval/prop.dita
@@ -55,16 +55,15 @@
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>
-      <p>The following markup in a DITAVAL document is an error condition:<ul>
-          <li>More than one <xmlelement>prop</xmlelement> element with no
-              <xmlatt>att</xmlatt> attribute</li>
-          <li>More than one <xmlelement>prop</xmlelement> element with the
-            same <xmlatt>att</xmlatt> attribute and no value </li>
-          <li>More than one <xmlelement>prop</xmlelement> element with the
-            same <xmlatt>att</xmlatt> attribute and same
-              <xmlatt>value</xmlatt></li>
-        </ul>Processors <term outputclass="RFC-2119">MAY</term> provide an
-        error or warning message for these error conditions.</p>
+      <p outputclass="errorcondition">The following markup in a DITAVAL document is an error condition:<ul>
+          <li>More than one <xmlelement>prop</xmlelement> element with no <xmlatt>att</xmlatt>
+            attribute</li>
+          <li>More than one <xmlelement>prop</xmlelement> element with the same <xmlatt>att</xmlatt>
+            attribute and no value </li>
+          <li>More than one <xmlelement>prop</xmlelement> element with the same <xmlatt>att</xmlatt>
+            attribute and same <xmlatt>value</xmlatt></li>
+        </ul>Processors <term outputclass="RFC-2119">MAY</term> provide an error or warning message
+        for these error conditions.</p>
       <div conkeyref="reuse-general/processing-outputclass"/>
     </section>
     <section id="attributes">

--- a/specification/langRef/ditaval/revprop.dita
+++ b/specification/langRef/ditaval/revprop.dita
@@ -35,12 +35,10 @@
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>
-      <p>It is an error to include more than one
-          <xmlelement>revprop</xmlelement> element with the same
-          <xmlatt>val</xmlatt> attribute. Recovery from this error is
-        implementation dependent. In such cases processors <term
-          outputclass="RFC-2119">MAY</term> provide an error or warning
-        message.</p>
+      <p outputclass="errorcondition">It is an error to include more than one
+          <xmlelement>revprop</xmlelement> element with the same <xmlatt>val</xmlatt> attribute.
+        Recovery from this error is implementation dependent. In such cases processors <term
+          outputclass="RFC-2119">MAY</term> provide an error or warning message.</p>
       <div conkeyref="reuse-general/processing-outputclass"/>
       <!--<p>[Details about processing expectations that should go elsewhere] If two or more DITAVAL properties apply <xmlatt>outputclass</xmlatt> flags to the same element, treat the flagged element as if each value was specified on that element's <xmlatt>outputclass</xmlatt> attribute; in that case, the order of those DITAVAL-based tokens is undefined. If the flagged element already specifies <xmlatt>outputclass</xmlatt>, treat the flagged element as if all DITAVAL-based <xmlatt>outputclass</xmlatt> values come first in the attribute.</p>-->
     </section>


### PR DESCRIPTION
Adding `outputclass="errorcondition"` to sections of the spec that identify error conditions for processors