### PR TITLE
Clean up xmlatt usage

### DIFF
--- a/specification/archSpec/base/adding-an-attribute-to-certain-table-elements.dita
+++ b/specification/archSpec/base/adding-an-attribute-to-certain-table-elements.dita
@@ -19,9 +19,8 @@
     </metadata>
   </prolog>
   <conbody>
-    <p>The DITA architect decides to create a new attribute
-        (<xmlatt>cell-purpose</xmlatt>) and add it to the attribute lists
-      of the following elements:</p>
+    <p>The DITA architect decides to create a new attribute (<xmlatt>cellPurpose</xmlatt>) and add
+      it to the attribute lists of the following elements:</p>
     <ul>
       <li><xmlelement>colspec</xmlelement></li>
       <li><xmlelement>entry</xmlelement></li>
@@ -39,25 +38,24 @@
       decide the elements to which to apply the attribute.</p>
     <ol>
       <li><!--<draft-comment author="Kristen J Eberlein" time="07 June 2021"><p>Comments by Eliot Kimber: </p><p>[Re the entity to be used in the @specializations attribute]: "Should there be leading and trailing space in the replacement text?"</p><p>[Re adding the attribute to the elements]: "I first thought we shouldn't allow this specialization-and-integration-in-one kind of module but I convinced myself it's OK. However, we still need an example of not doing this, for example, taking an *existing* attribute domain and using a separate extension module to allow it in specific places, omitting the usual global integration."</p></draft-comment>-->First,
-        the DITA architect creates the expansion module for the
-          <xmlatt>cell-purpose</xmlatt> attribute:
+        the DITA architect creates the expansion module for the <xmlatt>cellPurpose</xmlatt>
+        attribute:
           <filepath>acme-cellPurposeAttExpansion.ent</filepath>.<codeblock>&lt;!-- Define the attribute -->
 &lt;!ENTITY % cellPurposeAtt-d-attribute-expansion
-  "cell-purpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
+  "cellPurpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
 &gt;
 
 &lt;!-- Declare the entity to be used in the @specializations attribute -->
-&lt;!ENTITY cellPurposeAtt-d-att "@base/cell-purpose" >
+&lt;!ENTITY cellPurposeAtt-d-att "@base/cellPurpose" >
 
 &lt;!-- Add the attribute to the elements. -->
 &lt;!ATTLIST entry %cellPurposeAtt-d-attribute-expansion;>
 &lt;!ATTLIST row %cellPurposeAtt-d-attribute-expansion;>
 &lt;!ATTLIST colspec %cellPurposeAtt-d-attribute-expansion;>
 &lt;!ATTLIST strow %cellPurposeAtt-d-attribute-expansion;>
-&lt;!ATTLIST stentry %cellPurposeAtt-d-attribute-expansion;></codeblock><note
-          rev="2.0">The attribute definition entity is optional. It is used
-          here to enable the DITA architect to add the same attribute with
-          the same tokens to several elements.</note></li>
+&lt;!ATTLIST stentry %cellPurposeAtt-d-attribute-expansion;></codeblock><note rev="2.0"
+          >The attribute definition entity is optional. It is used here to enable the DITA architect
+          to add the same attribute with the same tokens to several elements.</note></li>
       <li><ph rev="2.0">They then update</ph> the
           <filepath>catalog.xml</filepath> file to include the expansion
         module.<!-- <draft-comment author="Kristen J Eberlein" time="07 June 2021"><p>Comment by Eliot Kimber: "This is something almost everybody *would* do but it's not actually required since the use of catalogs is not required by DITA or by the use of DTDs generally, at least in theory (and in actual fact if you are an Author/Editor user, which doesn't support catalogs)."</p></draft-comment>--></li>

--- a/specification/archSpec/base/dtd-coding-requirements-expansion-modules.dita
+++ b/specification/archSpec/base/dtd-coding-requirements-expansion-modules.dita
@@ -37,7 +37,7 @@
                             <p>For example, the following parameter entity defines a new attribute
                                 intended for use with various table elements:</p>
                             <codeblock>&lt;!ENTITY % cellPurposeAtt-d-attribute-expansion
-  "cell-purpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
+  "cellPurpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
 &gt;</codeblock>
                         </example>
                         <p>Note that the name of the parameter entity ends with

