### PR TITLE
Fix typo, id hierachy should be hierarchy

### DIFF
--- a/specification/langRef/base/area.dita
+++ b/specification/langRef/base/area.dita
@@ -16,7 +16,7 @@
         the linkable region, as well as the link target and its link
         text.</p>
     </section>
-<section id="specialization-hierachy">
+<section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>area</xmlelement> element is specialized
         from <xmlelement>div</xmlelement>. It is defined in the utilities

--- a/specification/langRef/base/attributedef.dita
+++ b/specification/langRef/base/attributedef.dita
@@ -11,7 +11,7 @@
                 <indexterm>subject scheme maps<indexterm>elements<indexterm><xmlelement>attributedef</xmlelement></indexterm></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-        <section id="specialization-hierachy">
+        <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>attributedef</xmlelement> element is specialized from
                     <xmlelement>data</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/coords.dita
+++ b/specification/langRef/base/coords.dita
@@ -66,7 +66,7 @@
         </strow>
       </simpletable>
     </section>
-        <section id="specialization-hierachy">
+        <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>coords</xmlelement> element is specialized from
                     <xmlelement>ph</xmlelement>. It is defined in the utilities-domain module.</p>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -47,7 +47,7 @@
           automatically an error condition.</p>
       </draft-comment>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>defaultSubject</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/ditavalmeta.dita
+++ b/specification/langRef/base/ditavalmeta.dita
@@ -23,7 +23,7 @@
         can also contain other information, such as navigation title, that
         might be useful for map architects but is not intended for
         rendering.</p></section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>ditavalmeta</xmlelement> element is specialized from
           <xmlelement>topicmeta</xmlelement>. It is defined in the DITAVAL-reference domain

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -114,7 +114,7 @@
           a map that instructs it to create two files of the same name, with different filter
           conditions applied.</draft-comment></p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>ditavalref</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the DITAVAL-reference domain

--- a/specification/langRef/base/dvrKeyscopePrefix.dita
+++ b/specification/langRef/base/dvrKeyscopePrefix.dita
@@ -33,7 +33,7 @@
         specified, regardless of whether the branch as authored specifies a
           <xmlatt>keyscope</xmlatt> value.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>dvrKeyscopePrefix</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>

--- a/specification/langRef/base/dvrKeyscopeSuffix.dita
+++ b/specification/langRef/base/dvrKeyscopeSuffix.dita
@@ -33,7 +33,7 @@
         specified, regardless of whether the branch as authored specifies a
           <xmlatt>keyscope</xmlatt> value.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>dvrKeyscopeSuffix</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -28,7 +28,7 @@
       <p>Some resources are not eligible for renaming, such as those marked with
           <codeph>scope="external"</codeph>.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>dvrResourcePrefix</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -32,7 +32,7 @@
       <p>Some resources are not eligible for renaming, such as those marked with
           <codeph>scope="external"</codeph>.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>dvrResourceSuffix</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the DITAVAL-reference domain module.</p>

--- a/specification/langRef/base/elementdef.dita
+++ b/specification/langRef/base/elementdef.dita
@@ -9,7 +9,7 @@
         <indexterm>subject scheme<indexterm>elements<indexterm><xmlelement>elementdef</xmlelement></indexterm></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>elementdef</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -95,7 +95,7 @@
             </dl>
 
         </section>
-        <section id="specialization-hierachy">
+        <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>enumerationdef</xmlelement> element is specialized from
                     <xmlelement>topicref</xmlelement>. It is defined in the subject scheme

--- a/specification/langRef/base/imagemap.dita
+++ b/specification/langRef/base/imagemap.dita
@@ -30,7 +30,7 @@
         image maps. For print-based formats, it can be rendered as an image
         and a list of the specified link targets.</p>
 		</section>
-		<section id="specialization-hierachy">
+		<section id="specialization-hierarchy">
 			<title>Specialization hierarchy</title>
 			<p>The <xmlelement>imagemap</xmlelement> element is specialized from
           <xmlelement>div</xmlelement>. It is defined in the utilities

--- a/specification/langRef/base/linktitle.dita
+++ b/specification/langRef/base/linktitle.dita
@@ -46,7 +46,7 @@
       <p>Processing expectations are dictated by the rules for the
           <xmlelement>titlealt</xmlelement> element.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>linktitle</xmlelement> element is specialized from
           <xmlelement>titlealt</xmlelement>. It is defined in the

