### PR TITLE
Fix examples and fix CI

### DIFF
--- a/.github/resources/extract-codeblock/xsl/extract.xsl
+++ b/.github/resources/extract-codeblock/xsl/extract.xsl
@@ -135,9 +135,16 @@
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[map | topicmeta | topicref | keydef | topicsubject | topicgroup | mapref]" mode="serialize">
+  <xsl:template match="fragment[map | topicmeta | topicref | keydef | topicsubject | topicgroup | mapref | reltable]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Base Map//EN"
       doctype-system="map.dtd">
+      <xsl:apply-templates select="." mode="copy"/>
+    </xsl:result-document>
+  </xsl:template>
+
+  <xsl:template match="fragment[bookmap | booklists | frontmatter | bookmeta | backmatter | bookrights]" mode="serialize">
+    <xsl:result-document href="{x:createFileName(., '.dita')}"
+      doctype-public="-//OASIS//DTD DITA 2.0 BookMap//EN" doctype-system="bookmap.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>

--- a/.github/src/test/java/CodeblockTest.java
+++ b/.github/src/test/java/CodeblockTest.java
@@ -18,6 +18,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -82,8 +83,20 @@ public class CodeblockTest {
             DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
             final Resolver resolver = new Resolver(config);
             documentBuilder.setEntityResolver(resolver);
-            final Document doc = documentBuilder.parse(file.toFile());
-            fail("Failed to parse " + getLocation(doc) + ": " + e.getMessage());
+            String location;
+            try {
+                final Document doc = documentBuilder.parse(file.toFile());
+                location = getLocation(doc);
+            } catch (SAXException locationException) {
+                e.addSuppressed(locationException);
+                location = getLocation(file);
+                fail("Failed to parse " + location + ": " + e.getMessage()
+                        + "\n\nFailed to parse generated file while determining source location: "
+                        + locationException.getMessage()
+                        + "\n\nGenerated file content:\n"
+                        + getContent(file));
+            }
+            fail("Failed to parse " + location + ": " + e.getMessage());
         }
     }
 
@@ -138,5 +151,48 @@ public class CodeblockTest {
             }
         }
         return buf.toString();
+    }
+
+    private String getLocation(Path file) throws IOException {
+        final String content = getContent(file);
+        final StringBuilder buf = new StringBuilder();
+        final String xtrf = getProcessingInstruction(content, "xtrf");
+        if (xtrf != null) {
+            final URI root = Paths.get(System.getProperty("root")).toAbsolutePath().normalize().toUri();
+            final URI nodeValue = Paths.get(URI.create(xtrf)).toAbsolutePath().normalize().toUri();
+            final URI path = root.relativize(nodeValue);
+            buf.append("https://github.com/");
+            buf.append(System.getProperty("repository"));
+            buf.append("/blob/");
+            buf.append(System.getProperty("sha"));
+            buf.append("/");
+            buf.append(path);
+        } else {
+            buf.append(file);
+        }
+        final String xtrc = getProcessingInstruction(content, "xtrc");
+        if (xtrc != null) {
+            buf.append("#L");
+            buf.append(xtrc, xtrc.indexOf(";") + 1, xtrc.lastIndexOf(":"));
+        }
+        return buf.toString();
+    }
+
+    private String getContent(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+
+    private String getProcessingInstruction(final String content, final String name) {
+        final String start = "<?" + name;
+        final int startIndex = content.indexOf(start);
+        if (startIndex == -1) {
+            return null;
+        }
+        final int valueStartIndex = startIndex + start.length();
+        final int endIndex = content.indexOf("?>", valueStartIndex);
+        if (endIndex == -1) {
+            return null;
+        }
+        return content.substring(valueStartIndex, endIndex).trim();
     }
 }

--- a/specification/archSpec/base/adding-an-existing-domain-attribute-to-certain-elements-rng.dita
+++ b/specification/archSpec/base/adding-an-existing-domain-attribute-to-certain-elements-rng.dita
@@ -74,7 +74,7 @@
   &lt;div>
     &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
     <b><line-through>&lt;include href="urn:pubid:oasis:names:tc:dita:rng:topicMod.rng:2.x"/></line-through></b>