--- a/specification/archSpec/base/dtd-coding-requirements-for-element-configuration-modules.dita
+++ b/specification/archSpec/base/dtd-coding-requirements-for-element-configuration-modules.dita
@@ -39,7 +39,7 @@
                             <p>The following parameter entity defines a new attribute intended for
                                 use with various table elements:</p>
                             <codeblock>&lt;!ENTITY % cellPurposeAtt-d-attribute<b>-expansion</b>
-  "cell-purpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
+  "cellPurpose  (sale | out-of-stock | new | last-chance | inherit | none)  #IMPLIED"
 &gt;</codeblock>
                         </dd>
                     </dlentry>

--- a/specification/archSpec/base/merging-of-cascading-attributes.dita
+++ b/specification/archSpec/base/merging-of-cascading-attributes.dita
@@ -14,10 +14,9 @@
                 <dd/>
             </dlentry>
         </dl>
-    <p>If no value is set for the <xmlatt>merge</xmlatt> attribute and no
-      value cascades from a containing element, processors <term
-        outputclass="RFC-2119">SHOULD</term> assume a default of
-        <keyword>merge</keyword>.</p>
+    <p>If no value is set for the <xmlatt>cascade</xmlatt> attribute and no value cascades from a
+            containing element, processors <term outputclass="RFC-2119">SHOULD</term> assume a
+            default of <keyword>merge</keyword>.</p>
         <p conkeyref="reuse-general/attribute-implementation-tokens">For
       example, a processor might define the token "appToken:audience" in
       order to specify cascading and merging behaviors for <b>only</b> the

--- a/specification/archSpec/base/overview-of-expansion-modules.dita
+++ b/specification/archSpec/base/overview-of-expansion-modules.dita
@@ -48,12 +48,10 @@
           <p>Expansion modules extend the attribute lists of specific
             elements by adding attributes specialized from either
               <xmlatt>base</xmlatt> or <xmlatt>props</xmlatt>.</p>
-          <p otherprops="examples">For example, an expansion for
-              <xmlelement>entry</xmlelement>, <xmlelement>row</xmlelement>,
-            and <xmlelement>colspec</xmlelement> can make
-              <xmlatt>cell-purpose</xmlatt> available only on those
-            elements. The <xmlatt>cell-purpose</xmlatt> attribute is
-            specialized from <xmlatt>base</xmlatt>.</p>
+          <p otherprops="examples">For example, an expansion for <xmlelement>entry</xmlelement>,
+              <xmlelement>row</xmlelement>, and <xmlelement>colspec</xmlelement> can make
+              <xmlatt>cellPurpose</xmlatt> available only on those elements. The
+              <xmlatt>cellPurpose</xmlatt> attribute is specialized from <xmlatt>base</xmlatt>.</p>
           <p>The <ph rev="review-p">additional</ph> attribute can be either
             defined directly within the expansion module, or it can be
             defined in a separate attribute-specialization module. In

--- a/specification/archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita
+++ b/specification/archSpec/base/rng-adding-an-attribute-to-certain-table-elements.dita
@@ -19,9 +19,8 @@
     </metadata>
   </prolog>
   <conbody>
-    <p>The DITA architect decides to create a new attribute
-        (<xmlatt>cell-purpose</xmlatt>) and add it to the content model of
-      the following elements:</p>
+    <p>The DITA architect decides to create a new attribute (<xmlatt>cellPurpose</xmlatt>) and add
+      it to the content model of the following elements:</p>
     <ul>
       <li><xmlelement>entry</xmlelement></li>
       <li><xmlelement>row</xmlelement></li>

--- a/specification/archSpec/base/specialization-specializations-attribute.dita
+++ b/specification/archSpec/base/specialization-specializations-attribute.dita
@@ -49,7 +49,7 @@
         the modules that are included in the document type shell.</p>
     </section>
 <example id="example" otherprops="examples">
-      <title>Example: <xmlatt>specializations attribute for </xmlatt> a task with multiple
+      <title>Example: <xmlatt>specializations</xmlatt> attribute for a task with multiple
         domains</title>
       <p>In this example, a document-type shell integrates the task structural module and the
         following domain modules:</p>

--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -259,8 +259,8 @@
         ><!--This element does not define any attributes.-->None</p>
                         </section>
                 <section id="section-3">
