### PR TITLE
Restore specializations att on dita element

### DIFF
--- a/doctypes/rng/base/ditaelement.rng
+++ b/doctypes/rng/base/ditaelement.rng
@@ -62,6 +62,7 @@
     <define name="dita.attlist" combine="interleave">
       <ref name="arch-atts"/>
       <ref name="localization-atts" dita:since="DITA 1.3"/>
+      <ref name="specializations-att"/>
     </define>
     
   </div>


### PR DESCRIPTION
The update that created a module for `<dita>` used a slightly older copy of the composite RNG file; need to update to include https://github.com/oasis-tcs/dita-techcomm/pull/273/changes/2d98232843c934d7e034836f6fba742ad0b422ec