### PR TITLE
Update attribute list, and add script for generating the list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ specification/out/pdf/ditaweb-review-e.pdf
 *.pdf
 specification/out/pdf/ditaweb-review-c.pdf
 *.pdf
+# Ignore compiled Java artifacts used to test spec
+.github/resources/*.class
 # Ignore Gradle project-specific cache directory
 .gradle
 # Ignore Gradle build output directory

--- a/resources/generate-base-attributes-report.sh
+++ b/resources/generate-base-attributes-report.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build/attribute-report"
+CLASS_DIR="$BUILD_DIR/classes"
+JSON_DIR="$BUILD_DIR/json"
+OUTPUT="$SCRIPT_DIR/base-attributes-a-to-z.dita"
+
+mkdir -p "$CLASS_DIR" "$JSON_DIR"
+
+javac -d "$CLASS_DIR" "$REPO_ROOT/.github/resources/RngToJson.java"
+
+java -cp "$CLASS_DIR" RngToJson \
+  --catalog "$REPO_ROOT/doctypes/catalog.xml" \
+  -o "$JSON_DIR/rng-topic.json" \
+  "$REPO_ROOT/doctypes/rng/base/basetopic.rng"
+
+java -cp "$CLASS_DIR" RngToJson \
+  --catalog "$REPO_ROOT/doctypes/catalog.xml" \
+  -o "$JSON_DIR/rng-map.json" \
+  "$REPO_ROOT/doctypes/rng/base/basemap.rng"
+
+java -cp "$CLASS_DIR" RngToJson \
+  --catalog "$REPO_ROOT/doctypes/catalog.xml" \
+  -o "$JSON_DIR/rng-subjectScheme.json" \
+  "$REPO_ROOT/doctypes/rng/subjectScheme/subjectScheme.rng"
+
+python3 "$SCRIPT_DIR/rng_json_attribute_report.py" \
+  "$JSON_DIR/rng-topic.json" \
+  "$JSON_DIR/rng-map.json" \
+  "$JSON_DIR/rng-subjectScheme.json" \
+  > "$OUTPUT"
+
+echo "Wrote $OUTPUT"

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Generate an attribute coverage report from RngToJson JSON output.
 
-Output format matches doctypes/dtd/rng_attribute_report.py:
-- HTML <ul>/<li> list
-- Attribute names wrapped in <xmlatt>...</xmlatt>
-- Element names rendered as <xref keyref="elements-<name>"/>
+Output format is a DITA reference topic:
+- Uses a DITA simple list
+- Each attribute name is wrapped in <xmlatt>...</xmlatt>
+- Each element name is linked using keyref, as <xref keyref="elements-<name>"/>
+- Additional information is included about the usage of the list
 """
 
 from __future__ import annotations
@@ -91,7 +92,7 @@ def build_report(
         for attr in attrs:
             attr_to_elements[attr].add(elem)
 
-    lines: list[str] = ["<ul>"]
+    lines: list[str] = ["<sl id=\"attributelist\">"]
 
     for attr in sorted(attr_to_elements, key=str.lower):
         present = attr_to_elements[attr]
@@ -99,15 +100,15 @@ def build_report(
         attr_xml = f"<xmlatt>{attr}</xmlatt>"
 
         if not missing:
-            lines.append(f"  <li>{attr_xml} (All elements)</li>")
+            lines.append(f"  <sli>{attr_xml}: All elements</sli>")
         elif len(missing) < exceptions_threshold:
             exc = ", ".join(element_ref(e) for e in missing)
-            lines.append(f"  <li>{attr_xml} (Missing: {exc})</li>")
+            lines.append(f"  <sli>{attr_xml}: All elements except {exc})</sli>")
         else:
             elems = ", ".join(element_ref(e) for e in sorted(present, key=str.lower))
-            lines.append(f"  <li>{attr_xml}: {elems}</li>")
+            lines.append(f"  <sli>{attr_xml}: {elems}</sli>")
 
-    lines.append("</ul>")
+    lines.append("</sl>")
     return "\n".join(lines)
 
 
@@ -139,7 +140,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     try:
-        report = build_report(
+        report_list = build_report(
             json_files=args.json_files,
             exclude_elements=set(args.exclude_element),
             exceptions_threshold=args.exceptions_threshold,
@@ -148,7 +149,22 @@ def main(argv: list[str]) -> int:
         print(exc, file=sys.stderr)
         return 2
 
-    print(report)
+    print('<?xml version="1.0" encoding="UTF-8"?>\n')
+    print("<!DOCTYPE reference PUBLIC \"-//OASIS//DTD DITA 2.0 Reference//EN\" \"reference.dtd\">\n")
+    print("<reference id=\"base-attributes-a-to-z\">\n")
+    print("<title>DITA Atrributes, A to Z</title>\n")
+    print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification, with a few exceptions.</shortdesc>\n")
+    print("<refbody><section>\n")
+    print("<p>The following exceptions apply:</p>")
+    print("<ul>\n")
+    print("<li>DITAVAL elements are not included.</li>")
+    print("<li>The <xref keyref=\"elements-no-topic-nesting\"/> element is not included.</li>")
+    print("</ul>\n")
+    print('<note type="reminder">Some attribtues are defined differently for different elements; ')
+    print('check the element description for details on values and any expected processing.</note>\n')
+    print(report_list)
+    print("</section></refbody>\n")
+    print("</reference>")
     return 0
 
 

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Generate an attribute coverage report from RngToJson JSON output.
+
+Output format matches doctypes/dtd/rng_attribute_report.py:
+- HTML <ul>/<li> list
+- Attribute names wrapped in <xmlatt>...</xmlatt>
+- Element names rendered as <xref keyref="elements-<name>"/>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+Report = dict[str, dict[str, str]]
+
+
+def element_ref(name: str) -> str:
+    return f'<xref keyref="elements-{name}"/>'
+
+
+def load_report(path: Path) -> Report:
+    try:
+        with path.open("r", encoding="utf-8") as report_file:
+            data: Any = json.load(report_file)
+    except FileNotFoundError as exc:
+        raise ValueError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Report must be a JSON object: {path}")
+
+    report: Report = {}
+    for element_name, attrs in data.items():
+        if not isinstance(element_name, str):
+            raise ValueError(f"Element names must be strings in {path}")
+        if not isinstance(attrs, dict):
+            raise ValueError(f"Element {element_name!r} must map to an object in {path}")
+
+        report[element_name] = {}
+        for attr_name, attr_value in attrs.items():
+            if not isinstance(attr_name, str) or not isinstance(attr_value, str):
+                raise ValueError(
+                    f"Attributes on element {element_name!r} must map string names to string values in {path}"
+                )
+            report[element_name][attr_name] = attr_value
+
+    return report
+
+
+def merge_reports(paths: Iterable[Path]) -> dict[str, set[str]]:
+    element_attr_map: dict[str, set[str]] = defaultdict(set)
+    for path in paths:
+        report = load_report(path)
+        for element_name, attrs in report.items():
+            element_attr_map[element_name].update(attrs.keys())
+    return element_attr_map
+
+
+def build_report(
+    json_files: Iterable[Path],
+    exclude_elements: set[str],
+    exceptions_threshold: int,
+) -> str:
+    element_attr_map = merge_reports(json_files)
+    scope_elements = set(element_attr_map) - exclude_elements
+
+    attr_to_elements: dict[str, set[str]] = defaultdict(set)
+    for elem, attrs in element_attr_map.items():
+        if elem not in scope_elements:
+            continue
+        for attr in attrs:
+            attr_to_elements[attr].add(elem)
+
+    lines: list[str] = ["<ul>"]
+
+    for attr in sorted(attr_to_elements, key=str.lower):
+        present = attr_to_elements[attr]
+        missing = sorted(scope_elements - present, key=str.lower)
+        attr_xml = f"<xmlatt>{attr}</xmlatt>"
+
+        if not missing:
+            lines.append(f"  <li>{attr_xml} (All elements)</li>")
+        elif len(missing) < exceptions_threshold:
+            exc = ", ".join(element_ref(e) for e in missing)
+            lines.append(f"  <li>{attr_xml} (Missing: {exc})</li>")
+        else:
+            elems = ", ".join(element_ref(e) for e in sorted(present, key=str.lower))
+            lines.append(f"  <li>{attr_xml}: {elems}</li>")
+
+    lines.append("</ul>")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an HTML attribute coverage report from RngToJson JSON files."
+    )
+    parser.add_argument(
+        "json_files",
+        nargs="+",
+        type=Path,
+        help="One or more JSON files produced by RngToJson.",
+    )
+    parser.add_argument(
+        "--exclude-element",
+        action="append",
+        default=["no-topic-nesting"],
+        help="Element name to exclude. Can be provided multiple times (default includes no-topic-nesting).",
+    )
+    parser.add_argument(
+        "--exceptions-threshold",
+        type=int,
+        default=10,
+        help="If fewer than this many elements are missing an attribute, list Missing exceptions (default: 10).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        report = build_report(
+            json_files=args.json_files,
+            exclude_elements=set(args.exclude_element),
+            exceptions_threshold=args.exceptions_threshold,
+        )
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -19,6 +19,15 @@ from typing import Any, Iterable
 
 Report = dict[str, dict[str, str]]
 
+DEFAULT_DITA_ELEMENT_ATTRS: dict[str, str] = {
+    "dir": "(lro | ltr | rlo | rtl | -dita-use-conref-target)",
+    "ditaarch:DITAArchVersion": "2.0",
+    "specializations": "@props/audience @props/deliveryTarget @props/platform @props/product @props/otherprops",
+    "translate": "(no | yes | -dita-use-conref-target)",
+    "xml:lang": "CDATA",
+    "xmlns:ditaarch": "http://dita.oasis-open.org/architecture/2005/",
+}
+
 
 def element_ref(name: str) -> str:
     return f'<xref keyref="elements-{name}"/>'
@@ -60,6 +69,10 @@ def merge_reports(paths: Iterable[Path]) -> dict[str, set[str]]:
         report = load_report(path)
         for element_name, attrs in report.items():
             element_attr_map[element_name].update(attrs.keys())
+
+    if "dita" not in element_attr_map:
+        element_attr_map["dita"].update(DEFAULT_DITA_ELEMENT_ATTRS.keys())
+
     return element_attr_map
 
 

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -77,6 +77,13 @@ def merge_reports(paths: Iterable[Path]) -> dict[str, set[str]]:
     return element_attr_map
 
 
+def load_excluded_elements(paths: Iterable[Path]) -> set[str]:
+    excluded: set[str] = set()
+    for path in paths:
+        excluded.update(load_report(path).keys())
+    return excluded
+
+
 def build_report(
     json_files: Iterable[Path],
     exclude_elements: set[str],
@@ -129,6 +136,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Element name to exclude. Can be provided multiple times (default includes no-topic-nesting).",
     )
     parser.add_argument(
+        "--exclude-json",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "JSON report whose element names should be excluded from the final report. "
+            "Can be provided multiple times."
+        ),
+    )
+    parser.add_argument(
         "--exceptions-threshold",
         type=int,
         default=10,
@@ -146,9 +163,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     try:
+        exclude_elements = set(args.exclude_element)
+        exclude_elements.update(load_excluded_elements(args.exclude_json))
         report_list = build_report(
             json_files=args.json_files,
-            exclude_elements=set(args.exclude_element),
+            exclude_elements=exclude_elements,
             exceptions_threshold=args.exceptions_threshold,
         )
     except ValueError as exc:

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -174,24 +174,24 @@ def main(argv: list[str]) -> int:
         print(exc, file=sys.stderr)
         return 2
 
-    print('<?xml version="1.0" encoding="UTF-8"?>\n')
-    print("<!DOCTYPE reference PUBLIC \"-//OASIS//DTD DITA 2.0 Reference//EN\" \"reference.dtd\">\n")
-    print("<reference id=\"attributes-a-to-z\">\n")
-    print("<title>DITA Atrributes, A to Z</title>\n")
-    print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>\n")
-    print("<refbody><section>\n")
+    print('<?xml version="1.0" encoding="UTF-8"?>')
+    print("<!DOCTYPE reference PUBLIC \"-//OASIS//DTD DITA 2.0 Reference//EN\" \"reference.dtd\">")
+    print("<reference id=\"attributes-a-to-z\">")
+    print("<title>DITA Atrributes, A to Z</title>")
+    print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>")
+    print("<refbody><section>")
     if args.spec == "techcomm":
         print("<p>This report includes only elements from the technical communications specification; it does not include elements from the base specification.</p>")
     else:
         print("<p>The following exceptions apply:</p>")
-        print("<ul>\n")
+        print("<ul>")
         print("<li>DITAVAL elements are not included.</li>")
         print("<li>The <xref keyref=\"elements-no-topic-nesting\"/> element is not included.</li>")
-        print("</ul>\n")
-    print('<note type="reminder">Some attribtues are defined differently for different elements; ')
-    print('check the element description for details on values and any expected processing.</note>\n')
+        print("</ul>")
+    print('<note>Some attribtues are defined differently for different elements; ')
+    print('check the element description for details on values and any expected processing.</note>')
     print(report_list)
-    print("</section></refbody>\n")
+    print("</section></refbody>")
     print("</reference>")
     return 0
 

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -134,6 +134,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=10,
         help="If fewer than this many elements are missing an attribute, list Missing exceptions (default: 10).",
     )
+    parser.add_argument(
+        "--spec",
+        choices=("base", "techcomm"),
+        default="base",
+        help="Specification scope for the report. Use techcomm to add the technical communications note (default: base).",
+    )
     return parser.parse_args(argv)
 
 
@@ -151,15 +157,18 @@ def main(argv: list[str]) -> int:
 
     print('<?xml version="1.0" encoding="UTF-8"?>\n')
     print("<!DOCTYPE reference PUBLIC \"-//OASIS//DTD DITA 2.0 Reference//EN\" \"reference.dtd\">\n")
-    print("<reference id=\"base-attributes-a-to-z\">\n")
+    print("<reference id=\"attributes-a-to-z\">\n")
     print("<title>DITA Atrributes, A to Z</title>\n")
-    print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification, with a few exceptions.</shortdesc>\n")
+    print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>\n")
     print("<refbody><section>\n")
-    print("<p>The following exceptions apply:</p>")
-    print("<ul>\n")
-    print("<li>DITAVAL elements are not included.</li>")
-    print("<li>The <xref keyref=\"elements-no-topic-nesting\"/> element is not included.</li>")
-    print("</ul>\n")
+    if args.spec == "techcomm":
+        print("<p>This report includes only elements from the technical communications specification; it does not include elements from the base specification.</p>")
+    else:
+        print("<p>The following exceptions apply:</p>")
+        print("<ul>\n")
+        print("<li>DITAVAL elements are not included.</li>")
+        print("<li>The <xref keyref=\"elements-no-topic-nesting\"/> element is not included.</li>")
+        print("</ul>\n")
     print('<note type="reminder">Some attribtues are defined differently for different elements; ')
     print('check the element description for details on values and any expected processing.</note>\n')
     print(report_list)

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -1,173 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 2.0 Reference//EN" "reference.dtd">
-<reference id="base-attributes-a-to-z">
-    <title>DITA attributes, A to Z</title>
-    <shortdesc>This topics provides links to DITA attributes in alphabetical order.</shortdesc>
-    <refbody>
-        <section id="attributelist">
-            <sl>
-                <sli><xmlatt>align</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-tgroup"/></sli>
-                <sli><xmlatt>appid</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>appid-role</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>appname</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>audience</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref
-                    keyref="elements-title"/>)</sli>
-                <sli><xmlatt>author</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
-                <sli><xmlatt>autoplay</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>base</xmlatt> (All elements)</sli>
-                <sli><xmlatt>callout</xmlatt>: <xref keyref="elements-fn"/></sli>
-                <sli><xmlatt>cascade</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>,
-                    <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>char</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>charoff</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>chunk</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>class</xmlatt> (All elements)</sli>
-                <sli><xmlatt>codetype</xmlatt>: <xref keyref="elements-object"/></sli>
-                <sli><xmlatt>collection-type</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>colname</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>colnum</xmlatt>: <xref keyref="elements-colspec"/></sli>
-                <sli><xmlatt>cols</xmlatt>: <xref keyref="elements-tgroup"/></sli>
-                <sli><xmlatt>colsep</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-table"/>, <xref keyref="elements-tgroup"/></sli>
-                <sli><xmlatt>colspan</xmlatt>: <xref keyref="elements-stentry"/></sli>
-                <sli><xmlatt>colwidth</xmlatt>: <xref keyref="elements-colspec"/></sli>
-                <sli><xmlatt>compact</xmlatt>: <xref keyref="elements-dl"/>, <xref keyref="elements-ol"/>, <xref keyref="elements-sl"/>, <xref keyref="elements-ul"/></sli>
-                <sli><xmlatt>conaction</xmlatt> (All elements)</sli>
-                <sli><xmlatt>conkeyref</xmlatt> (On all elements except: <xref keyref="elements-ditavalmeta"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/>)</sli>
-                <sli><xmlatt>conref</xmlatt> (All elements)</sli>
-                <sli><xmlatt>conrefend</xmlatt> (All elements)</sli>
-                <sli><xmlatt>content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
-                <sli><xmlatt>controls</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>data</xmlatt>: <xref keyref="elements-object"/></sli>
-                <sli><xmlatt>datakeyref</xmlatt>: <xref keyref="elements-object"/></sli>
-                <sli><xmlatt>datatype</xmlatt>: <xref keyref="elements-data"/></sli>
-                <sli><xmlatt>date</xmlatt>: <xref keyref="elements-created"/></sli>
-                <sli><xmlatt>deliveryTarget</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>,
-                    <xref keyref="elements-title"/>)</sli>
-                <sli><xmlatt>dir</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
-                <sli><xmlatt>disposition</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
-                <sli><xmlatt>ditaarch:DITAArchVersion</xmlatt>: <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
-                <sli><xmlatt>duplicates</xmlatt>: <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/></sli>
-                <sli><xmlatt>encoding</xmlatt>: <xref keyref="elements-include"/></sli>
-                <sli><xmlatt>end</xmlatt>: <xref keyref="elements-indexterm"/></sli>
-                <sli><xmlatt>expanse</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>, <xref keyref="elements-simpletable"/></sli>
-                <sli><xmlatt>experiencelevel</xmlatt>: <xref keyref="elements-audience"/></sli>
-                <sli><xmlatt>expiry</xmlatt>: <xref keyref="elements-created"/>, <xref keyref="elements-revised"/></sli>
-                <sli><xmlatt>features</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>format</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref
-                        keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref
-                            keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref
-                                keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref
-                                    keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
-                <sli><xmlatt>frame</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>, <xref keyref="elements-simpletable"/>, <xref keyref="elements-table"/></sli>
-                <sli><xmlatt>full-screen</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>golive</xmlatt>: <xref keyref="elements-created"/>, <xref keyref="elements-revised"/></sli>
-                <sli><xmlatt>headers</xmlatt>: <xref keyref="elements-entry"/>, <xref keyref="elements-stentry"/></sli>
-                <sli><xmlatt>height</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>href</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-mapref"/>, <xref
-                        keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref
-                            keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
-                <sli><xmlatt>id</xmlatt> (All elements)</sli>
-                <sli><xmlatt>importance</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>,
-                    <xref keyref="elements-title"/>)</sli>
-                <sli><xmlatt>impose-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref
-                    keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>job</xmlatt>: <xref keyref="elements-audience"/></sli>
-                <sli><xmlatt>keycol</xmlatt>: <xref keyref="elements-simpletable"/></sli>
-                <sli><xmlatt>keyref</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-b"/>, <xref keyref="elements-cite"/>, <xref keyref="elements-coords"/>, <xref keyref="elements-data"/>, <xref
-                    keyref="elements-defaultSubject"/>, <xref keyref="elements-dt"/>, <xref keyref="elements-em"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-i"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>,
-                    <xref keyref="elements-index-see"/>, <xref keyref="elements-index-see-also"/>, <xref keyref="elements-indexterm"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-keyword"/>, <xref keyref="elements-line-through"/>, <xref
-                        keyref="elements-link"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-lq"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-overline"/>, <xref keyref="elements-param"/>, <xref keyref="elements-ph"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-shape"/>, <xref
-                                keyref="elements-source"/>, <xref keyref="elements-strong"/>, <xref keyref="elements-sub"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-sup"/>, <xref keyref="elements-term"/>, <xref keyref="elements-topicref"/>, <xref
-                                    keyref="elements-tt"/>, <xref keyref="elements-u"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
-                <sli><xmlatt>keys</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-schemeref"/>, <xref
-                    keyref="elements-subjectdef"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>keyscope</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>kind</xmlatt>: <xref keyref="elements-media-track"/></sli>
-                <sli><xmlatt>left</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>linking</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>loop</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>mapref</xmlatt>: <xref keyref="elements-navref"/></sli>
-                <sli><xmlatt>modification</xmlatt>: <xref keyref="elements-vrm"/></sli>
-                <sli><xmlatt>modified</xmlatt>: <xref keyref="elements-revised"/></sli>
-                <sli><xmlatt>morerows</xmlatt>: <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>muted</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>name</xmlatt>: <xref keyref="elements-attributedef"/>, <xref keyref="elements-audience"/>, <xref keyref="elements-data"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref
-                    keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-object"/>, <xref keyref="elements-othermeta"/>, <xref keyref="elements-param"/>, <xref
-                        keyref="elements-sort-as"/>, <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>nameend</xmlatt>: <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>namest</xmlatt>: <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>on-top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>orient</xmlatt>: <xref keyref="elements-table"/></sli>
-                <sli><xmlatt>otherprops</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>,
-                    <xref keyref="elements-title"/>)</sli>
-                <sli><xmlatt>otherrole</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
-                <sli><xmlatt>othertype</xmlatt>: <xref keyref="elements-note"/></sli>
-                <sli><xmlatt>outputclass</xmlatt> (All elements)</sli>
-                <sli><xmlatt>parse</xmlatt>: <xref keyref="elements-include"/></sli>
-                <sli><xmlatt>pgwide</xmlatt>: <xref keyref="elements-table"/></sli>
-                <sli><xmlatt>placement</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/></sli>
-                <sli><xmlatt>platform</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref
-                    keyref="elements-title"/>)</sli>
-                <sli><xmlatt>processing-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref
-                    keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref
-                        keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>product</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref
-                    keyref="elements-title"/>)</sli>
-                <sli><xmlatt>props</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref
-                    keyref="elements-title"/>)</sli>
-                <sli><xmlatt>relative</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>relcolwidth</xmlatt>: <xref keyref="elements-simpletable"/></sli>
-                <sli><xmlatt>release</xmlatt>: <xref keyref="elements-vrm"/></sli>
-                <sli><xmlatt>remap</xmlatt>: <xref keyref="elements-required-cleanup"/></sli>
-                <sli><xmlatt>rev</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>)</sli>
-                <sli><xmlatt>role</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
-                <sli><xmlatt>rotate</xmlatt>: <xref keyref="elements-entry"/></sli>
-                <sli><xmlatt>rowheader</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-table"/></sli>
-                <sli><xmlatt>rowsep</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-row"/>, <xref keyref="elements-table"/>, <xref keyref="elements-tgroup"/></sli>
-                <sli><xmlatt>rowspan</xmlatt>: <xref keyref="elements-stentry"/></sli>
-                <sli><xmlatt>scale</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>,
-                    <xref keyref="elements-simpletable"/>, <xref keyref="elements-table"/></sli>
-                <sli><xmlatt>scalefit</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/></sli>
-                <sli><xmlatt>scope</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref
-                        keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref
-                            keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref
-                                keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-stentry"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref
-                                    keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
-                <sli><xmlatt>search</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>specializations</xmlatt>: <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
-                <sli><xmlatt>srclang</xmlatt>: <xref keyref="elements-media-track"/></sli>
-                <sli><xmlatt>start</xmlatt>: <xref keyref="elements-indexterm"/></sli>
-                <sli><xmlatt>status</xmlatt> (On all elements except: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-title"/>)</sli>
-                <sli><xmlatt>subjectrefs</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>tabindex</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-object"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>time</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
-                <sli><xmlatt>title-role</xmlatt>: <xref keyref="elements-linktitle"/>, <xref keyref="elements-navtitle"/>, <xref keyref="elements-searchtitle"/>, <xref keyref="elements-subtitle"/>, <xref keyref="elements-titlealt"/>, <xref
-                    keyref="elements-titlehint"/></sli>
-                <sli><xmlatt>tmclass</xmlatt>: <xref keyref="elements-tm"/></sli>
-                <sli><xmlatt>tmowner</xmlatt>: <xref keyref="elements-tm"/></sli>
-                <sli><xmlatt>tmtype</xmlatt>: <xref keyref="elements-tm"/></sli>
-                <sli><xmlatt>toc</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-                <sli><xmlatt>top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
-                <sli><xmlatt>trademark</xmlatt>: <xref keyref="elements-tm"/></sli>
-                <sli><xmlatt>translate</xmlatt> (On all elements except: <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
-                <sli><xmlatt>translate-content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
-                <sli><xmlatt>type</xmlatt>: <xref keyref="elements-audience"/>, <xref keyref="elements-author"/>, <xref keyref="elements-copyright"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-hazardstatement"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref
-                        keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-note"/>, <xref keyref="elements-object"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>,
-                    <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-xref"/></sli>
-                <sli><xmlatt>usemap</xmlatt>: <xref keyref="elements-object"/></sli>
-                <sli><xmlatt>ux-context-string</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>ux-source-priority</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>ux-windowref</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-                <sli><xmlatt>valign</xmlatt>: <xref keyref="elements-entry"/>, <xref keyref="elements-row"/>, <xref keyref="elements-tbody"/>, <xref keyref="elements-thead"/></sli>
-                <sli><xmlatt>value</xmlatt>: <xref keyref="elements-data"/>, <xref keyref="elements-param"/>, <xref keyref="elements-sort-as"/></sli>
-                <sli><xmlatt>version</xmlatt>: <xref keyref="elements-vrm"/></sli>
-                <sli><xmlatt>view</xmlatt>: <xref keyref="elements-permissions"/></sli>
-                <sli><xmlatt>width</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
-                <sli><xmlatt>xml:lang</xmlatt> (On all elements except: <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
-                <sli><xmlatt>xml:space</xmlatt>: <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/></sli>
-                <sli><xmlatt>xmlns:ditaarch</xmlatt>: <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
-                <sli><xmlatt>year</xmlatt>: <xref keyref="elements-copyryear"/></sli>
-            </sl>
-        </section>
-    </refbody>
+<reference id="attributes-a-to-z">
+<title>DITA Atrributes, A to Z</title>
+<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>
+<refbody><section>
+<p>The following exceptions apply:</p>
+<ul>
+<li>DITAVAL elements are not included.</li>
+<li>The <xref keyref="elements-no-topic-nesting"/> element is not included.</li>
+</ul>
+<note>Some attribtues are defined differently for different elements; 
+check the element description for details on values and any expected processing.</note>
+<sl id="attributelist">
+  <sli><xmlatt>align</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-tgroup"/></sli>
+  <sli><xmlatt>appid</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>appid-role</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>appname</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>audience</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>author</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
+  <sli><xmlatt>autoplay</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>base</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>callout</xmlatt>: <xref keyref="elements-fn"/></sli>
+  <sli><xmlatt>cascade</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>char</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>charoff</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>chunk</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>class</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>codetype</xmlatt>: <xref keyref="elements-object"/></sli>
+  <sli><xmlatt>collection-type</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>colname</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>colnum</xmlatt>: <xref keyref="elements-colspec"/></sli>
+  <sli><xmlatt>cols</xmlatt>: <xref keyref="elements-tgroup"/></sli>
+  <sli><xmlatt>colsep</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-table"/>, <xref keyref="elements-tgroup"/></sli>
+  <sli><xmlatt>colspan</xmlatt>: <xref keyref="elements-stentry"/></sli>
+  <sli><xmlatt>colwidth</xmlatt>: <xref keyref="elements-colspec"/></sli>
+  <sli><xmlatt>compact</xmlatt>: <xref keyref="elements-dl"/>, <xref keyref="elements-ol"/>, <xref keyref="elements-sl"/>, <xref keyref="elements-ul"/></sli>
+  <sli><xmlatt>conaction</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>conkeyref</xmlatt>: All elements except <xref keyref="elements-dita"/>, <xref keyref="elements-ditavalmeta"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/>)</sli>
+  <sli><xmlatt>conref</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>conrefend</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
+  <sli><xmlatt>controls</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>data</xmlatt>: <xref keyref="elements-object"/></sli>
+  <sli><xmlatt>datakeyref</xmlatt>: <xref keyref="elements-object"/></sli>
+  <sli><xmlatt>datatype</xmlatt>: <xref keyref="elements-data"/></sli>
+  <sli><xmlatt>date</xmlatt>: <xref keyref="elements-created"/></sli>
+  <sli><xmlatt>deliveryTarget</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>dir</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>disposition</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
+  <sli><xmlatt>ditaarch:DITAArchVersion</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
+  <sli><xmlatt>duplicates</xmlatt>: <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/></sli>
+  <sli><xmlatt>encoding</xmlatt>: <xref keyref="elements-include"/></sli>
+  <sli><xmlatt>end</xmlatt>: <xref keyref="elements-indexterm"/></sli>
+  <sli><xmlatt>expanse</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>, <xref keyref="elements-simpletable"/></sli>
+  <sli><xmlatt>experiencelevel</xmlatt>: <xref keyref="elements-audience"/></sli>
+  <sli><xmlatt>expiry</xmlatt>: <xref keyref="elements-created"/>, <xref keyref="elements-revised"/></sli>
+  <sli><xmlatt>features</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>format</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
+  <sli><xmlatt>frame</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>, <xref keyref="elements-simpletable"/>, <xref keyref="elements-table"/></sli>
+  <sli><xmlatt>full-screen</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>golive</xmlatt>: <xref keyref="elements-created"/>, <xref keyref="elements-revised"/></sli>
+  <sli><xmlatt>headers</xmlatt>: <xref keyref="elements-entry"/>, <xref keyref="elements-stentry"/></sli>
+  <sli><xmlatt>height</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>href</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
+  <sli><xmlatt>id</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>importance</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>impose-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>job</xmlatt>: <xref keyref="elements-audience"/></sli>
+  <sli><xmlatt>keycol</xmlatt>: <xref keyref="elements-simpletable"/></sli>
+  <sli><xmlatt>keyref</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-b"/>, <xref keyref="elements-cite"/>, <xref keyref="elements-coords"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-dt"/>, <xref keyref="elements-em"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-i"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-index-see"/>, <xref keyref="elements-index-see-also"/>, <xref keyref="elements-indexterm"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-keyword"/>, <xref keyref="elements-line-through"/>, <xref keyref="elements-link"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-lq"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-overline"/>, <xref keyref="elements-param"/>, <xref keyref="elements-ph"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-shape"/>, <xref keyref="elements-source"/>, <xref keyref="elements-strong"/>, <xref keyref="elements-sub"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-sup"/>, <xref keyref="elements-term"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-tt"/>, <xref keyref="elements-u"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
+  <sli><xmlatt>keys</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>keyscope</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>kind</xmlatt>: <xref keyref="elements-media-track"/></sli>
+  <sli><xmlatt>left</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>linking</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>loop</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>mapref</xmlatt>: <xref keyref="elements-navref"/></sli>
+  <sli><xmlatt>modification</xmlatt>: <xref keyref="elements-vrm"/></sli>
+  <sli><xmlatt>modified</xmlatt>: <xref keyref="elements-revised"/></sli>
+  <sli><xmlatt>morerows</xmlatt>: <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>muted</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>name</xmlatt>: <xref keyref="elements-attributedef"/>, <xref keyref="elements-audience"/>, <xref keyref="elements-data"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-object"/>, <xref keyref="elements-othermeta"/>, <xref keyref="elements-param"/>, <xref keyref="elements-sort-as"/>, <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>nameend</xmlatt>: <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>namest</xmlatt>: <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>on-top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>orient</xmlatt>: <xref keyref="elements-table"/></sli>
+  <sli><xmlatt>otherprops</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>otherrole</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
+  <sli><xmlatt>othertype</xmlatt>: <xref keyref="elements-note"/></sli>
+  <sli><xmlatt>outputclass</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>parse</xmlatt>: <xref keyref="elements-include"/></sli>
+  <sli><xmlatt>pgwide</xmlatt>: <xref keyref="elements-table"/></sli>
+  <sli><xmlatt>placement</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/></sli>
+  <sli><xmlatt>platform</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>processing-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>product</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>props</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>relative</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>relcolwidth</xmlatt>: <xref keyref="elements-simpletable"/></sli>
+  <sli><xmlatt>release</xmlatt>: <xref keyref="elements-vrm"/></sli>
+  <sli><xmlatt>remap</xmlatt>: <xref keyref="elements-required-cleanup"/></sli>
+  <sli><xmlatt>rev</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>)</sli>
+  <sli><xmlatt>role</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
+  <sli><xmlatt>rotate</xmlatt>: <xref keyref="elements-entry"/></sli>
+  <sli><xmlatt>rowheader</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-table"/></sli>
+  <sli><xmlatt>rowsep</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-row"/>, <xref keyref="elements-table"/>, <xref keyref="elements-tgroup"/></sli>
+  <sli><xmlatt>rowspan</xmlatt>: <xref keyref="elements-stentry"/></sli>
+  <sli><xmlatt>scale</xmlatt>: <xref keyref="elements-fig"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-imagemap"/>, <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/>, <xref keyref="elements-simpletable"/>, <xref keyref="elements-table"/></sli>
+  <sli><xmlatt>scalefit</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/></sli>
+  <sli><xmlatt>scope</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-stentry"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
+  <sli><xmlatt>search</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>specializations</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
+  <sli><xmlatt>srclang</xmlatt>: <xref keyref="elements-media-track"/></sli>
+  <sli><xmlatt>start</xmlatt>: <xref keyref="elements-indexterm"/></sli>
+  <sli><xmlatt>status</xmlatt>: All elements except <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>subjectrefs</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>tabindex</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-object"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>time</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
+  <sli><xmlatt>title-role</xmlatt>: <xref keyref="elements-linktitle"/>, <xref keyref="elements-navtitle"/>, <xref keyref="elements-searchtitle"/>, <xref keyref="elements-subtitle"/>, <xref keyref="elements-titlealt"/>, <xref keyref="elements-titlehint"/></sli>
+  <sli><xmlatt>tmclass</xmlatt>: <xref keyref="elements-tm"/></sli>
+  <sli><xmlatt>tmowner</xmlatt>: <xref keyref="elements-tm"/></sli>
+  <sli><xmlatt>tmtype</xmlatt>: <xref keyref="elements-tm"/></sli>
+  <sli><xmlatt>toc</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
+  <sli><xmlatt>top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
+  <sli><xmlatt>trademark</xmlatt>: <xref keyref="elements-tm"/></sli>
+  <sli><xmlatt>translate</xmlatt>: All elements except <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>translate-content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
+  <sli><xmlatt>type</xmlatt>: <xref keyref="elements-audience"/>, <xref keyref="elements-author"/>, <xref keyref="elements-copyright"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-hazardstatement"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-note"/>, <xref keyref="elements-object"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-xref"/></sli>
+  <sli><xmlatt>usemap</xmlatt>: <xref keyref="elements-object"/></sli>
+  <sli><xmlatt>ux-context-string</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>ux-source-priority</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>ux-windowref</xmlatt>: <xref keyref="elements-resourceid"/></sli>
+  <sli><xmlatt>valign</xmlatt>: <xref keyref="elements-entry"/>, <xref keyref="elements-row"/>, <xref keyref="elements-tbody"/>, <xref keyref="elements-thead"/></sli>
+  <sli><xmlatt>value</xmlatt>: <xref keyref="elements-data"/>, <xref keyref="elements-param"/>, <xref keyref="elements-sort-as"/></sli>
+  <sli><xmlatt>version</xmlatt>: <xref keyref="elements-vrm"/></sli>
+  <sli><xmlatt>view</xmlatt>: <xref keyref="elements-permissions"/></sli>
+  <sli><xmlatt>width</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
+  <sli><xmlatt>xml:lang</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>xml:space</xmlatt>: <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/></sli>
+  <sli><xmlatt>xmlns:ditaarch</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
+  <sli><xmlatt>year</xmlatt>: <xref keyref="elements-copyryear"/></sli>
+</sl>
+</section></refbody>
 </reference>


### PR DESCRIPTION
This reuses the Java class recently added for comparing DTD and RNG grammar files.

It adds a python script that takes the output of the RNG comparison script, which is a JSON list of all elements/attributes in the grammar, and:
1. Adds in `<dita>` which is defined in the base but not present in an RNG file
2. Creates a list of all attributes across all elements, similar to the current "attributes a to z" topic
3. Writes out those attributes as a DITA reference topic, meant to be directly copied over the existing topic in the spec
4. It also adds support for using that same script in the tech-comm spec, to generate an attribute list that excludes base elements
5. And finally adds a shell script to run all of this