### PR TITLE
Turn all chapters + appendices into submaps

### DIFF
--- a/specification/appendix-dita-constraint-modules.ditamap
+++ b/specification/appendix-dita-constraint-modules.ditamap
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>Appendix: Constraint modules</title>
+    <topicref
+        href="non-normative/developing-constraint-and-expansion-modules.dita">
+        <topicref href="archSpec/base/examples-constraints.dita">
+            <topicref
+                href="archSpec/base/example-contraints-redefine-content-model.dita"/>
+            <topicref
+                href="archSpec/base/example-contraints-redefine-content-model-attributes.dita"/>
+            <topicref href="archSpec/base/example-contraints-subset-domain.dita"/>
+            <topicref
+                href="archSpec/base/example-contraints-replace-base-element-w-domain-extensions.dita"/>
+            <topicref
+                href="archSpec/base/example-contraints-apply-multiple-constraints.dita"/>
+        </topicref>
+        <topicref
+            href="archSpec/base/examples-constraints-implemented-using-rng.dita">
+            <topicref
+                href="archSpec/base/example-rng-constraints-redefine-content-model.dita"/>
+            <topicref
+                href="archSpec/base/example-rng-constraints-redefine-content-model-attributes.dita"/>
+            <topicref
+                href="archSpec/base/example-constrain-a-domain-using-rng.dita"/>
+            <topicref
+                href="archSpec/base/example-rng-constraints-replace-base-element-w-domain-extensions.dita"/>
+            <topicref
+                href="archSpec/base/example-rng-constraints-apply-multiple-constraints.dita"
+            />
+        </topicref>
+    </topicref>
+</map>

--- a/specification/appendix-dita-expansion-modules.ditamap
+++ b/specification/appendix-dita-expansion-modules.ditamap
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>Appendix: Expansion modules</title>
+    <topicref
+        href="non-normative/expansion-modules.dita">
+        <topicref
+            href="archSpec/base/examples-expansion-implemented-using-dtds.dita">
+            <topicref
+                href="archSpec/base/adding-an-element-to-the-section-element.dita"/>
+            <topicref
+                href="archSpec/base/adding-an-attribute-to-certain-table-elements.dita"/>
+            <topicref
+                href="archSpec/base/adding-an-existing-domain-attribute-to-certain-elements.dita"/>
+            <topicref
+                href="archSpec/base/aggregating-constraint-and-expansion-modules.dita"/>
+        </topicref>
+        <topicref
+            href="archSpec/base/examples-expansion-implemented-using-rng.dita">
+            <topicref
+                href="archSpec/base/rng-adding-an-element-to-the-section-element.dita"/>
+            <topicref
+                href="archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita"/>
+            <topicref
+                href="archSpec/base/adding-an-existing-domain-attribute-to-certain-elements-rng.dita"/>
+            <topicref
+                href="archSpec/base/rng-aggregating-constraint-and-expansion-modules.dita"
+            />
+        </topicref>
+    </topicref>
+</map>

--- a/specification/archSpec/accessibility-and-translation.ditamap
+++ b/specification/archSpec/accessibility-and-translation.ditamap
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>Accessibility and Translation</title>
+    <topicref href="base/accessibility-and-translation.dita">
+        <mapref href="base/accessibility.ditamap"/>
+        <mapref href="base/translation-and-localization.ditamap"/>
+    </topicref>
+</map>

--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -63,94 +63,25 @@
   <chapter format="ditamap" href="terminology/dita-terminology.ditamap"/>
   <chapter format="ditamap"
     href="archSpec/base/introduction-to-dita.ditamap"/>
-  <chapter href="archSpec/base/accessibility-and-translation.dita">
-    <mapref href="archSpec/base/accessibility.ditamap"/>
-    <mapref href="archSpec/base/translation-and-localization.ditamap"/>
-  </chapter>
+  <chapter format="ditamap" href="archSpec/accessibility-and-translation.ditamap"/>
   <chapter format="ditamap" href="archSpec/base/ditamap-processing.ditamap"/>
   <chapter format="ditamap" href="archSpec/base/addressing.ditamap"/>
   <chapter format="ditamap" href="archSpec/base/processing.ditamap"/>
   <chapter format="ditamap"
     href="archSpec/base/specialization-and-custom-doctypes.ditamap"/>
   <!--<chapter format="ditamap" href="archSpec/base/coding-requirements.ditamap"/>-->
-  <chapter href="langRef/langRef-base.dita">
-    <topicref href="langRef/quick-reference/base-elements-a-to-z.dita"/>
-    <topicref href="langRef/quick-reference/base-attributes-a-to-z.dita"/>
-    <mapref href="langRef/base-elements.ditamap"/>
-    <mapref href="langRef/attributes/ditaref-attributes.ditamap"/>
-  </chapter>
+  <chapter format="ditamap" href="langRef/dita-2.0-element-reference.ditamap"/>
   <chapter href="conformance/conformance.dita"/>
   <appendix href="acknowledgments/acknowledgments.dita"/>
   <appendix href="non-normative/aggregated-RFC-2119-statements.dita"/>
   <appendix href="archSpec/base/coding-requirements.ditamap"
     format="ditamap"/>