--- a/specification/langRef/base/navtitle.dita
+++ b/specification/langRef/base/navtitle.dita
@@ -22,7 +22,7 @@
       id="usage-information"><title/><p/></section>
     <section conkeyref="reuse-navtitle/processing-expectations"
       id="processing-expectations"><title/><p/></section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>navtitle</xmlelement> element is specialized from
           <xmlelement>titlealt</xmlelement>. It is defined in the

--- a/specification/langRef/base/schemeref.dita
+++ b/specification/langRef/base/schemeref.dita
@@ -12,7 +12,7 @@
 </metadata></prolog>
 <refbody>
     <!--<section id="processing-expectations"><title>Processing expectations</title><p>The values specified in the subject scheme maps are merged<ph rev="review-d">. The</ph> result is equivalent to specifying all of the values in a single map.</p></section>-->
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>schemeref</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/searchtitle.dita
+++ b/specification/langRef/base/searchtitle.dita
@@ -36,7 +36,7 @@
       <p>Processing expectations are dictated by the rules for the
           <xmlelement>titlealt</xmlelement> element.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>searchtitle</xmlelement> element is specialized
         from <xmlelement>titlealt</xmlelement>. It is defined in the

--- a/specification/langRef/base/shape.dita
+++ b/specification/langRef/base/shape.dita
@@ -42,7 +42,7 @@
       <p>If the <xmlelement>shape</xmlelement> element is left empty, a
         rectangular shape is assumed. </p>
         </section>
-        <section id="specialization-hierachy">
+        <section id="specialization-hierarchy">
             <title>Specialization hierarchy</title>
             <p>The <xmlelement>shape</xmlelement> element is specialized
         from <xmlelement>keyword</xmlelement>. It is defined in the

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -98,7 +98,7 @@
         </ul></p>
       <div conkeyref="reuse-general/sort-as-construction"/>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>sort-as</xmlelement> element is specialized from
           <xmlelement>data</xmlelement>. It is defined in the utilities-domain module.</p>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -23,7 +23,7 @@
           <xmlatt>keys</xmlatt> or <xmlatt>keyref</xmlatt> attribute, so it
         does not define any controlled values.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>subjectHead</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/subjectHeadMeta.dita
+++ b/specification/langRef/base/subjectHeadMeta.dita
@@ -12,7 +12,7 @@
                 elements<indexterm><xmlelement>subjectHeadMeta</xmlelement></indexterm></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>subjectHeadMeta</xmlelement> element is specialized from
           <xmlelement>topicmeta</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/subjectScheme.dita
+++ b/specification/langRef/base/subjectScheme.dita
@@ -12,7 +12,7 @@
                 scheme<indexterm>elements<indexterm><xmlelement>subjectScheme</xmlelement></indexterm></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>subjectScheme</xmlelement> element is specialized from
           <xmlelement>map</xmlelement>. It is defined in the subject scheme module.</p>

--- a/specification/langRef/base/subjectdef.dita
+++ b/specification/langRef/base/subjectdef.dita
@@ -23,7 +23,7 @@
           subject and how authors should use it when classifying content or
           specifying a value for an attribute.</ph></p>
                 </section>
-                <section id="specialization-hierachy">
+                <section id="specialization-hierarchy">
                         <title>Specialization hierarchy</title>
                         <p>The <xmlelement>subjectdef</xmlelement> element is specialized from
                                         <xmlelement>topicref</xmlelement>. It is defined in the

--- a/specification/langRef/base/subtitle.dita
+++ b/specification/langRef/base/subtitle.dita
@@ -29,7 +29,7 @@
       <p>Processing expectations are dictated by the rules for the
           <xmlelement>titlealt</xmlelement> element.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>subtitle</xmlelement> element is specialized from
           <xmlelement>titlealt</xmlelement>. It is defined in the

--- a/specification/langRef/base/titlehint.dita
+++ b/specification/langRef/base/titlehint.dita
@@ -27,7 +27,7 @@
       <p>Processing expectations are dictated by the rules for the
           <xmlelement>titlealt</xmlelement> element.</p>
     </section>
-    <section id="specialization-hierachy">
+    <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>titlehint</xmlelement> element is specialized from
           <xmlelement>titlealt</xmlelement>. It is defined in the


### PR DESCRIPTION
Most specialization hierarchy sections use `id="specialization-hierarchy"`, these topics had a typo and used `id="specialization-hierachy". This just corrects the type in the IDs. There are no cross references to these within our spec content.