### PR TITLE
Consolidate all key definitions in one map

### DIFF
--- a/specification/dita-2.0-specification-all-key-definitions.ditamap
+++ b/specification/dita-2.0-specification-all-key-definitions.ditamap
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 2.x Map//EN" "map.dtd">
+<map>
+    <title>All key definitions for base specification</title>
+    <mapref href="dita-2.0-key-definitions-cover-pages.ditamap"
+        processing-role="resource-only"/>
+    <mapref href="common/key-definitions-oasis-boilerplate.ditamap"/>
+    <mapref href="common/key-definitions-library-topics.ditamap"/>
+    <mapref href="langRef/key-definitions-base-elements.ditamap"/>
+    <mapref href="common/key-definitions-reuse-w-lwdita.ditamap"/>
+    <mapref
+        href="langRef/attributes/key-definitions-ditaref-attributes.ditamap"/>
+    <mapref href="common/key-definitions-complex-attributes.ditamap"
+        processing-role="resource-only"/>
+    <mapref href="archSpec/key-definitions-archspec-topics.ditamap" processing-role="resource-only"/>
+</map>

--- a/specification/dita-2.0-specification.ditamap
+++ b/specification/dita-2.0-specification.ditamap
@@ -33,19 +33,8 @@
     </bookrights>
   </bookmeta>
   <mapresources>
-    <mapref href="dita-2.0-specification-subjectScheme.ditamap"
-      type="subjectScheme"/>
-    <mapref href="dita-2.0-key-definitions-cover-pages.ditamap"
-      processing-role="resource-only"/>
-    <mapref href="common/key-definitions-oasis-boilerplate.ditamap"/>
-    <mapref href="common/key-definitions-library-topics.ditamap"/>
-    <mapref href="langRef/key-definitions-base-elements.ditamap"/>
-    <mapref href="common/key-definitions-reuse-w-lwdita.ditamap"/>
-    <mapref
-      href="langRef/attributes/key-definitions-ditaref-attributes.ditamap"/>
-    <mapref href="common/key-definitions-complex-attributes.ditamap"
-      processing-role="resource-only"/>
-    <mapref href="archSpec/key-definitions-archspec-topics.ditamap" processing-role="resource-only"/>
+    <mapref href="dita-2.0-specification-subjectScheme.ditamap" type="subjectScheme"/>
+    <mapref href="dita-2.0-specification-all-key-definitions.ditamap" processing-role="resource-only"/>
     <mapref href="base-relationship-tables.ditamap"/>
   </mapresources>
   <frontmatter>


### PR DESCRIPTION
Couple reasons for this:
1. Other maps reusing the base spec (like the technical-content spec) can safely pull in all keys by reusing the single key map. If we add a new key map for the base spec, those others will not miss them.
2. Tools that process single topics within the context of a key map, can pass in this single key map