### PR TITLE
Remove invalid comment within attribute list parameter entity

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -189,7 +189,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                                     #IMPLIED
                keyscope
                           CDATA
-                                    #IMPLIED"
+                                    #IMPLIED
+               -- No subjectrefs --                                    
+                                    "
 >
 <!ENTITY % topicref-atts-no-toc-no-keyscope
               "collection-type
@@ -238,8 +240,10 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                                     #IMPLIED
                chunk
                           CDATA
-                                    #IMPLIED"
+                                    #IMPLIED               
+                                    "
 >
+<!-- No subjectRefs in preceding attribute set. -->
 <!ENTITY % topicref-atts-without-format
               "collection-type
                           (choice |


### PR DESCRIPTION
The comment inside the parameter entity replacement text is not valid. Causes a validation failure:

The attribute name must be specified in the attribute-list declaration for element "relcell".

Moved the comment to after the parameter entity declaration.