### PR TITLE
Rename outputclass to add-outputclass in DITAVAL

### DIFF
--- a/doctypes/dtd/ditaval/ditaval.dtd
+++ b/doctypes/dtd/ditaval/ditaval.dtd
@@ -49,7 +49,7 @@
   att       CDATA       #IMPLIED
   val       CDATA       #IMPLIED
   action    (flag|include|exclude|passthrough)  #REQUIRED
-  outputclass CDATA     #IMPLIED
+  add-outputclass CDATA     #IMPLIED
   color     CDATA       #IMPLIED
   backcolor CDATA       #IMPLIED
   style     NMTOKENS    #IMPLIED  
@@ -73,7 +73,7 @@
 <!ATTLIST revprop
   val       CDATA       #IMPLIED
   action    (include|passthrough|flag)  #REQUIRED
-  outputclass CDATA     #IMPLIED
+  add-outputclass CDATA     #IMPLIED
   changebar CDATA       #IMPLIED
   color     CDATA       #IMPLIED
   backcolor CDATA       #IMPLIED

--- a/doctypes/rng/ditaval/ditaval.rng
+++ b/doctypes/rng/ditaval/ditaval.rng
@@ -121,7 +121,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
       </choice>
     </attribute>
     <optional>
-      <attribute name="outputclass"/>
+      <attribute name="add-outputclass"/>
     </optional>
     <optional>
       <attribute name="color"/>
@@ -197,7 +197,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 DITAVAL//EN"
       </choice>
     </attribute>
     <optional>
-      <attribute name="outputclass"/>
+      <attribute name="add-outputclass"/>
     </optional>
     <optional>
       <attribute name="changebar"/>

--- a/specification/archSpec/base/example-flagging-outputclass.dita
+++ b/specification/archSpec/base/example-flagging-outputclass.dita
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept xml:lang="en-us" id="example-condproc-values">
-  <title>Example: Flagging with <xmlatt>outputclass</xmlatt></title>
-  <shortdesc>In this scenario, the <xmlatt>outputclass</xmlatt> attribute in a DITAVAL document is
-    used to enable CSS based flagging.</shortdesc>
+  <title>Example: Flagging with <xmlatt>add-outputclass</xmlatt></title>
+  <shortdesc>In this scenario, the <xmlatt>add-outputclass</xmlatt> attribute in a DITAVAL document
+    is used to enable CSS based flagging.</shortdesc>
   <conbody>
     <p>An additional expectation for this scenario is that the processor rendering DITA content
       preserves <xmlatt>outputclass</xmlatt> values as CSS <xmlatt>class</xmlatt> tokens in HTML5.
@@ -12,8 +12,8 @@
     <p>The following code sample illustrates a simple DITAVAL document that sets up two rules for
       flagging using <xmlatt>outputclass</xmlatt>.</p>
     <codeblock>&lt;val>
-  &lt;prop action="flag" att="product" val="myProduct" outputclass="myProductToken"/>
-  &lt;prop action="flag" att="product" val="myOtherProduct" outputclass="myOtherProductToken"/>
+  &lt;prop action="flag" att="product" val="myProduct" add-outputclass="myProductToken"/>
+  &lt;prop action="flag" att="product" val="myOtherProduct" add-outputclass="myOtherProductToken"/>
 &lt;/val></codeblock>
     <p>Now, assume the following DITA content is processed using the rules from that DITAVAL
       document:<codeblock>&lt;ol>
@@ -28,7 +28,7 @@
         <li>The first item does not specify any conditional processing attributes, and is handled
           normally.</li>
         <li>The second item specifies <codeph>product="myProduct"</codeph>. Based on the DITAVAL
-          document, this results in a setting on <codeph>outputclass="myProductToken"</codeph>. The
+          document, this results in a setting of <codeph>outputclass="myProductToken"</codeph>. The
           content is processed as if the original element was: <codeph>&lt;li product="myProduct"
             outputclass="myProductToken"></codeph>.</li>
         <li>The third item specifies <codeph>product="myProduct"</codeph>, but already has an
@@ -38,7 +38,7 @@
           value supplied by the DITAVAL document is placed before any value already in the
           source.</li>
         <li>The fourth item specifies <codeph>product="myOtherProduct"</codeph>. Based on the
-          DITAVAL document, this results in a setting on
+          DITAVAL document, this results in a setting of
             <codeph>outputclass="myOtherProductToken"</codeph>. The content is processed as if the
           original element was: <codeph>&lt;li product="myOtherProduct"
             outputclass="myOtherProductToken"></codeph>.</li>

