### PR TITLE
Make attr linking consistent

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -159,13 +159,13 @@
           conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="universal-outputclass-name" platform="dita">The following attributes
         are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/name"><xmlatt>name</xmlatt></xref>.</p><p id="universal-keyref" platform="dita">The following attributes are
+          keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p><p id="universal-keyref" platform="dita">The following attributes are
         available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
           keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-compact" platform="dita">The following attributes are available on this element:
                                         <ph conkeyref="reuse-attributes/ref-universalatts"/> and
-                                        <xref keyref="attributes-common/compact"
+                                        <xref keyref="attributes-common/attr-compact"
                                                 ><xmlatt>compact</xmlatt></xref>.</p><!--Used in <topic>, <concept>, etc.-->
                         <div id="topic-attributes">
         <p platform="dita">The following attributes are available on this
@@ -178,7 +178,7 @@
           conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="pre-attributes" platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-displayatts"/>, <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
-          keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p><p id="xref-attributes" platform="dita">The following attributes are available on this element: <ph
+          keyref="attributes-common/attr-xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p><p id="xref-attributes" platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p><div id="fn-attributes" platform="dita">

--- a/specification/common/reuse-w-lwdita/reuse-dl.dita
+++ b/specification/common/reuse-w-lwdita/reuse-dl.dita
@@ -23,7 +23,7 @@
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-compact"><xmlatt>compact</xmlatt></xref>.</p>
       <div conkeyref="reuse-lwdita-attributes/block-elements"
         platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-ol.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ol.dita
@@ -10,7 +10,7 @@
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-                    keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-compact"><xmlatt>compact</xmlatt></xref>.</p>
       <div conkeyref="reuse-lwdita-attributes/block-elements"
         platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-pre.dita
+++ b/specification/common/reuse-w-lwdita/reuse-pre.dita
@@ -35,7 +35,7 @@
          <p platform="dita">The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-displayatts"/>, <ph
                     conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
-                    keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
       <div conkeyref="reuse-lwdita-attributes/pre" platform="lwdita"/>
       </section>
 </refbody>

--- a/specification/common/reuse-w-lwdita/reuse-ul.dita
+++ b/specification/common/reuse-w-lwdita/reuse-ul.dita
@@ -9,7 +9,7 @@
       <title>Attributes</title>
       <p platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-compact"><xmlatt>compact</xmlatt></xref>.</p>
       <div conkeyref="reuse-lwdita-attributes/block-elements"
         platform="lwdita"/>
     </section>

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -21,9 +21,9 @@
             <p>The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
                     keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
-                    keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+                    keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
                     keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>,  <xref
-                    keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>,
+                    keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>,
                     <xref keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>,
                 and <xref keyref="attributes-universal/attr-translate"
                     ><xmlatt>translate</xmlatt></xref>.</p>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -19,9 +19,9 @@
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
           keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
-          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
           keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, <xref
           keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>, and <xref
           keyref="attributes-universal/attr-translate"><xmlatt>translate</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element,

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -117,8 +117,8 @@
             <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
           keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
-          keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/outputclass"><xmlatt>outputclass</xmlatt></xref>, and <xref
+          keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
+          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, and <xref
           keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>.</p>
         </section>
         <example>

--- a/specification/langRef/base/include.dita
+++ b/specification/langRef/base/include.dita
@@ -48,12 +48,12 @@ contents of the referenced resource at the location of the <xmlelement>include</
 If the content is unavailable to the processor or cannot be processed using the specified
 <xmlatt>parse</xmlatt> value, the contents of the <xmlelement>fallback</xmlelement> element, if any,
 are presented instead.</p>
-            <p>Processors <term outputclass="RFC-2119">SHOULD</term>
-        support the <xmlatt>parse</xmlatt> values <keyword>text</keyword>
-        and  <keyword>xml</keyword>.</p>
+            <p>Processors <term outputclass="RFC-2119">SHOULD</term> support the <xref
+                    keyref="attributes-common/attr-parse"><xmlatt>parse</xmlatt></xref> values
+                    <keyword>text</keyword> and <keyword>xml</keyword>.</p>
 <p>Processors <term outputclass="RFC-2119">SHOULD</term> detect the encoding of the referenced
                 document based on the rules described for the <xref