-    ...
+    &lt;!-- ... -->
     &lt;include href="urn:pubid:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0">
     &lt;/include>
   &lt;/div></codeblock>
@@ -85,7 +85,7 @@
           pattern:</p>
         <codeblock base="ci-xml">  &lt;div>
     &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
-      ...
+    &lt;!-- ... -->
     &lt;include href="urn:pubid:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0">
       <b>&lt;define name="props-attribute-extensions" combine="interleave">
       &lt;empty/>

--- a/specification/archSpec/base/adding-an-existing-domain-attribute-to-certain-elements.dita
+++ b/specification/archSpec/base/adding-an-existing-domain-attribute-to-certain-elements.dita
@@ -39,13 +39,12 @@
       </li>
       <li>They then update the <filepath>catalog.xml</filepath> file to
         include the expansion module.</li>
-      <li>They integrate the extension module into the applicable
-        document-type shell, <b>after</b> the declaration for the
-          <xmlatt>otherprops</xmlatt> attribute-specialization
+      <li>They integrate the extension module into the applicable document-type shell, <b>after</b>
+        the declaration for the <xmlatt>otherprops</xmlatt> attribute-specialization
         module:<codeblock base="ci-xml">&lt;!-- ============================================================= -->
 &lt;!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 &lt;!-- ============================================================= -->
-...
+&lt;!-- ... -->
 
 &lt;!ENTITY % otherpropsAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
@@ -57,7 +56,8 @@
          "acme-otherpropsAttExpansion.mod"
   >%otherprops-expansion-e-def;</b>
 
-...</codeblock></li>
+&lt;!-- ... -->
+</codeblock></li>
       <li>
         <p>They remove the reference to the <xmlatt>otherprops</xmlatt>
           attribute from the <codeph>props-attribute-extension</codeph>

--- a/specification/archSpec/base/alternative-titles.dita
+++ b/specification/archSpec/base/alternative-titles.dita
@@ -8,21 +8,21 @@
     <conbody>
     <section>
       <title>Custom title roles</title>
-      <p>A content architect could create a Topic specialization with
-        custom <xmlelement>titlealt</xmlelement> specializations called
-          <xmlelement>windowtitle</xmlelement> and
-          <xmlelement>breadcrumbtitle</xmlelement>. These specializations
-        specify default <xmlatt>title-role</xmlatt> values of
-          <codeph>window</codeph> and <codeph>breadcrumb</codeph>,
-        respectively, so that authors do not have to specify those roles
-        explicitly. Content containing these specializations could look
+      <p>A content architect could create a Topic specialization with custom
+          <xmlelement>titlealt</xmlelement> specializations called
+          <xmlelement>windowtitle</xmlelement> and <xmlelement>breadcrumbtitle</xmlelement>. These
+        specializations specify default <xmlatt>title-role</xmlatt> values of
+          <codeph>window</codeph> and <codeph>breadcrumb</codeph>, respectively, so that authors do
+        not have to specify those roles explicitly. Content using these specializations could look
         like the following.</p>
       <codeblock base="ci-xml">&lt;helpTopic id="topic167">
   &lt;title>Doing the Thing in the Place where the Stuff Is&lt;/title>
   &lt;prolog>
     &lt;windowtitle>Doing Things&lt;/windowtitle>
     &lt;breadcrumbtitle>Things&lt;/breadcrumbtitle>
-  &lt;/prolog></codeblock>
+  &lt;/prolog>
+  &lt;!-- ... -->
+&lt;/helpTopic></codeblock>
       <p>They could also incorporate these elements into their map document
         type shell, enabling map authors to override the values in
         topics.</p>
@@ -108,7 +108,7 @@
   &lt;topicmeta>
     &lt;titlealt title-role="breadcrumbTitle">Doin' Stuff&lt;/titlealt>
     &lt;titlealt title-role="longTitle">That thing you do when there's stuff that needs doing.&lt;/titlealt>
