### PR TITLE
Update build gate to validate grammar parity

### DIFF
--- a/.github/gradle/wrapper/gradle-wrapper.properties
+++ b/.github/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/.github/resources/DtdToJson.java
+++ b/.github/resources/DtdToJson.java
@@ -1,0 +1,374 @@
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.xml.XMLConstants;
+import javax.xml.catalog.CatalogFeatures;
+import javax.xml.catalog.CatalogManager;
+import javax.xml.catalog.CatalogResolver;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DeclHandler;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Reads an XML DTD and reports declared elements and attributes as JSON.
+ *
+ * <p>The parser expands parameter entities while reading the DTD. Attribute
+ * defaults reported by SAX are already normalized by the XML parser, including
+ * entity references in default literals.
+ */
+public final class DtdToJson {
+    private static final String DECL_HANDLER_PROPERTY =
+            "http://xml.org/sax/properties/declaration-handler";
+
+    private static final String LOAD_EXTERNAL_DTD_FEATURE =
+            "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+    private static final String EXTERNAL_GENERAL_ENTITIES_FEATURE =
+            "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES_FEATURE =
+            "http://xml.org/sax/features/external-parameter-entities";
+    private static final String DISALLOW_DOCTYPE_DECL_FEATURE =
+            "http://apache.org/xml/features/disallow-doctype-decl";
+
+    private DtdToJson() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            CliOptions options = CliOptions.parse(args);
+            if (options.help) {
+                printUsage();
+                return;
+            }
+
+            Map<String, Map<String, String>> report = parseDtd(options);
+            String json = toJson(report);
+
+            if (options.output == null) {
+                System.out.println(json);
+            } else {
+                Files.writeString(options.output, json + System.lineSeparator(), StandardCharsets.UTF_8);
+            }
+        } catch (UsageException ex) {
+            System.err.println(ex.getMessage());
+            System.err.println();
+            printUsage();
+            System.exit(2);
+        } catch (Exception ex) {
+            System.err.println("Failed to parse DTD: " + ex.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static Map<String, Map<String, String>> parseDtd(CliOptions options)
+            throws ParserConfigurationException, SAXException, IOException {
+        if (!Files.exists(options.dtdPath)) {
+            throw new IOException("DTD file not found: " + options.dtdPath);
+        }
+        for (Path catalog : options.catalogs) {
+            if (!Files.exists(catalog)) {
+                throw new IOException("Catalog file not found: " + catalog);
+            }
+        }
+
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(false);
+        factory.setValidating(false);
+
+        setFeatureIfSupported(factory, LOAD_EXTERNAL_DTD_FEATURE, true);
+        setFeatureIfSupported(factory, EXTERNAL_GENERAL_ENTITIES_FEATURE, true);
+        setFeatureIfSupported(factory, EXTERNAL_PARAMETER_ENTITIES_FEATURE, true);
+        setFeatureIfSupported(factory, DISALLOW_DOCTYPE_DECL_FEATURE, false);
+
+        SAXParser parser = factory.newSAXParser();
+        setPropertyIfSupported(parser, XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        setPropertyIfSupported(parser, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+
+        XMLReader reader = parser.getXMLReader();
+        DtdDeclCollector collector = new DtdDeclCollector();
+        reader.setContentHandler(new DefaultHandler());
+        reader.setProperty(DECL_HANDLER_PROPERTY, collector);
+
+        if (!options.catalogs.isEmpty()) {
+            CatalogFeatures features = CatalogFeatures.builder()
+                    .with(CatalogFeatures.Feature.RESOLVE, "continue")
+                    .build();
+            CatalogResolver resolver = CatalogManager.catalogResolver(
+                    features,
+                    options.catalogs.stream()
+                            .map(Path::toUri)
+                            .toArray(java.net.URI[]::new));
+            reader.setEntityResolver(resolver);
+        }
+
+        String dtdUri = options.dtdPath.toAbsolutePath().normalize().toUri().toASCIIString();
+        String probeDocument = "<!DOCTYPE __dtd_probe__ SYSTEM \"" + xmlEscape(dtdUri) + "\">\n"
+                + "<__dtd_probe__/>";
+        InputSource input = new InputSource(new StringReader(probeDocument));
+        input.setSystemId(options.dtdPath.toAbsolutePath().normalize().toUri().toASCIIString());
+        reader.parse(input);
+
+        return collector.report();
+    }
+
+    private static void setFeatureIfSupported(SAXParserFactory factory, String feature, boolean value)
+            throws ParserConfigurationException, SAXException {
+        try {
+            factory.setFeature(feature, value);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException ignored) {
+            // Optional parser feature. The JDK parser supports the ones this tool needs.
+        }
+    }
+
+    private static void setPropertyIfSupported(SAXParser parser, String property, String value)
+            throws SAXException {
+        try {
+            parser.setProperty(property, value);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException ignored) {
+            // Optional JAXP property. Some parser implementations do not use it.
+        }
+    }
+
+    private static String normalizeAttrValue(String attrName, String value) {
+        if ("class".equals(attrName)) {
+            return value;
+        }
+        return sortEnumerationValue(value.trim().replaceAll("\\s+", " "));
+    }
+
+    private static String sortEnumerationValue(String value) {
+        String prefix = "";
+        String body = value;
+        if (body.startsWith("NOTATION ")) {
+            prefix = "NOTATION ";
+            body = body.substring("NOTATION ".length());
+        }
+        if (!body.startsWith("(") || !body.endsWith(")") || !body.contains("|")) {
+            return value;
+        }
+
+        String inner = body.substring(1, body.length() - 1).trim();
+        List<String> values = Arrays.stream(inner.split("\\|"))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        if (values.stream().anyMatch(String::isEmpty)) {
+            return value;
+        }
+
+        List<String> ordered = values.stream()
+                .distinct()
+                .sorted(DtdToJson::compareEnumToken)
+                .collect(Collectors.toList());
+        return prefix + "(" + String.join(" | ", ordered) + ")";
+    }
+
+    private static int compareEnumToken(String left, String right) {
+        int leftRank = "-dita-use-conref-target".equals(left) ? 1 : 0;
+        int rightRank = "-dita-use-conref-target".equals(right) ? 1 : 0;
+        if (leftRank != rightRank) {
+            return Integer.compare(leftRank, rightRank);
+        }
+        return left.compareTo(right);
+    }
+
+    private static String toJson(Map<String, Map<String, String>> report) {
+        StringBuilder out = new StringBuilder();
+        out.append("{\n");
+        int elementIndex = 0;
+        for (Map.Entry<String, Map<String, String>> element : report.entrySet()) {
+            if (elementIndex++ > 0) {
+                out.append(",\n");
+            }
+            out.append("  \"").append(jsonEscape(element.getKey())).append("\": ");
+            out.append("{");
+            if (!element.getValue().isEmpty()) {
+                out.append("\n");
+                int attrIndex = 0;
+                for (Map.Entry<String, String> attr : element.getValue().entrySet()) {
+                    if (attrIndex++ > 0) {
+                        out.append(",\n");
+                    }
+                    out.append("    \"").append(jsonEscape(attr.getKey())).append("\": ");
+                    out.append("\"").append(jsonEscape(attr.getValue())).append("\"");
+                }
+                out.append("\n  ");
+            }
+            out.append("}");
+        }
+        out.append("\n}");
+        return out.toString();
+    }
+
+    private static String xmlEscape(String value) {
+        return value.replace("&", "&amp;").replace("\"", "&quot;");
+    }
+
+    private static String jsonEscape(String value) {
+        StringBuilder escaped = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '"':
+                    escaped.append("\\\"");
+                    break;
+                case '\\':
+                    escaped.append("\\\\");
+                    break;
+                case '\b':
+                    escaped.append("\\b");
+                    break;
+                case '\f':
+                    escaped.append("\\f");
+                    break;
+                case '\n':
+                    escaped.append("\\n");
+                    break;
+                case '\r':
+                    escaped.append("\\r");
+                    break;
+                case '\t':
+                    escaped.append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+            }
+        }
+        return escaped.toString();
+    }
+
+    private static void printUsage() {
+        System.err.println("Usage: javac DtdToJson.java && java DtdToJson [options] path/to/schema.dtd");
+        System.err.println();
+        System.err.println("Options:");
+        System.err.println("  -o, --output FILE       Write JSON report to FILE instead of stdout");
+        System.err.println("  --catalog FILE          XML Catalog for resolving PUBLIC/SYSTEM IDs; repeatable");
+        System.err.println("  -h, --help              Show this help");
+    }
+
+    private static final class DtdDeclCollector implements DeclHandler {
+        private final Set<String> elements = new TreeSet<>();
+        private final Map<String, Map<String, String>> attrsByElement = new TreeMap<>();
+
+        @Override
+        public void elementDecl(String name, String model) {
+            elements.add(name);
+        }
+
+        @Override
+        public void attributeDecl(
+                String elementName,
+                String attributeName,
+                String type,
+                String mode,
+                String value) {
+            elements.add(elementName);
+            String reportValue = value == null ? type : value;
+            attrsByElement
+                    .computeIfAbsent(elementName, ignored -> new TreeMap<>())
+                    .put(attributeName, normalizeAttrValue(attributeName, reportValue));
+        }
+
+        @Override
+        public void internalEntityDecl(String name, String value) {
+            // Entity declarations are consumed by the parser; the report is element/attribute only.
+        }
+
+        @Override
+        public void externalEntityDecl(String name, String publicId, String systemId) {
+            // Entity declarations are consumed by the parser; the report is element/attribute only.
+        }
+
+        Map<String, Map<String, String>> report() {
+            Map<String, Map<String, String>> result = new TreeMap<>();
+            for (String element : elements) {
+                result.put(element, attrsByElement.getOrDefault(element, new TreeMap<>()));
+            }
+            return result;
+        }
+    }
+
+    private static final class CliOptions {
+        private final Path dtdPath;
+        private final Path output;
+        private final List<Path> catalogs;
+        private final boolean help;
+
+        private CliOptions(Path dtdPath, Path output, List<Path> catalogs, boolean help) {
+            this.dtdPath = dtdPath;
+            this.output = output;
+            this.catalogs = catalogs;
+            this.help = help;
+        }
+
+        static CliOptions parse(String[] args) throws UsageException {
+            Path dtdPath = null;
+            Path output = null;
+            List<Path> catalogs = new ArrayList<>();
+            boolean help = false;
+
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                switch (arg) {
+                    case "-h":
+                    case "--help":
+                        help = true;
+                        break;
+                    case "-o":
+                    case "--output":
+                        output = requirePathArg(args, ++i, arg);
+                        break;
+                    case "--catalog":
+                        catalogs.add(requirePathArg(args, ++i, arg));
+                        break;
+                    default:
+                        if (arg.startsWith("-")) {
+                            throw new UsageException("Unknown option: " + arg);
+                        }
+                        if (dtdPath != null) {
+                            throw new UsageException("Only one DTD path may be provided.");
+                        }
+                        dtdPath = Path.of(arg);
+                        break;
+                }
+            }
+
+            if (!help && dtdPath == null) {
+                throw new UsageException("Missing DTD path.");
+            }
+            return new CliOptions(dtdPath, output, catalogs, help);
+        }
+
+        private static Path requirePathArg(String[] args, int index, String option) throws UsageException {
+            if (index >= args.length) {
+                throw new UsageException("Missing value for " + option);
+            }
+            return Path.of(args[index]);
+        }
+    }
+
+    private static final class UsageException extends Exception {
+        UsageException(String message) {
+            super(message);
+        }
+    }
+}