-                    keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>
+                    keyref="attributes-common/attr-encoding"><xmlatt>encoding</xmlatt></xref>
                 attribute.</p>
         </section>
         <section id="attributes">

--- a/specification/langRef/base/lines.dita
+++ b/specification/langRef/base/lines.dita
@@ -23,7 +23,7 @@
       <p>The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-displayatts"/>, <ph
                     conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
-                    keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples" rev="review-c">
       <title>Example</title>

--- a/specification/langRef/base/linklist.dita
+++ b/specification/langRef/base/linklist.dita
@@ -28,7 +28,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/collection-type"><xmlatt>collection-type</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>, <xref
           keyref="attributes-common/attr-duplicates"><xmlatt>duplicates</xmlatt></xref>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-otherrole"><xmlatt>otherrole</xmlatt></xref>, <xref

--- a/specification/langRef/base/linkpool.dita
+++ b/specification/langRef/base/linkpool.dita
@@ -28,7 +28,7 @@
 <section id="attributes"><title>Attributes</title>
    <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/collection-type"
+          keyref="attributes-common/attr-collection-type"
             ><xmlatt>collection-type</xmlatt></xref>, <xref
           keyref="attributes-common/attr-duplicates"
             ><xmlatt>duplicates</xmlatt></xref>, <xref

--- a/specification/langRef/base/no-topic-nesting.dita
+++ b/specification/langRef/base/no-topic-nesting.dita
@@ -24,7 +24,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attribute is available on this element: <xref
-                    keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>.</p>
+                    keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/base/sl.dita
+++ b/specification/langRef/base/sl.dita
@@ -25,7 +25,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
                     conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-                    keyref="attributes-common/compact"><xmlatt>compact</xmlatt></xref>.</p>
+                    keyref="attributes-common/attr-compact"><xmlatt>compact</xmlatt></xref>.</p>
     </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows how a simple list could be used in a
         topic that discusses related modules:</p>

--- a/specification/langRef/base/ux-window.dita
+++ b/specification/langRef/base/ux-window.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/class"><xmlatt>class</xmlatt></xref>, and the
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-idandconrefatts"/>, <ph conkeyref="reuse-attributes/ref-metadataatts"/>, <xref keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -7,15 +7,15 @@
         <section id="attributelist">
             <sl>
                 <sli><xref keyref="attributes-common/align"/></sli>
-                <sli><xref keyref="attributes-universal/audience"/></sli>
+                <sli><xref keyref="attributes-universal/attr-audience"/></sli>
                 <sli><xref keyref="elements-draft-comment/author"/></sli>
-                <sli><xref keyref="attributes-universal/base"/></sli>
+                <sli><xref keyref="attributes-universal/attr-base"/></sli>
                 <sli><xmlatt>callout</xmlatt></sli>
                 <sli><xref keyref="attributes-common/cascade"/></sli>
                 <sli><xref keyref="attributes-common/char"/></sli>
                 <sli><xref keyref="attributes-common/charoff"/></sli>
                 <sli><xref keyref="attributes-common/chunk"/></sli>
-                <sli><xref keyref="attributes-universal/class">class</xref></sli>
+                <sli><xref keyref="attributes-universal/attr-class">class</xref></sli>
                 <sli><xref keyref="attributes-common/collection-type"/></sli>
                 <sli><xref keyref="attributes-common/colsep"/></sli>
                 <sli><xref keyref="attributes-common/compact"/></sli>
@@ -24,8 +24,8 @@
                 <sli><xref keyref="attributes-universal/attr-conref"/></sli>
                 <sli><xref keyref="attributes-universal/attr-conrefend"/></sli>
                 <sli><xref keyref="attributes-common/datatype"/></sli>
-                <sli><xref keyref="attributes-universal/deliveryTarget"/></sli>
-                <sli><xref keyref="attributes-universal/dir"/></sli>
+                <sli><xref keyref="attributes-universal/attr-deliveryTarget"/></sli>
+                <sli><xref keyref="attributes-universal/attr-dir"/></sli>
                 <sli><xref keyref="elements-draft-comment/disposition"/></sli>
                 <sli><xref keyref="attributes-common/DITAArchVersion"/></sli>
                 <sli><xref keyref="elements-indexterm/start"/><xref keyref="elements-indexterm/end"