-  &lt;/topicmeta.
+  &lt;/topicmeta>
 &lt;/topicref></codeblock>
       <p>The referenced topic has the following prolog:</p>
       <codeblock>&lt;prolog>

--- a/specification/archSpec/base/dtd-coding-element-types.dita
+++ b/specification/archSpec/base/dtd-coding-element-types.dita
@@ -161,7 +161,7 @@
 
 &lt;!ENTITY % topichead      "topichead"                                   >
 
-...
+&lt;!-- ... -->
 
 &lt;!-- ============================================================= -->
 &lt;!--                    ELEMENT DECLARATIONS                       -->
@@ -184,13 +184,13 @@
 &lt;!ELEMENT  topichead %topichead.content;>
 &lt;!ATTLIST  topichead %topichead.attributes;>
 
-...
+&lt;!-- ... -->
 
 &lt;!-- ============================================================= -->
 &lt;!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 &lt;!-- ============================================================= -->
   
-...
+&lt;!-- ... -->
 
 &lt;!ATTLIST  topichead      class CDATA "+ map/topicref mapgroup-d/topichead ">
 

--- a/specification/archSpec/base/dtd-coding-structural-modules.dita
+++ b/specification/archSpec/base/dtd-coding-structural-modules.dita
@@ -37,11 +37,11 @@
 &lt;!--                    ELEMENT DECLARATIONS                       -->
 &lt;!-- ============================================================= -->
 
-...
+&lt;!-- ... -->
 
 &lt;!--                    LONG NAME: Concept                         -->
 
-...
+&lt;!-- ... -->
 
 &lt;!ATTLIST concept    
   %concept.attributes;

--- a/specification/archSpec/base/example-chunk-ignored.dita
+++ b/specification/archSpec/base/example-chunk-ignored.dita
@@ -35,7 +35,8 @@ specified on a grouping element.</shortdesc>
     &lt;!-- Any @chunk within submap.ditamap is ignored -->
     &lt;topicref href="submap.ditamap" format="ditamap"/>
   &lt;/topicref>
-</codeblock>
+
+&lt;/map></codeblock>
     </fig>
     <fig>
       <title>Ignoring <xmlatt>chunk</xmlatt> on a grouping element</title>

--- a/specification/archSpec/base/example-chunk-split.dita
+++ b/specification/archSpec/base/example-chunk-split.dita
@@ -26,11 +26,9 @@
       <p rev="review-h">This example covers the scenario of splitting a
         single topic document that is referenced in a DITA map.</p>
       <fig id="fig_gqp_nqd_1gb">
-        <title rev="review-h">Root map and the topic documents that it
-          references</title>
-        <p>Consider the following DITA map, <ph rev="review-h">which
-            references </ph> generated topics that document the messages
-            <ph rev="review-h">that are</ph> produced by an
+        <title rev="review-h">Root map and the topic documents that it references</title>
+        <p>Consider the following DITA map, <ph rev="review-h">which references </ph> generated
+          topics that document the messages <ph rev="review-h">that are</ph> produced by an
           application:</p>
         <codeblock>&lt;map>
   &lt;title>Message guide&lt;/title>
@@ -40,15 +38,14 @@
     &lt;topicref href="messages-other.dita"/>
   &lt;/topicref>
 &lt;/map></codeblock>
-        <p rev="review-h">The following code samples show the contents of
-          the four topic documents: <filepath>about.dita</filepath>,
-            <filepath>messages-install.dita</filepath>,
+        <p rev="review-h">The following code samples show the contents of the four topic documents:
+            <filepath>about.dita</filepath>, <filepath>messages-install.dita</filepath>,
             <filepath>messages-run.dita</filepath>, and
-            <filepath>messages-other.dita</filepath>.</p>
+          <filepath>messages-other.dita</filepath>.</p>
         <codeblock><b>&lt;!-- about.dita --></b>
 &lt;topic id="about">
   &lt;title>About this guide&lt;/title>
