### PR TITLE
Update GHA action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,15 @@ jobs:
     env:
       DITA_OT_VERSION: '3.5.4'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
           cache: 'gradle'
       - name: Cache DITA-OT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             dita-ot-${{ env.DITA_OT_VERSION }}.zip


### PR DESCRIPTION
GHA workflow https://github.com/oasis-tcs/dita/actions/runs/13141254481 failed with error message

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

This PR updates the GHA actions to latest versions.