--- a/.github/resources/RngToJson.java
+++ b/.github/resources/RngToJson.java
@@ -1,0 +1,675 @@
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Reads a modular Relax NG XML schema and reports declared elements/attributes as JSON.
+ *
+ * <p>This is intentionally shaped for DITA RNG modules: it follows include and
+ * externalRef files, resolves XML catalogs, and resolves common attribute
+ * reference patterns such as .attlist, .attributes, .att, and -atts.
+ */
+public final class RngToJson {
+    private static final String RNG_NS = "http://relaxng.org/ns/structure/1.0";
+    private static final String ANN_NS = "http://relaxng.org/ns/compatibility/annotations/1.0";
+    private static final String CAT_NS = "urn:oasis:names:tc:entity:xmlns:xml:catalog";
+
+    private RngToJson() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            CliOptions options = CliOptions.parse(args);
+            if (options.help) {
+                printUsage();
+                return;
+            }
+
+            CatalogMaps catalogs = loadCatalogs(options.catalogs);
+            Map<String, Map<String, String>> report = extractRngSummary(options.rngPath, catalogs);
+            String json = toJson(report);
+
+            if (options.output == null) {
+                System.out.println(json);
+            } else {
+                Files.writeString(options.output, json + System.lineSeparator(), StandardCharsets.UTF_8);
+            }
+        } catch (UsageException ex) {
+            System.err.println(ex.getMessage());
+            System.err.println();
+            printUsage();
+            System.exit(2);
+        } catch (Exception ex) {
+            System.err.println("Failed to parse schema/catalog: " + ex.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static Map<String, Map<String, String>> extractRngSummary(Path rngPath, CatalogMaps catalogs)
+            throws IOException, ParserConfigurationException, SAXException {
+        if (!Files.exists(rngPath)) {
+            throw new IOException("Schema file not found: " + rngPath);
+        }
+
+        GrammarForest forest = new GrammarForest(catalogs);
+        forest.ingest(rngPath);
+
+        AnalysisContext ctx = new AnalysisContext(forest.defines);
+        Map<String, Map<String, String>> attrsByElement = new TreeMap<>();
+
+        for (Element element : forest.elementNodes) {
+            String elementName = element.getAttribute("name");
+            if (elementName.isEmpty()) {
+                continue;
+            }
+            Map<String, String> attrs = attrsByElement.computeIfAbsent(elementName, ignored -> new TreeMap<>());
+            collectAttrsFromPattern(element, ctx, attrs, new HashSet<>());
+        }
+
+        return attrsByElement;
+    }
+
+    private static void collectAttrsFromPattern(
+            Element node,
+            AnalysisContext ctx,
+            Map<String, String> attrs,
+            Set<String> seenRefs) {
+        if (isRng(node, "attribute")) {
+            String rawName = node.getAttribute("name");
+            if (!rawName.isEmpty()) {
+                AttributeName attributeName = normalizeAttributeName(rawName, node);
+                if (attributeName.namespaceDeclarationName != null) {
+                    attrs.put(attributeName.namespaceDeclarationName, attributeName.namespaceUri);
+                }
+                String value;
+                if (node.hasAttributeNS(ANN_NS, "defaultValue")) {
+                    value = node.getAttributeNS(ANN_NS, "defaultValue");
+                } else {
+                    value = inferAttrType(node, ctx, new HashSet<>());
+                }
+                attrs.put(attributeName.reportName, normalizeAttrValue(attributeName.reportName, value));
+            }
+            return;
+        }
+
+        if (isRng(node, "ref")) {
+            String name = node.getAttribute("name");
+            if (!name.isEmpty()
+                    && (isAttributeRef(name) || ctx.refCanProduceAttrs(name, new HashSet<>()))
+                    && !seenRefs.contains(name)) {
+                Map<String, String> cached = ctx.refAttrCache.get(name);
+                if (cached != null) {
+                    attrs.putAll(cached);
+                    return;
+                }
+
+                seenRefs.add(name);
+                Map<String, String> localAttrs = new TreeMap<>();
+                for (Element define : ctx.defines.getOrDefault(name, List.of())) {
+                    collectAttrsFromPattern(define, ctx, localAttrs, seenRefs);
+                }
+                attrs.putAll(localAttrs);
+                ctx.refAttrCache.put(name, new TreeMap<>(localAttrs));
+                seenRefs.remove(name);
+            }
+            return;
+        }
+
+        if (isRng(node, "element")) {
+            for (Element child : childElements(node)) {
+                if (!isRng(child, "element")) {
+                    collectAttrsFromPattern(child, ctx, attrs, seenRefs);
+                }
+            }
+            return;
+        }
+
+        for (Element child : childElements(node)) {
+            collectAttrsFromPattern(child, ctx, attrs, seenRefs);
+        }
+    }
+
+    private static String inferAttrType(Element node, AnalysisContext ctx, Set<String> seenRefs) {
+        Set<String> values = collectValueLiterals(node, ctx, seenRefs);
+        if (!values.isEmpty()) {
+            List<String> ordered = values.stream()
+                    .map(value -> normalizeAttrValue("_", value))
+                    .distinct()
+                    .sorted(RngToJson::compareEnumToken)
+                    .collect(Collectors.toList());
+            return "(" + String.join(" | ", ordered) + ")";
+        }
+
+        Set<String> dataTypes = collectDataTypes(node, ctx, new HashSet<>());
+        if (!dataTypes.isEmpty()) {
+            return dataTypes.stream().sorted().findFirst().orElse("CDATA");
+        }
+        return "CDATA";
+    }
+
+    private static Set<String> collectValueLiterals(Element node, AnalysisContext ctx, Set<String> seenRefs) {
+        Set<String> out = new TreeSet<>(RngToJson::compareEnumToken);
+        if (isRng(node, "value")) {
+            String text = node.getTextContent();
+            if (text != null && !text.trim().isEmpty()) {
+                out.add(text.trim());
+            }
+            return out;
+        }
+
+        if (isRng(node, "ref")) {
+            String name = node.getAttribute("name");
+            if (name.isEmpty() || seenRefs.contains(name)) {
+                return out;
+            }
+            Set<String> cached = ctx.refValueCache.get(name);
+            if (cached != null) {
+                return new TreeSet<>(cached);
+            }
+
+            seenRefs.add(name);
+            for (Element define : ctx.defines.getOrDefault(name, List.of())) {
+                out.addAll(collectValueLiterals(define, ctx, seenRefs));
+            }
+            ctx.refValueCache.put(name, new TreeSet<>(out));
+            seenRefs.remove(name);
+            return out;
+        }
+
+        for (Element child : childElements(node)) {
+            out.addAll(collectValueLiterals(child, ctx, seenRefs));
+        }
+        return out;
+    }
+
+    private static Set<String> collectDataTypes(Element node, AnalysisContext ctx, Set<String> seenRefs) {
+        Set<String> out = new TreeSet<>();
+        if (isRng(node, "data")) {
+            String type = node.getAttribute("type");
+            out.add(normalizeDataType(type));
+            return out;
+        }
+        if (isRng(node, "text")) {
+            out.add("CDATA");
+            return out;
+        }
+
+        if (isRng(node, "ref")) {
+            String name = node.getAttribute("name");
+            if (name.isEmpty() || seenRefs.contains(name)) {
+                return out;
+            }
+            Set<String> cached = ctx.refTypeCache.get(name);
+            if (cached != null) {
+                return new TreeSet<>(cached);
+            }
+
+            seenRefs.add(name);
+            for (Element define : ctx.defines.getOrDefault(name, List.of())) {
+                out.addAll(collectDataTypes(define, ctx, seenRefs));
+            }
+            ctx.refTypeCache.put(name, new TreeSet<>(out));
+            seenRefs.remove(name);
+            return out;
+        }
+
+        for (Element child : childElements(node)) {
+            out.addAll(collectDataTypes(child, ctx, seenRefs));
+        }
+        return out;
+    }
+
+    private static boolean isAttributeRef(String name) {
+        return name.endsWith(".attlist")
+                || name.endsWith(".attributes")
+                || name.endsWith(".att")
+                || name.endsWith("-atts")
+                || name.contains("-atts-")
+                || name.endsWith("-att");
+    }
+
+    private static boolean patternCanProduceAttrs(Element node, AnalysisContext ctx, Set<String> seenRefs) {
+        if (isRng(node, "attribute")) {
+            return true;
+        }
+        if (isRng(node, "element")) {
+            return false;
+        }
+        if (isRng(node, "ref")) {
+            String name = node.getAttribute("name");
+            return !name.isEmpty() && ctx.refCanProduceAttrs(name, seenRefs);
+        }
+        for (Element child : childElements(node)) {
+            if (patternCanProduceAttrs(child, ctx, seenRefs)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static CatalogMaps loadCatalogs(List<Path> catalogPaths)
+            throws IOException, ParserConfigurationException, SAXException {
+        CatalogMaps maps = new CatalogMaps();
+        Set<Path> seen = new HashSet<>();
+        for (Path catalog : catalogPaths) {
+            if (!Files.exists(catalog)) {
+                throw new IOException("Catalog file not found: " + catalog);
+            }
+            loadCatalog(catalog, maps, seen);
+        }
+        return maps;
+    }
+
+    private static void loadCatalog(Path catalogPath, CatalogMaps maps, Set<Path> seen)
+            throws IOException, ParserConfigurationException, SAXException {
+        Path absPath = catalogPath.toAbsolutePath().normalize();
+        if (!seen.add(absPath)) {
+            return;
+        }
+
+        Document doc = newDocumentBuilder().parse(absPath.toFile());
+        Path baseDir = absPath.getParent();
+
+        for (Element uri : descendants(doc.getDocumentElement(), CAT_NS, "uri")) {
+            String name = uri.getAttribute("name");
+            String target = uri.getAttribute("uri");
+            if (!name.isEmpty() && !target.isEmpty()) {
+                maps.uriMap.put(name, baseDir.resolve(target).normalize());
+            }
+        }
+
+        for (Element system : descendants(doc.getDocumentElement(), CAT_NS, "system")) {
+            String systemId = system.getAttribute("systemId");
+            String target = system.getAttribute("uri");
+            if (!systemId.isEmpty() && !target.isEmpty()) {
+                maps.systemMap.put(systemId, baseDir.resolve(target).normalize());
+            }
+        }
+
+        for (Element nextCatalog : descendants(doc.getDocumentElement(), CAT_NS, "nextCatalog")) {
+            String next = nextCatalog.getAttribute("catalog");
+            if (!next.isEmpty()) {
+                loadCatalog(baseDir.resolve(next).normalize(), maps, seen);
+            }
+        }
+    }
+
+    private static Path resolveHref(String href, Path baseDir, CatalogMaps catalogs) throws IOException {
+        Path uriMatch = catalogs.uriMap.get(href);
+        if (uriMatch != null) {
+            return uriMatch;
+        }
+        Path systemMatch = catalogs.systemMap.get(href);
+        if (systemMatch != null) {
+            return systemMatch;
+        }
+        if (href.contains("://") || href.startsWith("urn:")) {
+            throw new IOException("Cannot resolve remote href without catalog mapping: " + href);
+        }
+        return baseDir.resolve(href).normalize();
+    }
+
+    private static AttributeName normalizeAttributeName(String name, Element attributeNode) {
+        int colon = name.indexOf(':');
+        if (colon < 0) {
+            return new AttributeName(name, null, null);
+        }
+
+        String prefix = name.substring(0, colon);
+        String localName = name.substring(colon + 1);
+        String namespaceUri = attributeNode.lookupNamespaceURI(prefix);
+        if ("http://dita.oasis-open.org/architecture/2005/".equals(namespaceUri)) {
+            String reportName = "ditaarch:" + localName;
+            return new AttributeName(reportName, "xmlns:ditaarch", namespaceUri);
+        }
+        if (namespaceUri != null && !namespaceUri.isEmpty()) {
+            return new AttributeName(name, "xmlns:" + prefix, namespaceUri);
+        }
+        return new AttributeName(name, null, null);
+    }
+
+    private static String normalizeDataType(String type) {
+        if (type == null || type.isEmpty() || "string".equals(type)) {
+            return "CDATA";
+        }
+        return type;
+    }
+
+    private static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        setFeatureIfSupported(factory, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        setFeatureIfSupported(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setEntityResolver((publicId, systemId) -> new org.xml.sax.InputSource(new java.io.StringReader("")));
+        return builder;
+    }
+
+    private static void setFeatureIfSupported(DocumentBuilderFactory factory, String feature, boolean value)
+            throws ParserConfigurationException {
+        try {
+            factory.setFeature(feature, value);
+        } catch (ParserConfigurationException ignored) {
+            // Some JAXP implementations do not expose every optional feature.
+        }
+    }
+
+    private static List<Element> descendants(Element root, String namespace, String localName) {
+        List<Element> out = new ArrayList<>();
+        NodeList nodes = root.getElementsByTagNameNS(namespace, localName);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node instanceof Element element) {
+                out.add(element);
+            }
+        }
+        return out;
+    }
+
+    private static List<Element> childElements(Element node) {
+        List<Element> out = new ArrayList<>();
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child instanceof Element element) {
+                out.add(element);
+            }
+        }
+        return out;
+    }
+
+    private static boolean isRng(Element node, String localName) {
+        return RNG_NS.equals(node.getNamespaceURI()) && localName.equals(node.getLocalName());
+    }
+
+    private static String normalizeAttrValue(String attrName, String value) {
+        if ("class".equals(attrName)) {
+            return value;
+        }
+        return sortEnumerationValue(value.trim().replaceAll("\\s+", " "));
+    }
+
+    private static String sortEnumerationValue(String value) {
+        if (!value.startsWith("(") || !value.endsWith(")") || !value.contains("|")) {
+            return value;
+        }
+        String inner = value.substring(1, value.length() - 1).trim();
+        List<String> values = Arrays.stream(inner.split("\\|"))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        if (values.stream().anyMatch(String::isEmpty)) {
+            return value;
+        }
+        List<String> ordered = values.stream()
+                .distinct()
+                .sorted(RngToJson::compareEnumToken)
+                .collect(Collectors.toList());
+        return "(" + String.join(" | ", ordered) + ")";
+    }
+
+    private static int compareEnumToken(String left, String right) {
+        int leftRank = "-dita-use-conref-target".equals(left) ? 1 : 0;
+        int rightRank = "-dita-use-conref-target".equals(right) ? 1 : 0;
+        if (leftRank != rightRank) {
+            return Integer.compare(leftRank, rightRank);
+        }
+        return left.compareTo(right);
+    }
+
+    private static String toJson(Map<String, Map<String, String>> report) {
+        StringBuilder out = new StringBuilder();
+        out.append("{\n");
+        int elementIndex = 0;
+        for (Map.Entry<String, Map<String, String>> element : report.entrySet()) {
+            if (elementIndex++ > 0) {
+                out.append(",\n");
+            }
+            out.append("  \"").append(jsonEscape(element.getKey())).append("\": ");
+            out.append("{");
+            if (!element.getValue().isEmpty()) {
+                out.append("\n");
+                int attrIndex = 0;
+                for (Map.Entry<String, String> attr : element.getValue().entrySet()) {
+                    if (attrIndex++ > 0) {
+                        out.append(",\n");
+                    }
+                    out.append("    \"").append(jsonEscape(attr.getKey())).append("\": ");
+                    out.append("\"").append(jsonEscape(attr.getValue())).append("\"");
+                }
+                out.append("\n  ");
+            }
+            out.append("}");
+        }
+        out.append("\n}");
+        return out.toString();
+    }
+
+    private static String jsonEscape(String value) {
+        StringBuilder escaped = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '"':
+                    escaped.append("\\\"");
+                    break;
+                case '\\':
+                    escaped.append("\\\\");
+                    break;
+                case '\b':
+                    escaped.append("\\b");
+                    break;
+                case '\f':
+                    escaped.append("\\f");
+                    break;
+                case '\n':
+                    escaped.append("\\n");
+                    break;
+                case '\r':
+                    escaped.append("\\r");
+                    break;
+                case '\t':
+                    escaped.append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+            }
+        }
+        return escaped.toString();
+    }
+
+    private static void printUsage() {
+        System.err.println("Usage: javac RngToJson.java && java RngToJson [options] path/to/schema.rng");
+        System.err.println();
+        System.err.println("Options:");
+        System.err.println("  -o, --output FILE       Write JSON report to FILE instead of stdout");
+        System.err.println("  --catalog FILE          XML Catalog for resolving include/externalRef hrefs; repeatable");
+        System.err.println("  -h, --help              Show this help");
+    }
+
+    private static final class GrammarForest {
+        private final CatalogMaps catalogs;
+        private final Set<Path> visitedFiles = new HashSet<>();
+        private final Map<String, List<Element>> defines = new HashMap<>();
+        private final List<Element> elementNodes = new ArrayList<>();
+
+        private GrammarForest(CatalogMaps catalogs) {
+            this.catalogs = catalogs;
+        }
+
+        private void ingest(Path path) throws IOException, ParserConfigurationException, SAXException {
+            Path absPath = path.toAbsolutePath().normalize();
+            if (!visitedFiles.add(absPath)) {
+                return;
+            }
+
+            Document doc = newDocumentBuilder().parse(absPath.toFile());
+            Element root = doc.getDocumentElement();
+            Path baseDir = absPath.getParent();
+
+            for (Element define : descendants(root, RNG_NS, "define")) {
+                String name = define.getAttribute("name");
+                if (!name.isEmpty()) {
+                    defines.computeIfAbsent(name, ignored -> new ArrayList<>()).add(define);
+                }
+            }
+
+            elementNodes.addAll(descendants(root, RNG_NS, "element").stream()
+                    .filter(element -> element.hasAttribute("name"))
+                    .collect(Collectors.toCollection(LinkedHashSet::new)));
+
+            for (Element include : descendants(root, RNG_NS, "include")) {
+                String href = include.getAttribute("href");
+                if (!href.isEmpty()) {
+                    ingest(resolveHref(href, baseDir, catalogs));
+                }
+            }
+
+            for (Element externalRef : descendants(root, RNG_NS, "externalRef")) {
+                String href = externalRef.getAttribute("href");
+                if (!href.isEmpty()) {
+                    ingest(resolveHref(href, baseDir, catalogs));
+                }
+            }
+        }
+    }
+
+    private static final class AnalysisContext {
+        private final Map<String, List<Element>> defines;
+        private final Map<String, Map<String, String>> refAttrCache = new HashMap<>();
+        private final Map<String, Set<String>> refValueCache = new HashMap<>();
+        private final Map<String, Set<String>> refTypeCache = new HashMap<>();
+        private final Map<String, Boolean> attrProducingRefCache = new HashMap<>();
+
+        private AnalysisContext(Map<String, List<Element>> defines) {
+            this.defines = defines;
+        }
+
+        private boolean refCanProduceAttrs(String name, Set<String> seenRefs) {
+            Boolean cached = attrProducingRefCache.get(name);
+            if (cached != null) {
+                return cached;
+            }
+            if (!seenRefs.add(name)) {
+                return false;
+            }
+
+            boolean result = false;
+            for (Element define : defines.getOrDefault(name, List.of())) {
+                if (patternCanProduceAttrs(define, this, seenRefs)) {
+                    result = true;
+                    break;
+                }
+            }
+            seenRefs.remove(name);
+            attrProducingRefCache.put(name, result);
+            return result;
+        }
+    }
+
+    private static final class CatalogMaps {
+        private final Map<String, Path> uriMap = new HashMap<>();
+        private final Map<String, Path> systemMap = new HashMap<>();
+    }
+
+    private static final class AttributeName {
+        private final String reportName;
+        private final String namespaceDeclarationName;
+        private final String namespaceUri;
+
+        private AttributeName(String reportName, String namespaceDeclarationName, String namespaceUri) {
+            this.reportName = reportName;
+            this.namespaceDeclarationName = namespaceDeclarationName;
+            this.namespaceUri = namespaceUri;
+        }
+    }
+
+    private static final class CliOptions {
+        private final Path rngPath;
+        private final Path output;
+        private final List<Path> catalogs;
+        private final boolean help;
+
+        private CliOptions(Path rngPath, Path output, List<Path> catalogs, boolean help) {
+            this.rngPath = rngPath;
+            this.output = output;
+            this.catalogs = catalogs;
+            this.help = help;
+        }
+
+        static CliOptions parse(String[] args) throws UsageException {
+            Path rngPath = null;
+            Path output = null;
+            List<Path> catalogs = new ArrayList<>();
+            boolean help = false;
+
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                switch (arg) {
+                    case "-h":
+                    case "--help":
+                        help = true;
+                        break;
+                    case "-o":
+                    case "--output":
+                        output = requirePathArg(args, ++i, arg);
+                        break;
+                    case "--catalog":
+                        catalogs.add(requirePathArg(args, ++i, arg));
+                        break;
+                    default:
+                        if (arg.startsWith("-")) {
+                            throw new UsageException("Unknown option: " + arg);
+                        }
+                        if (rngPath != null) {
+                            throw new UsageException("Only one RNG path may be provided.");
+                        }
+                        rngPath = Path.of(arg);
+                        break;
+                }
+            }
+
+            if (!help && rngPath == null) {
+                throw new UsageException("Missing RNG schema path.");
+            }
+            return new CliOptions(rngPath, output, catalogs, help);
+        }
+
+        private static Path requirePathArg(String[] args, int index, String option) throws UsageException {
+            if (index >= args.length) {
+                throw new UsageException("Missing value for " + option);
+            }
+            return Path.of(args[index]);
+        }
+    }
+
+    private static final class UsageException extends Exception {
+        UsageException(String message) {
+            super(message);
+        }
+    }
+}

