### PR TITLE
Update table header topics with usage info

### DIFF
--- a/specification/archSpec/key-definitions-archspec-topics.ditamap
+++ b/specification/archSpec/key-definitions-archspec-topics.ditamap
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 2.x Map//EN" "map.dtd">
+<map>
+    <title>Key definitions for architectural spec topics</title>
+    <!--This map is used to set up keys for topics in the architectural spec that are used as general link targets.-->
+    <topicref href="base/accessibletablemarkup.dita" keys="accessibility-tables"/>
+</map>

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -270,6 +270,10 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
         plus <keyword>Att</keyword>. For example, for the attribute named
           <xmlatt>deliveryTarget</xmlatt>, the attribute-domain name is "deliveryTargetAtt". The
         attribute-domain name is used to construct entity names for the domain. </p>
+      <p id="table-header-usage">In addition to providing a visual header, the cells within a table
+        header are an important accessibility aid that allow table navigation using assistive
+        technology. See <xref keyref="accessibility-tables"/> for more information about creating
+        accessible tables.</p>
                 </section>
 
                 <section id="section-7">

--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -45,6 +45,7 @@
       href="langRef/attributes/key-definitions-ditaref-attributes.ditamap"/>
     <mapref href="common/key-definitions-complex-attributes.ditamap"
       processing-role="resource-only"/>
+    <mapref href="archSpec/key-definitions-archspec-topics.ditamap" processing-role="resource-only"/>
     <mapref href="base-relationship-tables.ditamap"/>
   </mapresources>
   <frontmatter>

--- a/specification/langRef/base/sthead.dita
+++ b/specification/langRef/base/sthead.dita
@@ -5,11 +5,7 @@
         <indexterm>tables<indexterm>simple<indexterm>headers</indexterm></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <draft-comment author="Kristen J Eberlein" time="21 December 2021">
-        <p>This topic needs to mention the role that table headers play in
-          ensuring that content is accessible. It should link to the new
-          material (not yet developed) about accessibility.</p>
-      </draft-comment>
+      <p conkeyref="reuse-general/table-header-usage"/>
     </section>
     <section conkeyref="reuse-sthead/attributes" id="attributes"/>
     <example id="example" otherprops="examples">

--- a/specification/langRef/base/thead.dita
+++ b/specification/langRef/base/thead.dita
@@ -9,11 +9,7 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <draft-comment author="Kristen J Eberlein" time="21 December 2021">
-        <p>This topic needs to mention the role that table headers play in
-          ensuring that content is accessible. It should link to the new
-          material (not yet developed) about accessibility.</p>
-      </draft-comment>
+      <p conkeyref="reuse-general/table-header-usage"/>
     </section>
     <section id="attributes">
       <title>Attributes</title>


### PR DESCRIPTION
The `thead` and `sthead` elements both had empty Usage Info sections with a draft comment about material to be filled in (including a link to accessibility content)

This PR
1. Sets up a key map for architectural spec, and adds a key for the table accessibility topic
2. Adds reusable usage info that works for both elements, and reference that info
3. The usage info includes a key reference to the accessibility topic
4. Draft comments about this info are removed