-  <appendix
-    href="non-normative/developing-constraint-and-expansion-modules.dita">
-    <topicref href="archSpec/base/examples-constraints.dita">
-      <topicref
-        href="archSpec/base/example-contraints-redefine-content-model.dita"/>
-      <topicref
-        href="archSpec/base/example-contraints-redefine-content-model-attributes.dita"/>
-      <topicref href="archSpec/base/example-contraints-subset-domain.dita"/>
-      <topicref
-        href="archSpec/base/example-contraints-replace-base-element-w-domain-extensions.dita"/>
-      <topicref
-        href="archSpec/base/example-contraints-apply-multiple-constraints.dita"/>
-    </topicref>
-    <topicref
-      href="archSpec/base/examples-constraints-implemented-using-rng.dita">
-      <topicref
-        href="archSpec/base/example-rng-constraints-redefine-content-model.dita"/>
-      <topicref
-        href="archSpec/base/example-rng-constraints-redefine-content-model-attributes.dita"/>
-      <topicref
-        href="archSpec/base/example-constrain-a-domain-using-rng.dita"/>
-      <topicref
-        href="archSpec/base/example-rng-constraints-replace-base-element-w-domain-extensions.dita"/>
-      <topicref
-        href="archSpec/base/example-rng-constraints-apply-multiple-constraints.dita"
-      />
-    </topicref>
-  </appendix>
-  <appendix href="non-normative/expansion-modules.dita">
-    <topicref
-      href="archSpec/base/examples-expansion-implemented-using-dtds.dita">
-      <topicref
-        href="archSpec/base/adding-an-element-to-the-section-element.dita"/>
-      <topicref
-        href="archSpec/base/adding-an-attribute-to-certain-table-elements.dita"/>
-      <topicref
-        href="archSpec/base/adding-an-existing-domain-attribute-to-certain-elements.dita"/>
-      <topicref
-        href="archSpec/base/aggregating-constraint-and-expansion-modules.dita"/>
-    </topicref>
-    <topicref
-      href="archSpec/base/examples-expansion-implemented-using-rng.dita">
-      <topicref
-        href="archSpec/base/rng-adding-an-element-to-the-section-element.dita"/>
-      <topicref
-        href="archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita"/>
-      <topicref
-        href="archSpec/base/adding-an-existing-domain-attribute-to-certain-elements-rng.dita"/>
-      <topicref
-        href="archSpec/base/rng-aggregating-constraint-and-expansion-modules.dita"
-      />
-    </topicref>
-  </appendix>
+  <appendix href="appendix-dita-constraint-modules.ditamap" format="ditamap"/>
+  <appendix href="appendix-dita-expansion-modules.ditamap" format="ditamap"/>
   <appendix href="non-normative/elementsMerged.dita"/>
   <appendix href="non-normative/formatting-expectations.dita"/>
-  <appendix href="non-normative/migrating-to-dita-2.0.dita">
-    <topicref href="non-normative/changes-from-dita-1.3-to-dita-2.0.dita"/>
-    <topicref
-      href="non-normative/information-about-migrating-to-dita-2-0.dita"/>
-  </appendix>
-  <appendix href="non-normative/basedoctypes.dita">
-    <topicref href="non-normative/file-names-in-the-base-dita-edition.dita"/>
-    <topicref href="non-normative/dtd-public-identifiers.dita"/>
-    <topicref href="non-normative/oasisdomains.dita"/>
-    <topicref href="non-normative/oasis-document-type-shells.dita"/>
-  </appendix>
-
+  <appendix href="non-normative/migrating-to-dita-2.0.ditamap" format="ditamap"/>
+  <appendix href="non-normative/oasis-grammar-files.ditamap" format="ditamap"/>
   <appendix href="non-normative/interoperability-considerations.dita"/>
   <appendix href="non-normative/revision-history.dita"/>
   <backmatter>

--- a/specification/langRef/dita-2.0-element-reference.ditamap
+++ b/specification/langRef/dita-2.0-element-reference.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>Element Reference</title>
+    <topicref href="langRef-base.dita">
+        <topicref href="quick-reference/base-elements-a-to-z.dita"/>
+        <topicref href="quick-reference/base-attributes-a-to-z.dita"/>
+        <mapref href="base-elements.ditamap"/>
+        <mapref href="attributes/ditaref-attributes.ditamap"/>
+    </topicref>
+</map>

--- a/specification/non-normative/migrating-to-dita-2.0.ditamap
+++ b/specification/non-normative/migrating-to-dita-2.0.ditamap
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>Migrating to DITA 2.0</title>
+    <topicref href="migrating-to-dita-2.0.dita">
+        <topicref href="changes-from-dita-1.3-to-dita-2.0.dita"/>
+        <topicref
+            href="information-about-migrating-to-dita-2-0.dita"/>
+    </topicref>
+</map>

--- a/specification/non-normative/oasis-grammar-files.ditamap
+++ b/specification/non-normative/oasis-grammar-files.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>OASIS Grammar Files</title>
+    <topicref href="basedoctypes.dita">
+        <topicref href="file-names-in-the-base-dita-edition.dita"/>
+        <topicref href="dtd-public-identifiers.dita"/>
+        <topicref href="oasisdomains.dita"/>
+        <topicref href="oasis-document-type-shells.dita"/>
+    </topicref>
+</map>


### PR DESCRIPTION
Make our spec organization a bit more consistent; every chapter or appendix that is more than one single topic is now moved to a submap, so all chapters / appendices can be referenced independently without having to recreate a TOC structure.