-                        <title>Attributes used on image; most are common to image specializations,
-                                apart from <xmlatt>alt</xmlatt></title>
+                        <title>Attributes used on image; most are common to image
+        specializations</title>
                         <dl>
                                 <dlentry id="image-href" platform="dita">
           <dt id="attr-href"><xmlatt>href</xmlatt></dt>
@@ -425,18 +425,6 @@
         </dlentry>
                         </dl>
                 </section>
-                <section id="section-6"><title>Attributes for specialized relationship tables (drop <xmlatt>title</xmlatt> from base
-                                        <xmlelement>reltable</xmlelement>)</title><div id="reltable-minus-title" platform="dita">
-        <p>The following attributes are available on this element: <ph
-            conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-            conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
-            keyref="attributes-common/attr-type"><xmlatt>type</xmlatt></xref>, <xref
-            keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref
-            keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>.</p>
-        <p id="attr-exception-toc" outputclass="attr-exception">For this
-          element, the <xmlatt>toc</xmlatt> attribute has a default value
-          of <keyword>no</keyword>.</p>
-      </div></section>
                         <section id="section-8" platform="dita">
       <title>DITAVAL related common attributes</title>
       <p rev="review-m" id="ditaval-flagging-attr-intro">The following

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -215,17 +215,14 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
 
                 <section id="section-6">
                         <title>Paragraphs</title>
-                        <p id="attribute-implementation-tokens"
-        >Implementers <term outputclass="RFC-2119">MAY</term> define their
-        own custom, implementation-specific tokens for the
-          <xmlatt>merge</xmlatt> attribute. To avoid name conflicts between
-        implementations or with future additions to the standard,
-        implementation-specific tokens <term outputclass="RFC-2119"
-          >SHOULD</term> consist of a prefix that gives the name or an
-        abbreviation for the implementation followed by a colon followed by
-        the token or method name. For example, a processor might define the
-        token "appToken:audience" in order to specify cascading and merging
-        behaviors for <b>only</b> the <xmlatt>audience</xmlatt>
+                        <p id="attribute-implementation-tokens">Implementers <term
+          outputclass="RFC-2119">MAY</term> define their own custom, implementation-specific tokens
+        for the <xmlatt>cascade</xmlatt> attribute. To avoid name conflicts between implementations
+        or with future additions to the standard, implementation-specific tokens <term
+          outputclass="RFC-2119">SHOULD</term> consist of a prefix that gives the name or an
+        abbreviation for the implementation followed by a colon followed by the token or method
+        name. For example, a processor might define the token "appToken:audience" in order to
+        specify cascading and merging behaviors for <b>only</b> the <xmlatt>audience</xmlatt>
         attribute.</p>
       <!--<p id="module-version-xpl">The identifiers listed below are declared by the OASIS DITA Technical Committee for the modules that are shipped with DITA 1.3. Values that use a version number of 1.3 refer specifically to the modules that are delivered with the DITA 1.3 specification. Values that use a version number of 1.x refer to the modules in the latest approved DITA 1.x specification. Values without a version number refer to the modules in the latest approved DITA specification, regardless of version.</p>-->
                         <p id="keys-attribute-syntax">The <xmlatt>keys</xmlatt> attribute uses the

--- a/specification/common/reuse-w-lwdita/lwdita-attributes.dita
+++ b/specification/common/reuse-w-lwdita/lwdita-attributes.dita
@@ -56,11 +56,10 @@
         </dlentry>
         <dlentry>
           <dt>Localization attributes</dt>
-          <dd><ph id="localization-attr"><xref
-                keyref="attributes-groups/localization-attributes"
-                >localization attributes<desc>Localization attributes
-                  include <xmlatt>dir</xmlatt>, <xmlatt>translate</xmlatt>,
-                  and <xmlatt>xml:lang.</xmlatt></desc></xref></ph></dd>
+          <dd><ph id="localization-attr"><xref keyref="attributes-groups/localization-attributes"
+                >localization attributes<desc>Localization attributes include <xmlatt>dir</xmlatt>,
+                    <xmlatt>translate</xmlatt>, and
+            <xmlatt>xml:lang</xmlatt>.</desc></xref></ph></dd>
         </dlentry>
         <dlentry>
           <dt>Table accessibility attributes</dt>
@@ -73,11 +72,9 @@
         </dlentry>
         <dlentry>
           <dt>Universal attributes</dt>