@@ -37,9 +37,9 @@
                 <sli><xref keyref="attributes-common/frame"/></sli>
                 <sli><xref keyref="attributes-common/golive"/></sli>
                 <sli><xref keyref="attributes-common/attr-href"/></sli>
-                <sli><xref keyref="attributes-universal/id"/></sli>
+                <sli><xref keyref="attributes-universal/attr-id"/></sli>
                 <!--<sli><xref keyref="elements-topic/topic-id"><xmlatt>id</xmlatt> on <xmlelement>topic</xmlelement></xref></sli>-->
-                <sli><xref keyref="attributes-universal/importance"/></sli>
+                <sli><xref keyref="attributes-universal/attr-importance"/></sli>
                 <sli><xref keyref="attributes-common/keycol"/></sli>
                 <sli><xref keyref="attributes-common/keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keyref"/></sli>
@@ -47,15 +47,15 @@
                 <sli><xref keyref="attributes-common/attr-keyscope"/></sli>
                 <sli><xref keyref="attributes-common/linking"/></sli>
                 <sli><xref keyref="attributes-common/name"/></sli>
-                <sli><xref keyref="attributes-universal/otherprops"/></sli>
-                <sli><xref keyref="attributes-universal/outputclass"/></sli>
+                <sli><xref keyref="attributes-universal/attr-otherprops"/></sli>
+                <sli><xref keyref="attributes-universal/attr-outputclass"/></sli>
                 <sli><xref keyref="attributes-common/parse"/></sli>
-                <sli><xref keyref="attributes-universal/platform"/></sli>
+                <sli><xref keyref="attributes-universal/attr-platform"/></sli>
                 <sli><xref keyref="attributes-common/processing-role"/></sli>
-                <sli><xref keyref="attributes-universal/product"/></sli>
-                <sli><xref keyref="attributes-universal/props"/></sli>
+                <sli><xref keyref="attributes-universal/attr-product"/></sli>
+                <sli><xref keyref="attributes-universal/attr-props"/></sli>
                 <sli><xref keyref="attributes-common/relcolwidth"/></sli>
-                <sli><xref keyref="attributes-universal/rev"/></sli>
+                <sli><xref keyref="attributes-universal/attr-rev"/></sli>
                 <sli><xref keyref="attributes-common/attr-role"/></sli>
                 <sli><xref keyref="attributes-common/attr-otherrole"/></sli>
                 <sli><xref keyref="attributes-common/rowheader"/></sli>
@@ -66,7 +66,7 @@
                 <sli><xref keyref="attributes-common/search"/></sli>
                 <sli><xref keyref="attributes-common/specializations"/></sli>
                 <sli><xref keyref="elements-indexterm/start"/></sli>
-                <sli><xref keyref="attributes-universal/status"/></sli>
+                <sli><xref keyref="attributes-universal/attr-status"/></sli>
                 <sli><xref keyref="elements-draft-comment/time"/></sli>
                 <sli><xref keyref="attributes-common/toc"/></sli>
                 <sli><xmlatt>type</xmlatt></sli>
@@ -77,10 +77,10 @@
                             <xmlelement>hazardstatement</xmlelement></xref></sli>
             </sl>
             <sl>
-                <sli><xref keyref="attributes-universal/translate"/></sli>
+                <sli><xref keyref="attributes-universal/attr-translate"/></sli>
                 <sli><xref keyref="attributes-common/valign"/></sli>
                 <sli><xref keyref="attributes-common/value"/></sli>
-                <sli><xref keyref="attributes-universal/xmllang"/></sli>
+                <sli><xref keyref="attributes-universal/attr-xmllang"/></sli>
                 <sli><xref keyref="attributes-common/xmlnsditaarch"/></sli>
                 <sli><xref keyref="attributes-common/xmlspace"/></sli>
             </sl>

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -6,83 +6,83 @@
     <refbody>
         <section id="attributelist">
             <sl>