-  &lt;shortdesc>Warnings or errors are displayed when ... &lt;shortdesc>
+  &lt;shortdesc>Warnings or errors are displayed when ... &lt;/shortdesc>
 &lt;/topic></codeblock>
         <codeblock><b>&lt;!-- messages-install.dita --></b>
 &lt;dita>
@@ -58,7 +55,7 @@
   &lt;/topic>
   &lt;!-- More topics that document installation messages ... -->
 &lt;/dita></codeblock>
-        <codeblock><b>&lt;! messages-run.dita --></b>
+        <codeblock><b>&lt;!-- messages-run.dita --></b>
 &lt;dita>
   &lt;topic id="RUN001">
     &lt;title>RUN001: Failed to initialize&lt;/title>
@@ -83,11 +80,10 @@
     &lt;!-- Explanation and recovery steps ... -->
   &lt;/topic>
 &lt;/topic></codeblock>
-        <p><ph rev="review-h">When processed</ph> to HTML5, this map might
-          result in four result documents: <filepath>about.html</filepath>,
-            <filepath>messages-install.html</filepath>,
+        <p><ph rev="review-h">When processed</ph> to HTML5, this map might result in four result
+          documents: <filepath>about.html</filepath>, <filepath>messages-install.html</filepath>,
             <filepath>messages-run.html</filepath>, and
-            <filepath>messages-other.html</filepath>.</p>
+          <filepath>messages-other.html</filepath>.</p>
       </fig>
       <fig id="fig_ltd_yrd_1gb">
         <title rev="review-h">Splitting topics in one topic

--- a/specification/archSpec/base/example-conref-conaction-replace.dita
+++ b/specification/archSpec/base/example-conref-conaction-replace.dita
@@ -28,8 +28,7 @@
         conref="example.dita#example/b">
     &lt;cmd>Updated B&lt;/cmd>
   &lt;/step>
-&lt;/steps>
-&lt;/task></codeblock></p>
+&lt;/steps></codeblock></p>
     <p>The result will be an updated version of <filepath>example.dita</filepath> which contains the
       pushed <xmlelement>step</xmlelement>:<codeblock>&lt;task id="example" xml:lang="en">
   &lt;title>Example topic&lt;/title>

--- a/specification/archSpec/base/example-constrain-a-domain-using-rng.dita
+++ b/specification/archSpec/base/example-constrain-a-domain-using-rng.dita
@@ -42,7 +42,7 @@
             rev="2.0">they do</ph> not want the implementation to use:</p>
         <codeblock>&lt;div>
   &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
-  ...
+  &lt;!-- ... -->
   &lt;include href="highlightDomain.rng">
     &lt;define name="line-through.element">
       &lt;notAllowed/>
@@ -63,7 +63,7 @@
       &lt;notAllowed/>
     &lt;/define>
   &lt;/include>
-  ..  
+  &lt;!-- ... -->
 &lt;/div></codeblock>
         <note>The <ph rev="2.0">DITA</ph> architect made a choice as to
           where in the document-type shell <ph rev="2.0">they</ph> would

--- a/specification/archSpec/base/example-fallback-information-for-multimedia.dita
+++ b/specification/archSpec/base/example-fallback-information-for-multimedia.dita
@@ -19,7 +19,7 @@
       &lt;alt>This video cannot be displayed.&lt;/alt>
     &lt;/image>
   &lt;/fallback></b>
-  &lt;video-poster keyref="demo1-video-poster"
+  &lt;video-poster keyref="demo1-video-poster"/>
   &lt;media-source href="video.mp4" format="video/mp4"/>
 &lt;/video></codeblock>
     </conbody>

--- a/specification/archSpec/base/example-rng-constraints-apply-multiple-constraints.dita
+++ b/specification/archSpec/base/example-rng-constraints-apply-multiple-constraints.dita
@@ -115,7 +115,7 @@
               modify</ph> the include statement for the domain module:</p>
           <codeblock base="ci-xml">&lt;div>
   &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
