### PR TITLE
Update attribute generator to fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ specification/out/pdf/ditaweb-review-e.pdf
 *.pdf
 specification/out/pdf/ditaweb-review-c.pdf
 *.pdf
+# Ignore the generated attr topic inside resources folder
+resources/base-attributes-a-to-z.dita
 # Ignore compiled Java artifacts used to test spec
 .github/resources/*.class
 # Ignore Gradle project-specific cache directory

--- a/resources/rng_json_attribute_report.py
+++ b/resources/rng_json_attribute_report.py
@@ -110,7 +110,7 @@ def build_report(
             lines.append(f"  <sli>{attr_xml}: All elements</sli>")
         elif len(missing) < exceptions_threshold:
             exc = ", ".join(element_ref(e) for e in missing)
-            lines.append(f"  <sli>{attr_xml}: All elements except {exc})</sli>")
+            lines.append(f"  <sli>{attr_xml}: All elements except {exc}</sli>")
         else:
             elems = ", ".join(element_ref(e) for e in sorted(present, key=str.lower))
             lines.append(f"  <sli>{attr_xml}: {elems}</sli>")
@@ -177,7 +177,7 @@ def main(argv: list[str]) -> int:
     print('<?xml version="1.0" encoding="UTF-8"?>')
     print("<!DOCTYPE reference PUBLIC \"-//OASIS//DTD DITA 2.0 Reference//EN\" \"reference.dtd\">")
     print("<reference id=\"attributes-a-to-z\">")
-    print("<title>DITA Atrributes, A to Z</title>")
+    print("<title>DITA Attributes, A to Z</title>")
     print("<shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>")
     print("<refbody><section>")
     if args.spec == "techcomm":
@@ -188,7 +188,7 @@ def main(argv: list[str]) -> int:
         print("<li>DITAVAL elements are not included.</li>")
         print("<li>The <xref keyref=\"elements-no-topic-nesting\"/> element is not included.</li>")
         print("</ul>")
-    print('<note>Some attribtues are defined differently for different elements; ')
+    print('<note>Some attributes are defined differently for different elements; ')
     print('check the element description for details on values and any expected processing.</note>')
     print(report_list)
     print("</section></refbody>")

--- a/specification/langRef/quick-reference/base-attributes-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-attributes-a-to-z.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 2.0 Reference//EN" "reference.dtd">
 <reference id="attributes-a-to-z">
-<title>DITA Atrributes, A to Z</title>
+<title>DITA Attributes, A to Z</title>
 <shortdesc>This topic includes a simple list of all attributes defined on all elements in this specification.</shortdesc>
 <refbody><section>
 <p>The following exceptions apply:</p>
@@ -9,23 +9,23 @@
 <li>DITAVAL elements are not included.</li>
 <li>The <xref keyref="elements-no-topic-nesting"/> element is not included.</li>
 </ul>
-<note>Some attribtues are defined differently for different elements; 
+<note>Some attributes are defined differently for different elements; 
 check the element description for details on values and any expected processing.</note>
 <sl id="attributelist">
   <sli><xmlatt>align</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-tgroup"/></sli>
   <sli><xmlatt>appid</xmlatt>: <xref keyref="elements-resourceid"/></sli>
   <sli><xmlatt>appid-role</xmlatt>: <xref keyref="elements-resourceid"/></sli>
   <sli><xmlatt>appname</xmlatt>: <xref keyref="elements-resourceid"/></sli>
-  <sli><xmlatt>audience</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>audience</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>author</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
   <sli><xmlatt>autoplay</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
-  <sli><xmlatt>base</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>base</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
   <sli><xmlatt>callout</xmlatt>: <xref keyref="elements-fn"/></sli>
   <sli><xmlatt>cascade</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
   <sli><xmlatt>char</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
   <sli><xmlatt>charoff</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
   <sli><xmlatt>chunk</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-  <sli><xmlatt>class</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>class</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
   <sli><xmlatt>codetype</xmlatt>: <xref keyref="elements-object"/></sli>
   <sli><xmlatt>collection-type</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
   <sli><xmlatt>colname</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-entry"/></sli>
@@ -35,18 +35,18 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>colspan</xmlatt>: <xref keyref="elements-stentry"/></sli>
   <sli><xmlatt>colwidth</xmlatt>: <xref keyref="elements-colspec"/></sli>
   <sli><xmlatt>compact</xmlatt>: <xref keyref="elements-dl"/>, <xref keyref="elements-ol"/>, <xref keyref="elements-sl"/>, <xref keyref="elements-ul"/></sli>
-  <sli><xmlatt>conaction</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
-  <sli><xmlatt>conkeyref</xmlatt>: All elements except <xref keyref="elements-dita"/>, <xref keyref="elements-ditavalmeta"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/>)</sli>
-  <sli><xmlatt>conref</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
-  <sli><xmlatt>conrefend</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>conaction</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
+  <sli><xmlatt>conkeyref</xmlatt>: All elements except <xref keyref="elements-dita"/>, <xref keyref="elements-ditavalmeta"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-dvrKeyscopePrefix"/>, <xref keyref="elements-dvrKeyscopeSuffix"/>, <xref keyref="elements-dvrResourcePrefix"/>, <xref keyref="elements-dvrResourceSuffix"/></sli>
+  <sli><xmlatt>conref</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
+  <sli><xmlatt>conrefend</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
   <sli><xmlatt>content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
   <sli><xmlatt>controls</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-video"/></sli>
   <sli><xmlatt>data</xmlatt>: <xref keyref="elements-object"/></sli>
   <sli><xmlatt>datakeyref</xmlatt>: <xref keyref="elements-object"/></sli>
   <sli><xmlatt>datatype</xmlatt>: <xref keyref="elements-data"/></sli>
   <sli><xmlatt>date</xmlatt>: <xref keyref="elements-created"/></sli>
-  <sli><xmlatt>deliveryTarget</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
-  <sli><xmlatt>dir</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>deliveryTarget</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
+  <sli><xmlatt>dir</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>disposition</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
   <sli><xmlatt>ditaarch:DITAArchVersion</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
   <sli><xmlatt>duplicates</xmlatt>: <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/></sli>
@@ -63,8 +63,8 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>headers</xmlatt>: <xref keyref="elements-entry"/>, <xref keyref="elements-stentry"/></sli>
   <sli><xmlatt>height</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
   <sli><xmlatt>href</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-author"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-include"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-media-source"/>, <xref keyref="elements-media-track"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-video"/>, <xref keyref="elements-video-poster"/>, <xref keyref="elements-xref"/></sli>
-  <sli><xmlatt>id</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
-  <sli><xmlatt>importance</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>id</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
+  <sli><xmlatt>importance</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>impose-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-topicref"/></sli>
   <sli><xmlatt>job</xmlatt>: <xref keyref="elements-audience"/></sli>
   <sli><xmlatt>keycol</xmlatt>: <xref keyref="elements-simpletable"/></sli>
@@ -85,22 +85,22 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>namest</xmlatt>: <xref keyref="elements-entry"/></sli>
   <sli><xmlatt>on-top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>orient</xmlatt>: <xref keyref="elements-table"/></sli>
-  <sli><xmlatt>otherprops</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>otherprops</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>otherrole</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
   <sli><xmlatt>othertype</xmlatt>: <xref keyref="elements-note"/></sli>
-  <sli><xmlatt>outputclass</xmlatt>: All elements except <xref keyref="elements-dita"/>)</sli>
+  <sli><xmlatt>outputclass</xmlatt>: All elements except <xref keyref="elements-dita"/></sli>
   <sli><xmlatt>parse</xmlatt>: <xref keyref="elements-include"/></sli>
   <sli><xmlatt>pgwide</xmlatt>: <xref keyref="elements-table"/></sli>
   <sli><xmlatt>placement</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/></sli>
-  <sli><xmlatt>platform</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>platform</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>processing-role</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-ditavalref"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
-  <sli><xmlatt>product</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
-  <sli><xmlatt>props</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>product</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
+  <sli><xmlatt>props</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>relative</xmlatt>: <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>relcolwidth</xmlatt>: <xref keyref="elements-simpletable"/></sli>
   <sli><xmlatt>release</xmlatt>: <xref keyref="elements-vrm"/></sli>
   <sli><xmlatt>remap</xmlatt>: <xref keyref="elements-required-cleanup"/></sli>
-  <sli><xmlatt>rev</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>)</sli>
+  <sli><xmlatt>rev</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/></sli>
   <sli><xmlatt>role</xmlatt>: <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-related-links"/></sli>
   <sli><xmlatt>rotate</xmlatt>: <xref keyref="elements-entry"/></sli>
   <sli><xmlatt>rowheader</xmlatt>: <xref keyref="elements-colspec"/>, <xref keyref="elements-table"/></sli>
@@ -113,7 +113,7 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>specializations</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
   <sli><xmlatt>srclang</xmlatt>: <xref keyref="elements-media-track"/></sli>
   <sli><xmlatt>start</xmlatt>: <xref keyref="elements-indexterm"/></sli>
-  <sli><xmlatt>status</xmlatt>: All elements except <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-title"/>)</sli>
+  <sli><xmlatt>status</xmlatt>: All elements except <xref keyref="elements-colspec"/>, <xref keyref="elements-dita"/>, <xref keyref="elements-entry"/>, <xref keyref="elements-title"/></sli>
   <sli><xmlatt>subjectrefs</xmlatt>: <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
   <sli><xmlatt>tabindex</xmlatt>: <xref keyref="elements-audio"/>, <xref keyref="elements-object"/>, <xref keyref="elements-video"/></sli>
   <sli><xmlatt>time</xmlatt>: <xref keyref="elements-draft-comment"/></sli>
@@ -124,7 +124,7 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>toc</xmlatt>: <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectHead"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/></sli>
   <sli><xmlatt>top</xmlatt>: <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>trademark</xmlatt>: <xref keyref="elements-tm"/></sli>
-  <sli><xmlatt>translate</xmlatt>: All elements except <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>translate</xmlatt>: All elements except <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>translate-content</xmlatt>: <xref keyref="elements-othermeta"/></sli>
   <sli><xmlatt>type</xmlatt>: <xref keyref="elements-audience"/>, <xref keyref="elements-author"/>, <xref keyref="elements-copyright"/>, <xref keyref="elements-data"/>, <xref keyref="elements-defaultSubject"/>, <xref keyref="elements-hazardstatement"/>, <xref keyref="elements-keydef"/>, <xref keyref="elements-link"/>, <xref keyref="elements-linklist"/>, <xref keyref="elements-linkpool"/>, <xref keyref="elements-longdescref"/>, <xref keyref="elements-map"/>, <xref keyref="elements-mapref"/>, <xref keyref="elements-mapresources"/>, <xref keyref="elements-note"/>, <xref keyref="elements-object"/>, <xref keyref="elements-publisher"/>, <xref keyref="elements-related-links"/>, <xref keyref="elements-relcell"/>, <xref keyref="elements-relcolspec"/>, <xref keyref="elements-reltable"/>, <xref keyref="elements-schemeref"/>, <xref keyref="elements-source"/>, <xref keyref="elements-subjectdef"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topicgroup"/>, <xref keyref="elements-topichead"/>, <xref keyref="elements-topicref"/>, <xref keyref="elements-xref"/></sli>
   <sli><xmlatt>usemap</xmlatt>: <xref keyref="elements-object"/></sli>
@@ -136,7 +136,7 @@ check the element description for details on values and any expected processing.
   <sli><xmlatt>version</xmlatt>: <xref keyref="elements-vrm"/></sli>
   <sli><xmlatt>view</xmlatt>: <xref keyref="elements-permissions"/></sli>
   <sli><xmlatt>width</xmlatt>: <xref keyref="elements-hazardsymbol"/>, <xref keyref="elements-image"/>, <xref keyref="elements-object"/>, <xref keyref="elements-ux-window"/>, <xref keyref="elements-video"/></sli>
-  <sli><xmlatt>xml:lang</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/>)</sli>
+  <sli><xmlatt>xml:lang</xmlatt>: All elements except <xref keyref="elements-attributedef"/>, <xref keyref="elements-elementdef"/>, <xref keyref="elements-enumerationdef"/>, <xref keyref="elements-ux-window"/></sli>
   <sli><xmlatt>xml:space</xmlatt>: <xref keyref="elements-lines"/>, <xref keyref="elements-pre"/></sli>
   <sli><xmlatt>xmlns:ditaarch</xmlatt>: <xref keyref="elements-dita"/>, <xref keyref="elements-map"/>, <xref keyref="elements-subjectScheme"/>, <xref keyref="elements-topic"/></sli>
   <sli><xmlatt>year</xmlatt>: <xref keyref="elements-copyryear"/></sli>


### PR DESCRIPTION
* Fix 3 typos in the script that generates the attribute list
* Update `.gitignore` to ignore the generated copy, only use the actual copy
* Regenerate the attribute topic