-          <dd><ph id="universal-attr"><xref
-                keyref="attributes-groups/universal-attributes">universal
-                  attributes<desc>Universal attributes include
-                    <xmlatt>class</xmlatt> and
-                    <xmlatt>outputclass.</xmlatt>.</desc></xref></ph></dd>
+          <dd><ph id="universal-attr"><xref keyref="attributes-groups/universal-attributes"
+                >universal attributes<desc>Universal attributes include <xmlatt>class</xmlatt> and
+                    <xmlatt>outputclass</xmlatt>.</desc></xref></ph></dd>
         </dlentry>
       </dl>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-pre.dita
+++ b/specification/common/reuse-w-lwdita/reuse-pre.dita
@@ -8,10 +8,9 @@
 <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p platform="dita" rev="review-c">The <xmlelement>pre</xmlelement>
-        element is often used for ASCII diagrams and code samples. It is
-        the specialization base for the <xmlatt>codeblock</xmlatt> element
-        in the Technical Content edition.</p>
+      <p platform="dita" rev="review-c">The <xmlelement>pre</xmlelement> element is often used for
+        ASCII diagrams and code samples. It is the specialization base for the
+          <xmlelement>codeblock</xmlelement> element in the Technical Content edition.</p>
     </section>
       <section id="rendering-expectations">
          <title>Rendering expectations</title>

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -79,18 +79,21 @@
         </dlentry>
                 <dlentry>
                     <dt>Specify that an attribute is not valid.</dt>
-                    <dd><p>When the <xmlelement>enumerationdef</xmlelement> element <ph
-                rev="review-d">contains a <xmlatt>subjectdef</xmlatt> element that does not
-                reference a subject</ph>, no value is valid for the attribute.</p><p
-              otherprops="examples"/>For example, the following code sample specifies that no tokens
-            are valid for the <xmlatt>props</xmlatt> attribute:<codeblock>&lt;subjectScheme>
+                    <dd>
+            <p>When the <xmlelement>enumerationdef</xmlelement> element <ph rev="review-d">contains
+                a <xmlelement>subjectdef</xmlelement> element that does not reference a
+              subject</ph>, no value is valid for the attribute.</p>
+            <p otherprops="examples">For example, the following code sample specifies that no tokens
+              are valid for the <xmlatt>props</xmlatt>
+              attribute:<codeblock id="codeblock_qxr_wq3_2jc">&lt;subjectScheme>
   &lt;!-- ... -->
   &lt;enumerationdef>
     &lt;attributedef name="props"/>
     &lt;subjectdef/>
   &lt;/enumerationdef>
   &lt;!-- ... -->
-&lt;/subjectScheme></codeblock></dd>
+&lt;/subjectScheme></codeblock></p>
+          </dd>
                 </dlentry>
             </dl>
 

--- a/specification/langRef/base/hazardstatement.dita
+++ b/specification/langRef/base/hazardstatement.dita
@@ -27,7 +27,8 @@
             conkeyref="reuse-attributes/ref-universalatts"/> and the attribute defined below.</p>
         <dl>
           <dlentry id="type">
-            <dt id="attr-type"><xmlatt>type (REQUIRED)</xmlatt></dt>
+            <dt id="attr-type"><xmlatt>type</xmlatt>
+              <b>(REQUIRED)</b></dt>
             <dd>Specifies the level of hazard. The values correspond to the
               signal words that are defined by the ANSI Z535.6 standard:<dl>
                 <dlentry>

--- a/specification/langRef/base/image.dita
+++ b/specification/langRef/base/image.dita
@@ -9,8 +9,10 @@
         <indexterm>accessibility<indexterm>images</indexterm></indexterm>
         <indexterm>elements<indexterm>body<indexterm><xmlelement>image</xmlelement></indexterm></indexterm></indexterm><indexterm>images<indexterm>alternate
             text</indexterm><indexterm>overview</indexterm><indexterm>placement</indexterm><indexterm>size</indexterm></indexterm>
-        <indexterm>normative statements<indexterm><xmlatt>image</xmlatt></indexterm></indexterm>
-        <indexterm>rendering expectations<indexterm><xmlatt>image</xmlatt></indexterm></indexterm>
+        <indexterm>normative
+          statements<indexterm><xmlelement>image</xmlelement></indexterm></indexterm>
+        <indexterm>rendering
+          expectations<indexterm><xmlelement>image</xmlelement></indexterm></indexterm>
 </keywords>
 </metadata></prolog>
 <refbody>

