### PR TITLE
Add rev val from TC spec to subject scheme

### DIFF
--- a/specification/dita-2.0-specification-subjectScheme.ditamap
+++ b/specification/dita-2.0-specification-subjectScheme.ditamap
@@ -48,6 +48,7 @@
     <subjectdef keys="review-c"/>
     <subjectdef keys="review-d"/>
     <subjectdef keys="review-e"/>
+    <subjectdef keys="review-e.2"/>
     <subjectdef keys="review-g"/>
     <subjectdef keys="review-h"/>
     <subjectdef keys="review-i"/>


### PR DESCRIPTION
Revision `revision-e.2` is used in the TC spec, from the second round of review E, and is throwing errors because it's missing from the scheme.