-  ...
+  &lt;!-- ... -->
   &lt;include href="highlightDomain.rng">
     &lt;define name="line-through.element">
       &lt;notAllowed/>
@@ -136,7 +136,7 @@
       &lt;notAllowed/>
     &lt;/define>
   &lt;/include>
-  ..  
+  &lt;!-- ... -->
 &lt;/div></codeblock>
         </li>
         <li>Finally, to disallow <xmlelement>ph</xmlelement>, <ph rev="2.0"

--- a/specification/archSpec/base/example-rng-constraints-replace-base-element-w-domain-extensions.dita
+++ b/specification/archSpec/base/example-rng-constraints-replace-base-element-w-domain-extensions.dita
@@ -32,9 +32,9 @@
   &lt;include href="urn:pubid:oasis:names:tc:dita:rng:topicMod.rng:2.0">
     <b>&lt;define name="ph.element">
       &lt;notAllowed/>
-    &lt;/define>
-</b>  &lt;/include>
-  ...
+    &lt;/define></b>
+  &lt;/include>
+  &lt;!-- ... -->
 &lt;/div></codeblock>
         </li>
         <li><ph rev="2.0">They make</ph> similar changes to all the other

--- a/specification/archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita
+++ b/specification/archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita
@@ -97,7 +97,7 @@
           shell:</p>
         <codeblock>&lt;div>
     &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
-    ...  
+    &lt;!-- ... -->
     <b>&lt;include href="urn:pubid:example:names:tc:dita:rng:cellPurposeAtt.rng:2.0"/></b>
   &lt;/div></codeblock>
       </li>

--- a/specification/archSpec/base/rng-adding-an-element-to-the-section-element.dita
+++ b/specification/archSpec/base/rng-adding-an-element-to-the-section-element.dita
@@ -93,7 +93,7 @@
             domain module:</p>
           <codeblock>  &lt;div>
     &lt;a:documentation>MODULE INCLUSIONS&lt;/a:documentation>
-    ...
+    &lt;!-- ... -->
     <b>&lt;include href="urn:pubid:example:names:tc:dita:rng:sectionDescDomain.rng:2.0"/></b>
   &lt;/div></codeblock>
           <p>At this point, the new domain is integrated into the
@@ -151,7 +151,7 @@
         &lt;ref name="topic.element"/>
       &lt;/define>
     &lt;/include></line-through>
-    ... 
+    &lt;!-- ... -->
     &lt;include href="urn:pubid:example:names:tc:dita:rng:sectionDescDomain.rng:2.0"/>
   &lt;/div></codeblock>
         </li>

--- a/specification/dita-2.0-specification-subjectScheme.ditamap
+++ b/specification/dita-2.0-specification-subjectScheme.ditamap
@@ -7,6 +7,7 @@
   <subjectdef keys="values-base">
     <subjectdef keys="ci-xml"/>
     <subjectdef keys="ci-skip"/>
+    <subjectdef keys="ci-generaltask"/>
   </subjectdef>
   <subjectdef keys="values-audience-draft-comment">
     <subjectdef keys="spec-editors"/>

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -93,7 +93,7 @@
   &lt;p>The following table explains the symbols that are used to indicate the price
      categories of the lodging options:&lt;/p>
   &lt;simpletable>
-    &lt;! -- ... -->
+    &lt;!-- ... -->
   &lt;/simpletable>
 <b>&lt;/abstract></b></codeblock>
       </fig>

--- a/specification/langRef/base/abstract.dita
+++ b/specification/langRef/base/abstract.dita
@@ -93,7 +93,10 @@
   &lt;p>The following table explains the symbols that are used to indicate the price
      categories of the lodging options:&lt;/p>
   &lt;simpletable>
-    &lt;!-- ... -->
+    &lt;strow>
+      &lt;stentry> &lt;!-- ... --> &lt;/stentry>
+      &lt;stentry> &lt;!-- ... --> &lt;/stentry>
+    &lt;/strow>
   &lt;/simpletable>
 <b>&lt;/abstract></b></codeblock>
       </fig>