--- a/specification/langRef/base/indexterm.dita
+++ b/specification/langRef/base/indexterm.dita
@@ -14,9 +14,8 @@
 <refbody>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <p>The content of <xmlatt>indexterm</xmlatt> entries is not rendered
-        in the flow of body text; it is rendered only as part of <ph
-          rev="review-chenier">an index</ph>.</p>
+      <p>The content of <xmlelement>indexterm</xmlelement> entries is not rendered in the flow of
+        body text; it is rendered only as part of <ph rev="review-chenier">an index</ph>.</p>
     </section>
     <!--<section id="processing-expectations"><title>Processing expectations</title><p>It is an error if an <xmlelement>indexterm</xmlelement> that contains <xmlelement>indexterm</xmlelement> children contains both an <xmlelement>index-see</xmlelement> and an <xmlelement>index-see-also</xmlelement> element. In the case of this error condition, an implementation <term outputclass="RFC-2119">MAY</term> give an error message; it <term outputclass="RFC-2119">MAY</term> recover by treating all such <xmlelement>index-see</xmlelement> elements as <xmlelement>index-see-also</xmlelement> elements.</p></section>-->
     <section id="attributes">

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -89,12 +89,10 @@
         </dlentry>
         <dlentry id="appid">
           <dt id="attr-appid"><xmlatt>appid</xmlatt></dt>
-          <dd>Specifies an ID that can be used by an application to
-            identify the topic.<p>When <xmlatt>app-role</xmlatt> is set to
-                <keyword>deliverable-anchor</keyword>, certain restrictions
-              apply to the value of the <xmlatt>appid</xmlatt> attribute.
-              See <xref keyref="elements-resourceid/usage-information"
-              />.</p></dd>
+          <dd>Specifies an ID that can be used by an application to identify the topic.<p>When
+                <xmlatt>appid-role</xmlatt> is set to <keyword>deliverable-anchor</keyword>, certain
+              restrictions apply to the value of the <xmlatt>appid</xmlatt> attribute. See <xref
+                keyref="elements-resourceid/usage-information"/>.</p></dd>
         </dlentry>
         <dlentry>
           <dt id="attr-appid-role"><xmlatt>appid-role</xmlatt></dt>
@@ -112,14 +110,11 @@
               </dlentry>
               <dlentry>
                 <dt>deliverable-anchor</dt>
-                <dd>Specifies that the value of the <xmlatt>appid</xmlatt>
-                  attribute is used to construct anchors for the associated
-                    resource.<p>When <xmlatt>app-role</xmlatt> is set to
-                      <keyword>deliverable-anchor</keyword>, certain
-                    restrictions apply to the value of the
-                      <xmlatt>appid</xmlatt> attribute. See <xref
-                      keyref="elements-resourceid/usage-information"
-                  />.</p></dd>
+                <dd>Specifies that the value of the <xmlatt>appid</xmlatt> attribute is used to
+                  construct anchors for the associated resource.<p>When <xmlatt>appid-role</xmlatt>
+                    is set to <keyword>deliverable-anchor</keyword>, certain restrictions apply to
+                    the value of the <xmlatt>appid</xmlatt> attribute. See <xref
+                      keyref="elements-resourceid/usage-information"/>.</p></dd>
               </dlentry>
             </dl></dd>
         </dlentry>

--- a/specification/non-normative/changes-1.3-to-2.0/added-to-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/added-to-standard.dita
@@ -186,7 +186,7 @@
         <section id="section_mwy_5td_3vb">
             <title>Attributes</title>
             <p>DITA 2.0 introduces the following new attributes:<ul id="ul_rbg_wtd_3vb">
-                    <li><xmlatt>impose-rule</xmlatt>. When specified on a
+                    <li><xmlatt>impose-role</xmlatt>. When specified on a
                             <xmlelement>topicref</xmlelement> element, with a value of "impose", and
                         the <xmlelement>topicref</xmlelement> is a reference to a map, this
                         attribute indicates that the role of the <xmlelement>topicref</xmlelement>

--- a/specification/non-normative/changes-1.3-to-2.0/elements-from-which-attributes-have-been-removed.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/elements-from-which-attributes-have-been-removed.dita
@@ -38,7 +38,7 @@
         <stentry>
           <ul>
             <li><xmlatt>archive</xmlatt></li>
