### PR TITLE
Move resources to new mapresources element

### DIFF
--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -32,7 +32,7 @@
       </bookowner>
     </bookrights>
   </bookmeta>
-  <frontmatter>
+  <mapresources>
     <mapref href="dita-2.0-specification-subjectScheme.ditamap"
       type="subjectScheme"/>
     <mapref href="dita-2.0-key-definitions-cover-pages.ditamap"
@@ -46,6 +46,8 @@
     <mapref href="common/key-definitions-complex-attributes.ditamap"
       processing-role="resource-only"/>
     <mapref href="base-relationship-tables.ditamap"/>
+  </mapresources>
+  <frontmatter>
     <notices platform="dita-tc-publishing">
       <topicref href="resources/oasis-cover.dita" linking="none" toc="no"/>
       <topicref href="resources/oasis-notices.dita" linking="none" toc="no"


### PR DESCRIPTION
DITA 2.0 created `mapresources` as a container for things like key definitions, particularly in book maps where these resources did not have a good logical home in DITA 1.x

Now that we're using the 2.0 bookmap, we should move the subject scheme and key definitions into this new element