-                <sli><xref keyref="attributes-common/align"/></sli>
+                <sli><xref keyref="attributes-common/attr-align"/></sli>
                 <sli><xref keyref="attributes-universal/attr-audience"/></sli>
                 <sli><xref keyref="elements-draft-comment/author"/></sli>
                 <sli><xref keyref="attributes-universal/attr-base"/></sli>
                 <sli><xmlatt>callout</xmlatt></sli>
-                <sli><xref keyref="attributes-common/cascade"/></sli>
-                <sli><xref keyref="attributes-common/char"/></sli>
-                <sli><xref keyref="attributes-common/charoff"/></sli>
-                <sli><xref keyref="attributes-common/chunk"/></sli>
+                <sli><xref keyref="attributes-common/attr-cascade"/></sli>
+                <sli><xref keyref="attributes-common/attr-char"/></sli>
+                <sli><xref keyref="attributes-common/attr-charoff"/></sli>
+                <sli><xref keyref="attributes-common/attr-chunk"/></sli>
                 <sli><xref keyref="attributes-universal/attr-class">class</xref></sli>
-                <sli><xref keyref="attributes-common/collection-type"/></sli>
-                <sli><xref keyref="attributes-common/colsep"/></sli>
-                <sli><xref keyref="attributes-common/compact"/></sli>
+                <sli><xref keyref="attributes-common/attr-collection-type"/></sli>
+                <sli><xref keyref="attributes-common/attr-colsep"/></sli>
+                <sli><xref keyref="attributes-common/attr-compact"/></sli>
                 <sli><xref keyref="attributes-universal/attr-conaction"/></sli>
                 <sli><xref keyref="attributes-universal/attr-conkeyref"/></sli>
                 <sli><xref keyref="attributes-universal/attr-conref"/></sli>
                 <sli><xref keyref="attributes-universal/attr-conrefend"/></sli>
-                <sli><xref keyref="attributes-common/datatype"/></sli>
+                <sli><xref keyref="attributes-common/attr-datatype"/></sli>
                 <sli><xref keyref="attributes-universal/attr-deliveryTarget"/></sli>
                 <sli><xref keyref="attributes-universal/attr-dir"/></sli>
                 <sli><xref keyref="elements-draft-comment/disposition"/></sli>
-                <sli><xref keyref="attributes-common/DITAArchVersion"/></sli>
+                <sli><xref keyref="attributes-common/attr-DITAArchVersion"/></sli>
                 <sli><xref keyref="elements-indexterm/start"/><xref keyref="elements-indexterm/end"
                     /></sli>
-                <sli><xref keyref="attributes-common/encoding"/></sli>
-                <sli><xref keyref="attributes-common/expanse"/></sli>
-                <sli><xref keyref="attributes-common/expiry"/></sli>
+                <sli><xref keyref="attributes-common/attr-encoding"/></sli>
+                <sli><xref keyref="attributes-common/attr-expanse"/></sli>
+                <sli><xref keyref="attributes-common/attr-expiry"/></sli>
                 <sli><xref keyref="attributes-common/attr-format"/></sli>
-                <sli><xref keyref="attributes-common/frame"/></sli>
-                <sli><xref keyref="attributes-common/golive"/></sli>
+                <sli><xref keyref="attributes-common/attr-frame"/></sli>
+                <sli><xref keyref="attributes-common/attr-golive"/></sli>
                 <sli><xref keyref="attributes-common/attr-href"/></sli>
                 <sli><xref keyref="attributes-universal/attr-id"/></sli>
                 <!--<sli><xref keyref="elements-topic/topic-id"><xmlatt>id</xmlatt> on <xmlelement>topic</xmlelement></xref></sli>-->
                 <sli><xref keyref="attributes-universal/attr-importance"/></sli>
-                <sli><xref keyref="attributes-common/keycol"/></sli>
-                <sli><xref keyref="attributes-common/keyref"/></sli>
+                <sli><xref keyref="attributes-common/attr-keycol"/></sli>
+                <sli><xref keyref="attributes-common/attr-keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keyref"/></sli>
                 <sli><xref keyref="attributes-common/attr-keys"/></sli>
                 <sli><xref keyref="attributes-common/attr-keyscope"/></sli>