-            <li><xmlatt>archivekeyref</xmlatt></li>
+            <li><xmlatt>archivekeyrefs</xmlatt></li>
             <li><xmlatt>classid</xmlatt></li>
             <li><xmlatt>classidkeyref</xmlatt></li>
             <li><xmlatt>codebase</xmlatt></li>

--- a/specification/non-normative/changes-1.3-to-2.0/modified-in-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/modified-in-standard.dita
@@ -68,7 +68,7 @@
                     <dt><xmlelement>hazardstatement</xmlelement></dt>
                     <dd>
                         <ul id="ul_qy4_5mk_3vb">
-                            <li>Move <xmlatt>hazardsymbol</xmlatt> element to be a child of
+                            <li>Move <xmlelement>hazardsymbol</xmlelement> element to be a child of
                                     <xmlelement>messagepanel</xmlelement></li>
                             <li>Allow <xmlelement>hazardsymbol</xmlelement> within
                                     <xmlelement>typeofhazard</xmlelement>

--- a/specification/non-normative/changes-1.3-to-2.0/new-features-and-enhancements-in-dita-2-0.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/new-features-and-enhancements-in-dita-2-0.dita
@@ -25,7 +25,7 @@
         <dt>Redesign of chunking</dt>
         <dd>The chunking feature has been simplified. The
             <xmlatt>chunk</xmlatt> attribute now takes only two tokens:
-            <xmlatt>combine</xmlatt> and <xmlatt>split</xmlatt>. This
+            <keyword>combine</keyword> and <keyword>split</keyword>. This
           supports the two most critical use cases for chunking: the
           ability to combine many documents into a single document, and the
           ability to split a single document into many documents.</dd>

--- a/specification/non-normative/changes-1.3-to-2.0/removed-attributes.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/removed-attributes.dita
@@ -165,7 +165,7 @@
           <stentry>
             <ul>
               <li><xmlatt>archive</xmlatt></li>
-              <li><xmlatt>archivekeyref</xmlatt></li>
+              <li><xmlatt>archivekeyrefs</xmlatt></li>
               <li><xmlatt>classid</xmlatt></li>
               <li><xmlatt>classidkeyref</xmlatt></li>
               <li><xmlatt>codebase</xmlatt></li>

--- a/specification/non-normative/changes-1.3-to-2.0/removed-from-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/removed-from-standard.dita
@@ -105,7 +105,7 @@
           <stentry>
             <ul>
               <li><xmlatt>archive</xmlatt></li>
-              <li><xmlatt>archivekeyref</xmlatt></li>
+              <li><xmlatt>archivekeyrefs</xmlatt></li>
               <li><xmlatt>classid</xmlatt></li>
               <li><xmlatt>classidkeyref</xmlatt></li>
               <li><xmlatt>codebase</xmlatt></li>

--- a/specification/non-normative/changes-1.3-to-2.0/replaced-in-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/replaced-in-standard.dita
@@ -133,13 +133,11 @@
                             <stentry><xmlatt>deliveryTarget</xmlatt></stentry>
                         </strow>
                         <strow>
-                            <stentry><xmlatt>role="external"</xmlatt></stentry>
-                            <stentry><xmlatt>scope="external"</xmlatt></stentry>
+                            <stentry><xmlatt>role</xmlatt> with value <keyword>external</keyword></stentry>
+                            <stentry><xmlatt>scope</xmlatt> with value <keyword>external</keyword></stentry>
                         </strow>
                         <strow>
-                            <stentry><xmlatt>type="external"</xmlatt> or
-                                    <xmlatt>type="internal"</xmlatt> on
-                                <xmlelement>lq</xmlelement></stentry>
+                            <stentry><xmlatt>type</xmlatt> on <xmlelement>lq</xmlelement> with value <keyword>external</keyword> or value <keyword>internal</keyword> </stentry>
                             <stentry><xmlatt>scope</xmlatt> and <xmlatt>format</xmlatt></stentry>
                         </strow>
                     

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -450,8 +450,7 @@
           <stentry><xmlelement>lq</xmlelement></stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>reftitle</xmlatt> can specify translatable
-            content.</stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>media-source</xmlelement></stentry>


### PR DESCRIPTION
* We had samples for attribute extension that used a mix of `cell-purpose` and `cellPurpose` -- this makes them consistent with `cellPurpose`
* Clean up obsolete info from the reuse-attributes file
* Clean up use of `xmlatt` (elements marked as attributes, typos, and attributes with values)