--- a/.github/resources/compare_json_reports.py
+++ b/.github/resources/compare_json_reports.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Compare two element/attribute JSON reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+Report = dict[str, dict[str, str]]
+
+
+def load_report(path: Path) -> Report:
+    try:
+        with path.open("r", encoding="utf-8") as report_file:
+            data: Any = json.load(report_file)
+    except FileNotFoundError as exc:
+        raise ValueError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Report must be a JSON object: {path}")
+
+    report: Report = {}
+    for element_name, attrs in data.items():
+        if not isinstance(element_name, str):
+            raise ValueError(f"Element names must be strings in {path}")
+        if not isinstance(attrs, dict):
+            raise ValueError(f"Element {element_name!r} must map to an object in {path}")
+
+        report[element_name] = {}
+        for attr_name, attr_value in attrs.items():
+            if not isinstance(attr_name, str) or not isinstance(attr_value, str):
+                raise ValueError(
+                    f"Attributes on element {element_name!r} must map string names to string values in {path}"
+                )
+            report[element_name][attr_name] = attr_value
+
+    return report
+
+
+def compare_reports(left_path: Path, left: Report, right_path: Path, right: Report) -> list[str]:
+    messages: list[str] = []
+    left_label = str(left_path)
+    right_label = str(right_path)
+
+    for element_name in sorted(set(left) | set(right)):
+        if element_name not in left:
+            messages.append(f"In file {left_label}, the element <{element_name}> is missing")
+            continue
+        if element_name not in right:
+            messages.append(f"In file {right_label}, the element <{element_name}> is missing")
+            continue
+
+        left_attrs = left[element_name]
+        right_attrs = right[element_name]
+        for attr_name in sorted(set(left_attrs) | set(right_attrs)):
+            if attr_name not in left_attrs:
+                messages.append(
+                    f"In file {left_label}, the element <{element_name}> is missing the attribute @{attr_name}"
+                )
+                continue
+            if attr_name not in right_attrs:
+                messages.append(
+                    f"In file {right_label}, the element <{element_name}> is missing the attribute @{attr_name}"
+                )
+                continue
+
+            left_value = left_attrs[attr_name]
+            right_value = right_attrs[attr_name]
+            if left_value != right_value:
+                messages.append(
+                    f"In file {left_label}, the attribute @{attr_name!r} on element <{element_name}> "
+                    f"has value [{left_value}], while in file {right_label}, the attribute @{attr_name!r} "
+                    f"on element <{element_name}> has value [{right_value}]"
+                )
+
+    return messages
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare two JSON reports containing elements and attributes."
+    )
+    parser.add_argument(
+        "left",
+        nargs="?",
+        default="compare.json",
+        type=Path,
+        help="First JSON report, usually the DTD output (default: compare.json)",
+    )
+    parser.add_argument(
+        "right",
+        nargs="?",
+        default="rng-compare.json",
+        type=Path,
+        help="Second JSON report, usually the RNG output (default: rng-compare.json)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only set the exit code; do not print a success message when reports match.",
+    )
+    args = parser.parse_args()
+
+    try:
+        left = load_report(args.left)
+        right = load_report(args.right)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    messages = compare_reports(args.left, left, args.right, right)
+    if messages:
+        print("\n".join(messages))
+        print(f"\nFound {len(messages)} difference(s).")
+        return 1
+
+    if not args.quiet:
+        print(f"No differences found between {args.left} and {args.right}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,53 @@ jobs:
       DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
+      - name: Compare DTD and Relax NG grammar reports
+        run: |
+          set -e
+          mkdir -p build/grammar-compare/classes build/grammar-compare/reports
+          javac -d build/grammar-compare/classes \
+            .github/resources/DtdToJson.java \
+            .github/resources/RngToJson.java
+
+          compare_grammar_pair() {
+            name="$1"
+            dtd_path="$2"
+            rng_path="$3"
+            dtd_json="build/grammar-compare/reports/${name}-dtd.json"
+            rng_json="build/grammar-compare/reports/${name}-rng.json"
+
+            java -cp build/grammar-compare/classes DtdToJson \
+              --catalog doctypes/catalog.xml \
+              -o "$dtd_json" \
+              "$dtd_path"
+            java -cp build/grammar-compare/classes RngToJson \
+              --catalog doctypes/catalog.xml \
+              -o "$rng_json" \
+              "$rng_path"
+            python3 .github/resources/compare_json_reports.py \
+              "$dtd_json" \
+              "$rng_json" \
+              --quiet
+          }
+
+          compare_grammar_pair basetopic \
+            doctypes/dtd/base/basetopic.dtd \
+            doctypes/rng/base/basetopic.rng
+          compare_grammar_pair basemap \
+            doctypes/dtd/base/basemap.dtd \
+            doctypes/rng/base/basemap.rng
+          compare_grammar_pair ditaval \
+            doctypes/dtd/ditaval/ditaval.dtd \
+            doctypes/rng/ditaval/ditaval.rng
+          compare_grammar_pair subjectScheme \
+            doctypes/dtd/subjectScheme/subjectScheme.dtd \
+            doctypes/rng/subjectScheme/subjectScheme.rng
       - name: Cache DITA-OT
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This adds a check to ensure parity between the DTD and RNG versions of each grammar.

* Adds a Java class that will read in the DTD, expanding all of the parameter / text entities to get a version of the DTD. The element and attribute lists are exported as JSON. There is an entry for each element; within each element, we list the attribute; and the attribute includes either the default value, or the type of the attribute. There is also normalization of spaces and sorting.
* Adds a Java class to do the same with RNG. In addition, it converts the RNG attribute type "string" to CDATA to match the DTD version.
* Adds a python script to compare the output, and fail with logging if the two do not match
* Updates the CI/CD script to run this on each DTD in the base vocabulary. If a change is made to DTD or RNG that is not matched in the other, we will be prevented from merging.