--- a/specification/langRef/base/fn.dita
+++ b/specification/langRef/base/fn.dita
@@ -104,11 +104,11 @@ with error correcting support.&lt;/p></codeblock>
       <b>&lt;fn conref="footnotes.dita#footnotes/DQTI" id="dqti"/></b>
     &lt;/bodydiv>
     &lt;!-- ... -->
-    &lt;p>See the online resource<b>&lt;xref="#./dqti" type="fn"/></b> for more 
-       information about how to assess the quality of technical documentation./p>
+    &lt;p>See the online resource<b>&lt;xref href="#./dqti" type="fn"/></b> for more 
+       information about how to assess the quality of technical documentation.&lt;/p>
     &lt;!-- ... -->
   &lt;/body>
-&lt;topic></codeblock>
+&lt;/topic></codeblock>
       </fig>
     </example>
 </refbody>

--- a/specification/langRef/base/foreign.dita
+++ b/specification/langRef/base/foreign.dita
@@ -72,7 +72,7 @@
         definitions for the SVG elements.</p><codeblock>&lt;p&gt;... as in the formula 
   <b>&lt;svg&gt;</b>
     &lt;svg:svg width="100%" height="100%" version="1.1"
-xmlns:svg="http://www.w3.org/2000/svg"&gt;
+xmlns="http://www.w3.org/2000/svg"&gt;
 
 &lt;ellipse cx="300" cy="150" rx="200" ry="80"
 style="fill:rgb(200,100,50);

--- a/specification/langRef/base/foreign.dita
+++ b/specification/langRef/base/foreign.dita
@@ -4,7 +4,6 @@
 <title><xmlelement>foreign</xmlelement></title>
   <shortdesc>Foreign content is non-DITA content, such as MathML, SVG, or Rich Text Format
     (RTF).</shortdesc>
-  <!--<shortdesc>The <xmlelement>foreign</xmlelement> element enables the inclusion of non-DITA content, such as MathML, SVG, or Rich Text Format (RTF).</shortdesc>-->
 <prolog><metadata>
 <keywords>
         <indexterm>specialization
@@ -73,7 +72,7 @@
         definitions for the SVG elements.</p><codeblock>&lt;p&gt;... as in the formula 
   <b>&lt;svg&gt;</b>
     &lt;svg:svg width="100%" height="100%" version="1.1"
-xmlns="http://www.w3.org/2000/svg"&gt;
+xmlns:svg="http://www.w3.org/2000/svg"&gt;
 
 &lt;ellipse cx="300" cy="150" rx="200" ry="80"
 style="fill:rgb(200,100,50);

--- a/specification/langRef/base/linktitle.dita
+++ b/specification/langRef/base/linktitle.dita
@@ -87,7 +87,8 @@
   &lt;prolog>
     &lt;linktitle>Drive train circuitry&lt;/linktitle>
   &lt;/prolog>
-</codeblock>
+  &lt;!-- ... -->
+&lt;/topic></codeblock>
       </fig>
       <p>Note that this link title might be overridden by a link title that
         is specified in a DITA map that references the topic.</p>

--- a/specification/langRef/base/mapresources.dita
+++ b/specification/langRef/base/mapresources.dita
@@ -53,7 +53,7 @@
   &lt;mapresources>
     &lt;mapref href="key-definitions.ditamap"/>
     &lt;mapref href="subject-scheme.ditamap" type="subjectscheme"/>
-    &lt;topicref href="cover-page.dita outputclass="cover-page"/>
+    &lt;topicref href="cover-page.dita" outputclass="cover-page"/>
   &lt;/mapresources></b>
   &lt;!-- ... -->
 &lt;/bookmap></codeblock>
@@ -73,10 +73,10 @@
     &lt;keydef keys="model-illustration" href="model-XNP09.png" format="png"/>
     &lt;keydef keys="remove-cover" href="remove-cover-XNP09.png" format="png"/>
   &lt;/mapresources></b>
