### PR TITLE
Remove obsolete entity for removed element

### DIFF
--- a/doctypes/dtd/base/commonElements.ent
+++ b/doctypes/dtd/base/commonElements.ent
@@ -66,7 +66,6 @@
 <!ENTITY % term        "term"                                        >
 <!ENTITY % ph          "ph"                                          >
 <!ENTITY % tm          "tm"                                          >
-<!ENTITY % state       "state"                                       >
 <!ENTITY % image       "image"                                       >
 <!ENTITY % alt         "alt"                                         >
 <!ENTITY % longdescref "longdescref"                                 >


### PR DESCRIPTION
The `<state>` element was removed from 2.0 a while back, but the entity declaration was left behind. Removing the entity as a cleanup item.