### PR TITLE
Restore cite element attributes

### DIFF
--- a/specification/langRef/base/cite.dita
+++ b/specification/langRef/base/cite.dita
@@ -17,6 +17,11 @@
         typically rendered in a way that distinguishes it from the
         surrounding text.</p>
     </section>
+    <section id="attributes">
+        <title>Attributes</title>
+        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+    </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows how the
           <xmlelement>cite</xmlelement> element can be used to mark up the


### PR DESCRIPTION
The attributes section for `<cite>` element was accidentally removed with this commit:
https://github.com/oasis-tcs/dita/commit/11b9cbb82531e0bd2c4f9e1e3f20951a72291a46#diff-76976665476beea64a35a2f65268d68da294c79d5d8f6acf92865ab1e54a39a7

This update just restores the section as it was