-  &lt;topicref href="model-overview.dita/>
+  &lt;topicref href="model-overview.dita"/>
   &lt;topicref href="installing.dita"/>
-  &lt;topicref href="uninstalling.dita/>
-  ...
+  &lt;topicref href="uninstalling.dita"/>
+  &lt;!-- ... -->
 &lt;/map></codeblock>
           </fig>
         </example>

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -106,7 +106,7 @@
         data="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776
               %2C0.00030577182769775396
               %2C51.478569861898606
-              &amp;layer=mapnik"
+              &amp;amp;layer=mapnik"
         width="800"
         height="600"
         id="map-uk-greenwich"
@@ -116,7 +116,7 @@
        href="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776
               %2C0.00030577182769775396
               %2C51.478569861898606
-              &amp;layer=mapnik"
+              &amp;amp;layer=mapnik"
     />&lt;/fallback><b>
 &lt;/object&gt;</b></codeblock>
         <p>The above code might generate the following HTML:</p>
@@ -130,11 +130,10 @@
     &lt;iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776
       %2C0.00030577182769775396
       %2C51.478569861898606
-      &amp;layer=mapnik"       
+      &amp;amp;layer=mapnik"       
       >Street map&lt;/iframe>
   &lt;/body>
 &lt;/html></codeblock>
-        <p/>
       </fig>
             <fig id="fig_o2l_bfb_4k">
                 <title>Object with reference to video using key reference on the

--- a/specification/langRef/base/object.dita
+++ b/specification/langRef/base/object.dita
@@ -102,7 +102,7 @@
           web page in an inline frame. It assumes that the processing
           engine uses the <codeph>outputclass="iframe"</codeph>
           directive.</p>
-        <codeblock><b>&lt;object type="text/html"</b>
+        <codeblock base="ci-skip"><b>&lt;object type="text/html"</b>
         data="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776
               %2C0.00030577182769775396
               %2C51.478569861898606
@@ -120,7 +120,7 @@
     />&lt;/fallback><b>
 &lt;/object&gt;</b></codeblock>
         <p>The above code might generate the following HTML:</p>
-        <codeblock>&lt;!DOCTYPE html>
+        <codeblock base="ci-skip">&lt;!DOCTYPE html>
 &lt;html>
   &lt;head>
     &lt;title>Test of Iframe&lt;/title>

--- a/specification/langRef/base/ph.dita
+++ b/specification/langRef/base/ph.dita
@@ -12,8 +12,8 @@
             <section conkeyref="reuse-ph/usage-information" id="usage-information"><title/><p/></section>
       <section conkeyref="reuse-ph/attributes" id="attributes"/>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows <xmlelement>ph</xmlelement> elements that are used for
-                        conditional processing:</p><codeblock>&lt;p&gt;The Style menu is the <b>&lt;ph product="Software1000"/&gt;third item&lt;/ph&gt;
-&lt;ph product="Software9000"/&gt;fourth item&lt;/ph&gt;</b> from the left on the menu bar.&lt;/p&gt;
+                        conditional processing:</p><codeblock>&lt;p&gt;The Style menu is the <b>&lt;ph product="Software1000">third item&lt;/ph&gt;
+&lt;ph product="Software9000"&gt;fourth item&lt;/ph&gt;</b> from the left on the menu bar.&lt;/p&gt;
 </codeblock></example>
 </refbody>
 </reference>

--- a/specification/langRef/base/relcolspec.dita
+++ b/specification/langRef/base/relcolspec.dita
@@ -141,7 +141,7 @@
   &lt;/relheader>
   &lt;relrow>
     &lt;relcell>
-      &lt;topicref href="debug_login.dita"/>
+      &lt;topicref href="debug_login.dita">
         &lt;topicmeta>&lt;linktitle>Debugging login errors&lt;/linktitle>&lt;/topicmeta>
       &lt;/topicref>
     &lt;/relcell>

--- a/specification/langRef/base/sort-as.dita
+++ b/specification/langRef/base/sort-as.dita
@@ -135,7 +135,7 @@
             <xmlelement>glossterm</xmlelement> element:</p>
         <codeblock>&lt;glossentry id="gloss-dada">
   &lt;glossterm>
