### PR TITLE
Add missing element in a-to-z list

### DIFF
--- a/specification/langRef/quick-reference/base-elements-a-to-z.dita
+++ b/specification/langRef/quick-reference/base-elements-a-to-z.dita
@@ -162,6 +162,7 @@
     <sli><xref keyref="elements-ul"/></sli>
     <sli><xref keyref="elements-ux-window"/></sli>
     <sli><xref keyref="elements-video"/></sli>
+    <sli><xref keyref="elements-video-poster"/></sli>
     <sli><xref keyref="elements-vrm"/></sli>
     <sli><xref keyref="elements-vrmlist"/></sli>
     <sli><xref keyref="elements-xref"/></sli>


### PR DESCRIPTION
`video-poster` was added more recently and is missing from the a-to-z list