### PR TITLE
Sync subjectrefs definition between RNG and DTD

### DIFF
--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -190,6 +190,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       <optional>
         <attribute name="keyscope"/>
       </optional>
+      <optional>
+        <attribute name="subjectrefs"/>
+      </optional>
     </define>
     <define name="topicref-atts-no-toc">
       <optional>
@@ -339,9 +342,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       <optional>
         <attribute name="chunk"/>
       </optional>
-      <optional>
-        <attribute name="subjectrefs"/>
-      </optional>
     </define>
     <define name="topicref-atts-without-format">
       <optional>
@@ -415,6 +415,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       <optional>
         <attribute name="keyscope"/>
       </optional>
+      <optional>
+        <attribute name="subjectrefs"/>
+      </optional>
     </define>
     <define name="topicref-atts-for-reltable" dita:since="2.0">
       <optional>
@@ -475,9 +478,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
       </optional>
       <optional>
         <attribute name="chunk"/>
-      </optional>
-      <optional>
-        <attribute name="subjectrefs"/>
       </optional>
     </define>
     <define name="impose-role-attribute">


### PR DESCRIPTION
The optional attribute subjectrefs was pasted into the wrong attribute groups, making it available on several reltable-related elements, and leaving it off of topicref elements. This updates to match what was already working in the DTD.