### PR TITLE
Update copyr end date to 2026

### DIFF
--- a/specification/dita-2.0-draft-pdf.ditamap
+++ b/specification/dita-2.0-draft-pdf.ditamap
@@ -27,7 +27,7 @@
 				<year>2005</year>
 			</copyrfirst>
 			<copyrlast>
-				<year>2018</year>
+				<year>2026</year>
 			</copyrlast>
 			<bookowner>
 				<organization>OASIS</organization>

--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -25,7 +25,7 @@
         <year>2005</year>
       </copyrfirst>
       <copyrlast>
-        <year>2022</year>
+        <year>2026</year>
       </copyrlast>
       <bookowner>
         <organization>OASIS</organization>


### PR DESCRIPTION
Just updates the main bookmap to update the end of the copyright range to 2026

Also updates the draft-pdf map in case that is used to build any further draft PDFs