### PR TITLE
Fix wording about DITA element

### DIFF
--- a/specification/langRef/base/dita.dita
+++ b/specification/langRef/base/dita.dita
@@ -7,7 +7,7 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p rev="review-a">The ditabase document type is a container topic
+      <p rev="review-a">The ditabase document type is a container
         that can manage any sequence of any type of topic. It can be used
         to hold elements designed for reuse, and it is also useful as an
         intermediate output for conversion operations.</p>


### PR DESCRIPTION
The DITA element is not itself a topic, it is a container to hold topics. Fixed misleading word in the langref that described it as a topic.