### PR TITLE
Make attribute IDs consistent for xml-attrname

### DIFF
--- a/specification/langRef/attributes/attribute-groups.dita
+++ b/specification/langRef/attributes/attribute-groups.dita
@@ -305,7 +305,7 @@
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="attributes-universal/xml-lang">
+        <dlentry conkeyref="attributes-universal/xmllang">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -1195,7 +1195,7 @@
             the element that cannot be changed or deleted by authors.</dd>
         </dlentry>
         <dlentry id="xmlnsditaarch" platform="dita lwdita">
-          <dt id="attr-xmlns-ditaarch"><xmlatt>xmlns:ditaarch</xmlatt>
+          <dt id="attr-xmlnsditaarch"><xmlatt>xmlns:ditaarch</xmlatt>
             <ph otherprops="attr-list-label">(architectural
               attributes)</ph></dt>
           <dd>Declares the default DITA namespace. This namespace is

--- a/specification/langRef/attributes/universalAttributes.dita
+++ b/specification/langRef/attributes/universalAttributes.dita
@@ -339,8 +339,8 @@
                 needed to be aware of.</p>
             </draft-comment></dd>
         </dlentry>
-        <dlentry id="xml-lang">
-          <dt id="attr-xml-lang"><xmlatt>xml:lang</xmlatt></dt>
+        <dlentry id="xmllang">
+          <dt id="attr-xmllang"><xmlatt>xml:lang</xmlatt></dt>
           <dd id="reusable-lang">Specifies the language and optional locale of the content that is
             contained in an element. Valid values are language tokens or the null string. The
               <xmlatt>xml:lang</xmlatt> attribute and its values are described in the <xref

--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -18,7 +18,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
-          keyref="attributes-common/attr-xmlns-ditaarch"><xmlatt>xmlns:ditaarch</xmlatt></xref>,
+          keyref="attributes-common/attr-xmlnsditaarch"><xmlatt>xmlns:ditaarch</xmlatt></xref>,
           <xref keyref="attributes-common/attr-DITAArchVersion"
           ><xmlatt>DITAArchVersion</xmlatt></xref>, and <ph conkeyref="reuse-attributes/ref-localizationatts"/>.</p>
     </section>

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -80,7 +80,7 @@
                 <sli><xref keyref="attributes-universal/translate"/></sli>
                 <sli><xref keyref="attributes-common/valign"/></sli>
                 <sli><xref keyref="attributes-common/value"/></sli>
-                <sli><xref keyref="attributes-universal/xml-lang"/></sli>
+                <sli><xref keyref="attributes-universal/xmllang"/></sli>
                 <sli><xref keyref="attributes-common/xmlnsditaarch"/></sli>
                 <sli><xref keyref="attributes-common/xmlspace"/></sli>
             </sl>

--- a/specification/langRef/review/universal-attributes.dita
+++ b/specification/langRef/review/universal-attributes.dita
@@ -42,7 +42,7 @@
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="attributes-universal/xml-lang">
+        <dlentry conkeyref="attributes-universal/xmllang">
           <dt/>
           <dd/>
         </dlentry>


### PR DESCRIPTION
We have attributes on `<dlentry>` for the attribute name, used all over for linking. Today those are `xmlnsditaarch`, `xmlspace`, and `xml-lang`. On the `<dt>` itself they are `attr-xmlns-ditaarch`, `attr-xmlspace`, and `attr-xml-lang`

Updating to make them consistent, no hyphen in the names, only with `attr-`