-    <b>&lt;sort-as value="dada"/</b>>
+    <b>&lt;sort-as value="dada"/></b>
     &amp;#x5927;&amp;#x5927;
   &lt;/glossterm>
   &lt;glossdef>Literally "big big".&lt;/glossdef>

--- a/specification/langRef/base/subjectHead.dita
+++ b/specification/langRef/base/subjectHead.dita
@@ -63,7 +63,7 @@
         &lt;/subjectHeadMeta>
         &lt;subjectdef keys="knitting" href="knitting.dita"/>
         &lt;subjectdef keys="quilting" href="quilting.dita"/>
-        &lt;subjectdef keys="sewing" href="sewing.dita/>
+        &lt;subjectdef keys="sewing" href="sewing.dita"/>
       &lt;/subjectHead>
     &lt;/subjectdef>
     &lt;subjectdef keys="woodworking">

--- a/specification/langRef/base/subtitle.dita
+++ b/specification/langRef/base/subtitle.dita
@@ -66,6 +66,8 @@
   &lt;prolog>
     &lt;subtitle>An introduction to the Acme Inc. processing system&lt;/subtitle>
   &lt;/prolog>
+  &lt;!-- ... -->
+&lt;/topic>
 </codeblock>
       </fig>
     </example>

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -172,8 +172,9 @@
           the following markup would be equivalent:</p>
         <codeblock rev="review-a">&lt;topicref keys="about" href="about.dita">
   &lt;topicmeta>
-    &lt;linktitle>About the product&lt;/navtitle>
-    &lt;searchtitle">About&lt;/searchtitle>
+    &lt;linktitle>About the product&lt;/linktitle>
+    &lt;navtitle>About the product&lt;/navtitle>
+    &lt;searchtitle>About&lt;/searchtitle>
     &lt;titlehint>About the Acme TextMax 5000&lt;/titlehint>
   &lt;/topicmeta>
 &lt;/topicref></codeblock>

--- a/specification/langRef/base/xref.dita
+++ b/specification/langRef/base/xref.dita
@@ -35,7 +35,7 @@ list of DITA features is available in the DITA specification
         <p>The following code sample shows a cross reference to a web
           page:</p>
         <codeblock>&lt;xref href="https://www.example.com/docview.wss?rs=757"
-scope="external" format="html"&gt;Part number SSVNX5/></codeblock>
+scope="external" format="html"&gt;Part number SSVNX5&lt;/xref></codeblock>
       </fig>
           </example>
 </refbody>

--- a/specification/langRef/ditaval/alt-text.dita
+++ b/specification/langRef/ditaval/alt-text.dita
@@ -38,6 +38,7 @@
     &lt;startflag imageref="expert-icon.gif">
       <b>&lt;alt-text>Expert&lt;/alt-text></b>
     &lt;/startflag>
+  &lt;/prop>
 &lt;/val></codeblock></example>
 </refbody>
 </reference>

--- a/specification/langRef/ditaval/revprop.dita
+++ b/specification/langRef/ditaval/revprop.dita
@@ -126,10 +126,10 @@
         the flagged revision. Alternate text is provided.</p>
       <codeblock>&lt;val>
   &lt;revprop action="flag" color="red" val="edits">
-    &lt;startflag imageref="start-glyph.png>
+    &lt;startflag imageref="start-glyph.png">
       &lt;alt-text>Start of revision&lt;/alt-text>
     &lt;/startflag>
-    &lt;endflag imageref="end-glyph.png>
+    &lt;endflag imageref="end-glyph.png">
       &lt;alt-text>End of revision&lt;/alt-text>
     &lt;/endflag>
   &lt;/revprop>


### PR DESCRIPTION
1. Minor update to subject scheme, to add the token used in tech-comm examples for CI validation
2. Many fixes to bad XML in code samples
3. Ensure ellipses `...` are commented out in DTD and RNG examples