### PR TITLE
Removing more stale draft comments

### DIFF
--- a/specification/langRef/base/audience.dita
+++ b/specification/langRef/base/audience.dita
@@ -11,7 +11,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <!--<section id="usage-information"><title>Usage information</title><p>A topic can indicate multiple audiences by including multiple <xmlelement>audience</xmlelement> elements. For each audience specified, the high-level task they are trying to accomplish can be identified with the <xmlatt>job</xmlatt> attribute, and the level of experience expected can be specified with the <xmlatt>experiencelevel</xmlatt> attribute. </p><draft-comment author="Kristen J Eberlein" time="27 December 2021"><p>Do we really want to state this? I've never seen this used, and it seems like residue of what folks thought was on the horizon 15+ years ago.</p></draft-comment><p>The <xmlelement>audience</xmlelement> element can be used to provide a more detailed definition of values used throughout the map or topic on the <xmlatt>audience</xmlatt> attribute.</p></section>-->
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>


### PR DESCRIPTION
Continuing to work through draft comments, this removes an obsolete commented out section that included a draft comment