### PR TITLE
Fix duplicate key for rendering

### DIFF
--- a/specification/common/key-definitions-library-topics.ditamap
+++ b/specification/common/key-definitions-library-topics.ditamap
@@ -3,7 +3,7 @@
 <map>
     <title>Key definitions: Library topics</title>
     <!--<keydef keys="library-short-descriptions" href="conref-short-descriptions.dita"/>-->
-    <keydef keys="rendering" href="conref-rendering-expectations.dita"/>
+    <keydef keys="rendering-expectations" href="conref-rendering-expectations.dita"/>
     <!-- Key definitions for reuse topics -->
     <keydef keys="reuse-general" href="conref-file.dita"/>
     <keydef keys="reuse-attributes" href="conref-attribute.dita"/>

--- a/specification/common/reuse-w-lwdita/reuse-image.dita
+++ b/specification/common/reuse-w-lwdita/reuse-image.dita
@@ -9,7 +9,7 @@
       <title>Rendering expectations</title>
       <p platform="dita lwdita">The referenced image typically is rendered
         in the main flow of the content.</p>
-      <p conkeyref="rendering/image-video" platform="dita lwdita"/>
+      <p conkeyref="rendering-expectations/image-video" platform="dita lwdita"/>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/base/hazardsymbol.dita
+++ b/specification/langRef/base/hazardsymbol.dita
@@ -23,7 +23,7 @@ a result of not avoiding a hazard, or any combination of these messages.</shortd
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <p conkeyref="rendering/image-video"/>
+      <p conkeyref="rendering-expectations/image-video"/>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -26,7 +26,7 @@
         </section>
         <section id="rendering-expectations">
             <title>Rendering expectations</title>
-            <p conkeyref="rendering/image-video"/>
+            <p conkeyref="rendering-expectations/image-video"/>
             <p>When an object cannot be rendered in a meaningful way, processors <term
                     outputclass="RFC-2119">SHOULD</term> present the contents of the
                     <xmlelement>fallback</xmlelement> element, if it is present.</p>

--- a/specification/langRef/ditaval/prop.dita
+++ b/specification/langRef/ditaval/prop.dita
@@ -51,7 +51,7 @@
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <div conkeyref="rendering/ditaval-rendering"/>
+      <div conkeyref="rendering-expectations/ditaval-rendering"/>
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>

--- a/specification/langRef/ditaval/revprop.dita
+++ b/specification/langRef/ditaval/revprop.dita
@@ -31,7 +31,7 @@
         can provide default alternate text to indicate the start and end
         point of the flagged content.</p>
       <!--<p><ph id="default-text">When no alternate text is specified for a revision flag, the default alternate text for <xmlelement>revprop</xmlelement> start of change is typically a localized translation of "Start of change", and the default alternate text for <xmlelement>revprop</xmlelement> end of change is typically a localized translation of "End of change". </ph></p>-->
-      <div conkeyref="rendering/ditaval-rendering"/>
+      <div conkeyref="rendering-expectations/ditaval-rendering"/>
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>


### PR DESCRIPTION
We've ended up with a duplicate key for `rendering`, one as an actual topic key and one as a subject key.

Updating one to be unique.