### PR TITLE
Restore attribute section for ditaval elements without atts

### DIFF
--- a/specification/common/conref-attribute.dita
+++ b/specification/common/conref-attribute.dita
@@ -255,8 +255,7 @@
                         </dl></section>
                         <section id="no-attributes">
                                 <title>Attributes</title>
-                                <p id="no-atts"
-        ><!--This element does not define any attributes.-->None</p>
+                                <p id="no-atts">This element does not define any attributes.</p>
                         </section>
                 <section id="section-3">
                         <title>Attributes used on image; most are common to image

--- a/specification/langRef/ditaval/alt-text.dita
+++ b/specification/langRef/ditaval/alt-text.dita
@@ -20,9 +20,11 @@
         alternate text is specified but the containing element does not
         reference an image, applications can render the text itself as a
         way to flag content.</p>
-      <!--<p><ph conref="ditaval-revprop.dita#ditaval-revprop/default-text"/></p>-->
     </section>
-    <!--<section id="attributes"><title>Attributes</title><p conkeyref="reuse-attributes/no-atts"/></section>-->
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/no-atts"/>
+    </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample shows a DITAVAL document that is used to
         render icons before content that is specific to particular

--- a/specification/langRef/ditaval/val.dita
+++ b/specification/langRef/ditaval/val.dita
@@ -18,7 +18,10 @@
         multiple property attributes or multiple properties within a single
         attribute, see <xref href="../../archSpec/base/condproc.dita"/>. </p>
     </section>
-    <!--<section id="attributes"><title>Attributes</title><p conkeyref="reuse-attributes/no-atts"/></section>-->
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/no-atts"/>
+    </section>
 <example id="example" otherprops="examples"><title>Example</title>
       <p>This section contains examples of DITAVAL documents and how they
         can be used.</p><fig><title>Sample DITAVAL document</title>


### PR DESCRIPTION
Reviewer noticed that these elements were inconsistent with other element reference topics, because they are the only two missing the "Attributes" section. Restored the previously commented-out section that says they have no attributes.