--- a/specification/archSpec/base/flagging.dita
+++ b/specification/archSpec/base/flagging.dita
@@ -10,10 +10,17 @@
    applies to a specific audience or operating system. Flagging can also draw a reader's attention
    to content that has been marked as being revised.</p>
   <p>When deciding whether to flag a particular element, a processor evaluates each value. Wherever
-   an attribute value that has been set as flagged appears (for example,
-    <codeph>audience="administrator"</codeph>), the processor adds the flag. When multiple flags
-   apply to a single element, multiple flags are rendered, typically in the order that they are
-   encountered.</p>
+      an attribute value that has been set as flagged appears (for example,
+        <codeph>audience="administrator"</codeph>), the processor adds the flag. When multiple flags
+      apply to a single element, multiple flags are rendered, typically in the order that they are
+      encountered.</p>
+    <!--Following paragraph added with #964, changing "outputclass" to "add-outputclass"-->
+    <p>Flagging behavior is determined based on the DITAVAL rule that matches a metadata attribute
+      value. Flagging options for the content of an element include setting a text style, color, or
+      background color. It also includes the ability to place an image or text at the start or end
+      of the flagged content. If the <xmlatt>add-outputclass</xmlatt> attribute is present in the
+      matching DITAVAL rule, the flagged element is treated as if the specified value is added to
+      its <xmlatt>outputclass</xmlatt> attribute.</p>
   <p>When the same element evaluates as both flagged and included, the element is both flagged and
    included. When the same element evaluates as both flagged and filtered (for example, flagged
    because of a value for the <xmlatt>audience</xmlatt> attribute and filtered because of a value

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -144,33 +144,25 @@
                                         value are specified, implementations <term
                                                 outputclass="RFC-2119">MAY</term> ignore one of the
                                         two values when they are unable to scale to each direction
-                                        using different factors.</ph></p><p id="data-link-universal-keyref-outputclass" platform="dita">The
-        following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-dataatts"/>, <ph
+                                        using different factors.</ph></p><p id="data-link-universal-keyref-outputclass" platform="dita">The following attributes are
+        available on this element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass" platform="dita">The following
-        attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-dataatts"/>, <ph
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="data-link-universal-outputclass" platform="dita">The following attributes are available on
+        this element: <ph conkeyref="reuse-attributes/ref-dataatts"/>, <ph
           conkeyref="reuse-attributes/ref-linkatts"/>, and <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="only-universal" platform="dita">The following attributes are
-        available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="universal-outputclass-name" platform="dita">The following attributes
-        are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="only-universal" platform="dita">The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p><p id="universal-outputclass-name" platform="dita">The following attributes are available on this
+        element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
+          keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p><p id="universal-keyref" platform="dita">The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/attr-name"><xmlatt>name</xmlatt></xref>.</p><p id="universal-keyref" platform="dita">The following attributes are
-        available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/attr-keyref"
-          ><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-compact" platform="dita">The following attributes are available on this element:
-                                        <ph conkeyref="reuse-attributes/ref-universalatts"/> and
-                                        <xref keyref="attributes-common/attr-compact"
-                                                ><xmlatt>compact</xmlatt></xref>.</p><!--Used in <topic>, <concept>, etc.-->
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p><p id="universal-compact" platform="dita">The following attributes are available on this element:
+          <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
+          keyref="attributes-common/attr-compact"><xmlatt>compact</xmlatt></xref>.</p><!--Used in <topic>, <concept>, etc.-->
                         <div id="topic-attributes">
-        <p platform="dita">The following attributes are available on this
-          element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and
-            <ph conkeyref="reuse-attributes/ref-architecturalatts"/>.</p>
+        <p platform="dita">The following attributes are available on this element: <ph
+            conkeyref="reuse-attributes/ref-universalatts"/> and <ph
+            conkeyref="reuse-attributes/ref-architecturalatts"/>.</p>
         <p id="attr-exception-topicid" outputclass="attr-exception">For
           this element, the <xmlatt>id</xmlatt> attribute is required.</p>
       </div><p id="fig-attributes" platform="dita">The following attributes are available on this element: <ph
@@ -183,8 +175,7 @@
           conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p><div id="fn-attributes" platform="dita">
         <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/> and the
-          attribute defined below.</p>
+            conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
         <!--<dl><dlentry id="callout"><dt id="attr-callout"><xmlatt>callout</xmlatt></dt><dd>Specifies the character that is used for the footnote link, for example, a number or an alphabetical character. The attribute can also specify a short string of characters.</dd></dlentry></dl>-->
       </div><div id="author-attributes" platform="dita">
         <p>The following attributes are available on this element: <ph
@@ -193,13 +184,11 @@
             keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </div><div id="standard-topicref-attributes" platform="dita">
                                 <p>The following attributes are available on this element: <ph
-                                                conkeyref="reuse-attributes/ref-universalatts"/>,
-                                                <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
-                                                conkeyref="reuse-attributes/ref-commonmapatts"/>,
-                                                <xref keyref="attributes-common/attr-keys"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                keyref="attributes-common/attr-keyref"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
+            keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                         </div><div>
                                 <p>Define the <keyword>format</keyword> value common to map
                                         references.</p>
@@ -207,40 +196,32 @@
                                         <dlentry id="format-mapref">
                                                 <dt id="attr-format-mapref"
                                                   ><xmlatt>format</xmlatt></dt>
-                                                <dd>Specifies the format of
-              the resource. By default, it is set to
-                <keyword>ditamap</keyword>. <ph platform="dita">Otherwise,
-                the attribute is the same as described in <ph
-                  conkeyref="reuse-attributes/ref-linkatts"/>.</ph></dd>
+                                                <dd>Specifies the format of the resource. By
+              default, it is set to <keyword>ditamap</keyword>. <ph platform="dita">Otherwise, the
+                attribute is the same as described in <ph conkeyref="reuse-attributes/ref-linkatts"
+                />.</ph></dd>
                                         </dlentry>
                                 </dl>
                         </div><div id="scheme-HAS-elements" platform="dita">
                                 <p>The following attributes are available on this element: <ph
-                                                conkeyref="reuse-attributes/ref-universalatts"/>,
-                                                <ph conkeyref="reuse-attributes/ref-linkatts"/>,
-                                                <xref
-                                                keyref="attributes-common/attr-processing-role"
-                                                  ><xmlatt>processing-role</xmlatt></xref>, <xref
-                                                keyref="attributes-common/attr-keys"
-                                                  ><xmlatt>keys</xmlatt></xref>, and <xref
-                                                keyref="attributes-common/attr-keyref"
-                                                  ><xmlatt>keyref</xmlatt></xref>.</p>
+            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+            conkeyref="reuse-attributes/ref-linkatts"/>, <xref
+            keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
+            <xref keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                         </div><div id="univ-outputclass-keyref-translate-NO">
                                 <!--Used for <shape> and <coords>-->
-                                <p platform="dita">The following attributes
-          are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-            keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>.</p>
+                                <p platform="dita">The following attributes are available on this
+          element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
                                 <p id="attr-exception-translate" outputclass="attr-exception">For this element, the
                                                 <xmlatt>translate</xmlatt> attribute has a default
                                         value of <keyword>no</keyword>.</p>
                         </div>
       <div platform="dita" id="stentry-attr">
         <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-table-access-attr"/>,  <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, and the
-          attributes defined below.</p>
+            conkeyref="reuse-attributes/ref-table-access-attr"/>, <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>, and the attributes defined below.</p>
       </div>
       <div platform="dita" id="choicetable-attr">
         <p>The following attributes are available on this element: <ph
@@ -369,26 +350,21 @@
                         </dl>
                 </section>
                         <section id="section-4"><title>Attributes used on the <xmlelement>map</xmlelement> element</title><div id="all-map-attributes" platform="dita">
-        <p id="map-attributes-common">The following attributes are
-          available on this element: <ph
+        <p id="map-attributes-common">The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <ph
             conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
             conkeyref="reuse-attributes/ref-architecturalatts"/>, <xref
-            keyref="attributes-common/attr-format"
-            ><xmlatt>format</xmlatt></xref>, <xref
-            keyref="attributes-common/attr-scope"
-            ><xmlatt>scope</xmlatt></xref>, and <xref
-            keyref="attributes-common/attr-type"
-            ><xmlatt>type</xmlatt></xref>.</p>
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>.</p>
       </div></section>
                 <section id="section-5">
                         <title>Common for <xmlelement>simpletable</xmlelement> and at least one
                                 specialization</title>
                         <p id="simpletable-attributes" platform="dita">The following attributes are
-                                available on this element: <ph
-                                        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                                        conkeyref="reuse-attributes/ref-displayatts"/>, and <ph
-                                        conkeyref="reuse-attributes/ref-simpletableatts"/>.</p>
+        available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-displayatts"/>, and <ph
+          conkeyref="reuse-attributes/ref-simpletableatts"/>.</p>
                 </section>
                 <section id="section_tbf_vhy_jlb">
                         <title>Common for <xmlelement>stentry</xmlelement> and
@@ -454,12 +430,9 @@
         <p>The following attributes are available on this element: <ph
             conkeyref="reuse-attributes/ref-universalatts"/>, <ph
             conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
-            keyref="attributes-common/attr-type"
-            ><xmlatt>type</xmlatt></xref>, <xref
-            keyref="attributes-common/attr-scope"
-            ><xmlatt>scope</xmlatt></xref>, and <xref
-            keyref="attributes-common/attr-format"
-            ><xmlatt>format</xmlatt></xref>.</p>
+            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
+            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
+            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>
         <p id="attr-exception-toc" outputclass="attr-exception">For this
           element, the <xmlatt>toc</xmlatt> attribute has a default value
           of <keyword>no</keyword>.</p>
@@ -493,12 +466,12 @@
               keyref="attributes-href"/> for information on supported
             values and processing implications.</dd>
         </dlentry>
-        <dlentry id="ditaval-outputclass">
-          <dt id="attr-outputclass"><xmlatt>outputclass</xmlatt></dt>
-          <dd>Specifies a value for the <xmlatt>outputclass</xmlatt>
-            attribute. The flagged element is treated as if the specified
-              <xmlatt>outputclass</xmlatt> value was specified on that
-            element.</dd>
+        <dlentry id="ditaval-add-outputclass">
+          <dt id="attr-outputclass"><xmlatt>add-outputclass</xmlatt></dt>
+          <dd>Specifies a value that will be added to the <xmlatt>outputclass</xmlatt> attribute on
+            the flagged element. The flagged element is treated as if the specified
+              <xmlatt>add-outputclass</xmlatt> value was specified within
+              <xmlatt>outputclass</xmlatt> on that element.</dd>
         </dlentry>
         <dlentry id="ditaval-style">
           <dt id="attr-style"><xmlatt>style</xmlatt></dt>

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -328,23 +328,19 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
     <section id="section_nw3_3pr_wsb">
       <title>DITAVAL reuse material</title>
       <div id="processing-outputclass">
-        <p>The following list outlines how processors apply
-            <xmlatt>outputclass</xmlatt> flags:</p>
+        <p>The following list outlines how processors apply flagging based on values in
+            <xmlatt>add-outputclass</xmlatt>:</p>
         <ul>
-          <li>If one or more DITAVAL properties apply
-              <xmlatt>outputclass</xmlatt> flags to the same element, and
-            the element already specifies one or more values for the
-              <xmlatt>outputclass</xmlatt> attribute, processors treat the
-            element as if <ph rev="review-m">the tokens for the
-                <xmlatt>outputclass</xmlatt> attribute that were provided
-              in the DITAVAL document</ph> are specified first.</li>
-          <li>If two or more DITAVAL properties apply
-              <xmlatt>outputclass</xmlatt> flags to the same element,
-            processors treat the element as if each value was specified for
-            the <xmlatt>outputclass</xmlatt> attribute. The order of the
-              <ph rev="review-m"> tokens for the
-                <xmlatt>outputclass</xmlatt> attribute that were provided
-              in the DITAVAL document</ph> is undefined.</li>
+          <li>If one or more DITAVAL properties apply <xmlatt>add-outputclass</xmlatt> flags to the
+            same element, and the element already specifies one or more values for the
+              <xmlatt>outputclass</xmlatt> attribute, processors treat the element as if <ph
+              rev="review-m">the tokens from the <xmlatt>add-outputclass</xmlatt> attribute that
+              were provided in the DITAVAL document</ph> are specified first.</li>
+          <li>If two or more DITAVAL properties apply <xmlatt>add-outputclass</xmlatt> flags to the
+            same element, processors treat the element as if each value was specified for the
+              <xmlatt>outputclass</xmlatt> attribute on the flagged element. The order of the  <ph
+              rev="review-m">tokens for the <xmlatt>outputclass</xmlatt> attribute that were
+              provided in the DITAVAL document</ph> is undefined.</li>
         </ul>
       </div>
     </section>

--- a/specification/langRef/ditaval/prop.dita
+++ b/specification/langRef/ditaval/prop.dita
@@ -130,7 +130,7 @@
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="reuse-attributes/ditaval-outputclass">
+        <dlentry conkeyref="reuse-attributes/ditaval-add-outputclass">
           <dt/>
           <dd/>
         </dlentry>

--- a/specification/langRef/ditaval/revprop.dita
+++ b/specification/langRef/ditaval/revprop.dita
@@ -105,7 +105,7 @@
           <dt/>
           <dd/>
         </dlentry>
-        <dlentry conkeyref="reuse-attributes/ditaval-outputclass">
+        <dlentry conkeyref="reuse-attributes/ditaval-add-outputclass">
           <dt/>
           <dd/>
         </dlentry>


### PR DESCRIPTION
Implements #964 

Renames the outputclass value within DITAVAL to `add-outputclass`, based on community confusion and the fact that this attribute contains values that will be added to `outputclass` on flagged elements. It is not intended to cause filter/flagging processors to match based on `@outputclass`.