-                <sli><xref keyref="attributes-common/linking"/></sli>
-                <sli><xref keyref="attributes-common/name"/></sli>
+                <sli><xref keyref="attributes-common/attr-linking"/></sli>
+                <sli><xref keyref="attributes-common/attr-name"/></sli>
                 <sli><xref keyref="attributes-universal/attr-otherprops"/></sli>
                 <sli><xref keyref="attributes-universal/attr-outputclass"/></sli>
-                <sli><xref keyref="attributes-common/parse"/></sli>
+                <sli><xref keyref="attributes-common/attr-parse"/></sli>
                 <sli><xref keyref="attributes-universal/attr-platform"/></sli>
-                <sli><xref keyref="attributes-common/processing-role"/></sli>
+                <sli><xref keyref="attributes-common/attr-processing-role"/></sli>
                 <sli><xref keyref="attributes-universal/attr-product"/></sli>
                 <sli><xref keyref="attributes-universal/attr-props"/></sli>
-                <sli><xref keyref="attributes-common/relcolwidth"/></sli>
+                <sli><xref keyref="attributes-common/attr-relcolwidth"/></sli>
                 <sli><xref keyref="attributes-universal/attr-rev"/></sli>
                 <sli><xref keyref="attributes-common/attr-role"/></sli>
                 <sli><xref keyref="attributes-common/attr-otherrole"/></sli>
-                <sli><xref keyref="attributes-common/rowheader"/></sli>
-                <sli><xref keyref="attributes-common/rowsep"/></sli>
-                <sli><xref keyref="attributes-common/scale"/></sli>
-                <sli><xref keyref="attributes-common/scope"/></sli>
+                <sli><xref keyref="attributes-common/attr-rowheader"/></sli>
+                <sli><xref keyref="attributes-common/attr-rowsep"/></sli>
+                <sli><xref keyref="attributes-common/attr-scale"/></sli>
                 <sli><xref keyref="attributes-common/attr-scope"/></sli>
-                <sli><xref keyref="attributes-common/search"/></sli>
-                <sli><xref keyref="attributes-common/specializations"/></sli>
+                <sli><xref keyref="attributes-common/attr-scope"/></sli>
+                <sli><xref keyref="attributes-common/attr-search"/></sli>
+                <sli><xref keyref="attributes-common/attr-specializations"/></sli>
                 <sli><xref keyref="elements-indexterm/start"/></sli>
                 <sli><xref keyref="attributes-universal/attr-status"/></sli>
                 <sli><xref keyref="elements-draft-comment/time"/></sli>
-                <sli><xref keyref="attributes-common/toc"/></sli>
+                <sli><xref keyref="attributes-common/attr-toc"/></sli>
                 <sli><xmlatt>type</xmlatt></sli>
             </sl>
             <sl>
                 <sli><xref keyref="attributes-common/attr-type"/></sli>
-                <sli><xref keyref="elements-hazardstatement/type"><xmlatt>type</xmlatt> on
+                <sli><xref keyref="elements-hazardstatement/attr-type"><xmlatt>type</xmlatt> on
                             <xmlelement>hazardstatement</xmlelement></xref></sli>
             </sl>
             <sl>
                 <sli><xref keyref="attributes-universal/attr-translate"/></sli>
-                <sli><xref keyref="attributes-common/valign"/></sli>
-                <sli><xref keyref="attributes-common/value"/></sli>
+                <sli><xref keyref="attributes-common/attr-valign"/></sli>
+                <sli><xref keyref="attributes-common/attr-value"/></sli>
                 <sli><xref keyref="attributes-universal/attr-xmllang"/></sli>
-                <sli><xref keyref="attributes-common/xmlnsditaarch"/></sli>
-                <sli><xref keyref="attributes-common/xmlspace"/></sli>
+                <sli><xref keyref="attributes-common/attr-xmlnsditaarch"/></sli>
+                <sli><xref keyref="attributes-common/attr-xmlspace"/></sli>
             </sl>
         </section>
     </refbody>


### PR DESCRIPTION
For all universal and common attributes, we have `<dlentry id="name"><dt id="attr-name">` where `name` is the name of the attribute.

Links to these use a mix, with keys linking to `name` or `attr-name`

Making these consistent so that we have more consistent rendering