### PR TITLE
Remove extra copy of dita-use-conref-target from TOC

### DIFF
--- a/specification/langRef/attributes/ditaref-attributes.ditamap
+++ b/specification/langRef/attributes/ditaref-attributes.ditamap
@@ -7,7 +7,5 @@
       ><!--<ditavalref href="no-attr-list-labels.ditaval"/>--></topicref>
   <topicref keyref="attributes-universal"/>
   <topicref keyref="attributes-common"/>
-    <topicref keyref="attributes-useconreftarget"
-      href="../../archSpec/base/ditauseconreftarget.dita" platform="tcdita"/>
  </topicref>
 </map>


### PR DESCRIPTION
The explanatory topic on how to use `-dita-use-conref-target` appears twice in the TOC, after earlier re-organization of content. This causes errors in the spec processing that numbers topics, because it ends up in both places. 

I've removed the extra copy, and kept the one that is in a more logical location.