### PR TITLE
Add dita element as module in base spec

### DIFF
--- a/doctypes/dtd/base/catalog.xml
+++ b/doctypes/dtd/base/catalog.xml
@@ -8,6 +8,10 @@
            uri="basetopic.dtd"/>
    <public publicId="-//OASIS//DTD DITA 2.x Base Topic//EN"
            uri="basetopic.dtd"/>
+   <public publicId="-//OASIS//ELEMENT DITA 2.0 Element//EN"
+                uri="ditaelement.mod"/>
+   <public publicId="-//OASIS//ELEMENT DITA 2.x Element//EN"
+                uri="ditaelement.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA 2.0 Common Elements//EN"
            uri="commonElements.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA 2.x Common Elements//EN"

--- a/doctypes/dtd/base/ditaelement.mod
+++ b/doctypes/dtd/base/ditaelement.mod
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!-- Darwin Information Typing Architecture (DITA) Version 2.0     -->
+<!-- [[[Draft level]]]                                           -->
+<!-- [[[Release date]]]                                           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
+<!-- Source: [[[Source link]]]                                -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!--  MODULE:    DITA BASE ELEMENT MODULE                          -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                        -->
+<!--  PURPOSE:   Defines the <dita> element for use in shells      -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                    TYPICAL INVOCATION                         -->
+<!--                                                               -->
+<!--  Refer to this file by the following public identifier or an  -->
+<!--       appropriate system identifier                           -->
+<!--                                                               -->
+<!-- PUBLIC "-//OASIS//ELEMENT DITA 2.x Element//EN"               -->
+<!-- The public ID above refers to the latest version of this DTD. -->
+<!--      To refer to this specific version, use this value: -->
+<!--                                                               -->
+<!-- PUBLIC "-//OASIS//ELEMENT DITA 2.0 Element//EN"               -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!--             (C) Copyright OASIS Open 2005, 2026.              -->
+<!--             (C) Copyright IBM Corporation 2001, 2004.         -->
+<!--             All Rights Reserved.                              -->
+<!--                                                               -->
+<!--  UPDATES:                                                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                DEFINE ELEMENT AND ATTRIBUTES                  -->
+<!-- ============================================================= -->
+
+<!-- The <dita> element cannot be specialized, so it does not      -->
+<!-- a class attribute or a named entity for the element.          -->
+
+<!ATTLIST dita
+              specializations 
+                        CDATA                            
+                                  "&included-domains;"
+              %arch-atts;
+              %localization-atts;
+>
+<!ELEMENT dita          (%info-types;)+                              >
+

--- a/doctypes/dtd/base/ditaelement.mod
+++ b/doctypes/dtd/base/ditaelement.mod
@@ -41,7 +41,7 @@
 <!-- ============================================================= -->
 
 <!-- The <dita> element cannot be specialized, so it does not      -->
-<!-- a class attribute or a named entity for the element.          -->
+<!-- define a class attribute or use a named element entity.       -->
 
 <!ATTLIST dita
               specializations 

--- a/doctypes/rng/base/catalog.xml
+++ b/doctypes/rng/base/catalog.xml
@@ -11,6 +11,10 @@
               uri="basetopic.rng"/>
       <system systemId="urn:pubid:oasis:names:tc:dita:rng:basetopic.rng:2.x"
               uri="basetopic.rng"/>
+      <system systemId="urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng:2.0"
+              uri="ditaelement.rng"/>
+      <system systemId="urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng:2.x"
+              uri="ditaelement.rng"/>
       <system systemId="urn:pubid:oasis:names:tc:dita:rng:commonElementsMod.rng:2.0"
               uri="commonElementsMod.rng"/>
       <system systemId="urn:pubid:oasis:names:tc:dita:rng:commonElementsMod.rng:2.x"
@@ -89,6 +93,10 @@
            uri="basetopic.rng"/>
       <uri name="urn:pubid:oasis:names:tc:dita:rng:basetopic.rng:2.x"
            uri="basetopic.rng"/>
+      <uri name="urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng:2.0"
+           uri="ditaelement.rng"/>
+      <uri name="urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng:2.x"
+           uri="ditaelement.rng"/>
       <uri name="urn:pubid:oasis:names:tc:dita:rng:commonElementsMod.rng:2.0"
            uri="commonElementsMod.rng"/>
       <uri name="urn:pubid:oasis:names:tc:dita:rng:commonElementsMod.rng:2.x"

--- a/doctypes/rng/base/ditaelement.rng
+++ b/doctypes/rng/base/ditaelement.rng
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
+                         schematypens="http://relaxng.org/ns/structure/1.0"?>
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:dita="http://dita.oasis-open.org/architecture/2005/" xmlns="http://relaxng.org/ns/structure/1.0"
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <moduleDesc xmlns="http://dita.oasis-open.org/architecture/2005/">
+    <moduleTitle>DITA Base Element Module</moduleTitle>
+    <headerComment xml:space="preserve">
+=============================================================
+                   HEADER                                    
+=============================================================
+ MODULE:    DITA Base Element Module                            
+ VERSION:   2.0                                              
+ DATE:      [[[Release date]]]                                    
+ PURPOSE:   Defines the &lt;dita&gt; element for use in shells                             
+                                                             
+=============================================================
+
+=============================================================
+                   PUBLIC DOCUMENT TYPE DEFINITION           
+                   TYPICAL INVOCATION                        
+                                                             
+ Refer to this file by the following public identifier or an 
+      appropriate system identifier 
+ PUBLIC "-//OASIS//ELEMENT DITA 2.0 Element//EN"
+      Delivered as file "ditaelement.mod"                            
+
+=============================================================
+                                                             
+            (C) Copyright OASIS Open 2005, 2026.             
+            (C) Copyright IBM Corporation 2001, 2004.        
+            All Rights Reserved.                             
+                                                             
+ UPDATES:                                                    
+=============================================================
+      
+    </headerComment>
+    <moduleMetadata>
+      <moduleType>elementdomain</moduleType>
+      <moduleShortName>ditaelement</moduleShortName>
+      <modulePublicIds>
+        <dtdMod>-//OASIS//ELEMENT DITA<var presep=" " name="ditaver"/> Element//EN</dtdMod>
+        <rngMod>urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng<var presep=":" name="ditaver"/></rngMod>
+      </modulePublicIds>
+    </moduleMetadata>
+  </moduleDesc>
+
+  <div>
+    <a:documentation>Define a container for topics in the DITA composite type</a:documentation>
+    <define name="dita.element">
+      <element name="dita">
+        <a:documentation>The &lt;dita&gt; element provides a top-level container for multiple topics when you create documents using the ditabase document type. The &lt;dita&gt; element lets you create any
+          sequence of concept, task, and reference topics, and the ditabase document type lets you further nest these topic types inside each other. The &lt;dita&gt; element has no particular output
+          implications; it simply allows you to create multiple topics of different types at the same level in a single document. Category: Ditabase document type</a:documentation>
+        <ref name="dita.attlist"/>
+        <oneOrMore>
+          <ref name="info-types"/>
+        </oneOrMore>
+      </element>
+    </define>
+    
+    <define name="dita.attlist" combine="interleave">
+      <ref name="arch-atts"/>
+      <ref name="localization-atts" dita:since="DITA 1.3"/>
+    </define>
+    
+  </div>
+
+</grammar>


### PR DESCRIPTION
Fixes #952

The `<dita>` element is defined in the base specification, but was only defined in the technical-content grammar. It should be defined in the base vocabulary and then used as a module within the technical-content context.