### PR TITLE
Fix otherprops attribute value

### DIFF
--- a/specification/archSpec/base/accessiblemarkup.dita
+++ b/specification/archSpec/base/accessiblemarkup.dita
@@ -55,7 +55,7 @@
 				</dlentry>
 			</dl>
 			<p>While DITA provides the markup to enable these accessibility features, it is up to DITA
-        processors to render output that uses the markup properly. <ph otherprops="example">For
+        processors to render output that uses the markup properly. <ph otherprops="examples">For
           example, when a processor generates HTML5, alternate text must be specified using the
             <xmlatt>alt</xmlatt> attribute on the <xmlelement>img</xmlelement> element.</ph></p>
 		</section>

--- a/specification/archSpec/base/establishing-links-with-reltable.dita
+++ b/specification/archSpec/base/establishing-links-with-reltable.dita
@@ -17,19 +17,19 @@
             references in different cells of the same row are related. By default, topic references
             that are in the same cell do not establish linking relationships to each other.</p>
         <p>Relationship table columns are typically used to group topic references that share some
-            trait. <ph otherprops="example">For example, a three column table might use the columns
+            trait. <ph otherprops="examples">For example, a three column table might use the columns
                 to set up relationships between concept, task, and reference topics, while a two
                 column table might be used to set up relationships between local topics in the first
                 column and external resources in the second.</ph>.</p>
         <p>A <xmlelement>relheader</xmlelement> element can act as a header for the table, using
                 <xmlelement>relcolspec</xmlelement> elements to explicitly lay out column semantics.
-                <ph otherprops="example">For example, the <xmlelement>relcolspec</xmlelement>
+                <ph otherprops="examples">For example, the <xmlelement>relcolspec</xmlelement>
                 element can set <xmlatt>type</xmlatt> or <xmlatt>scope</xmlatt> to declare something
                 about the topic references in each column.</ph></p>
         <p> By default, linking relationships in maps are reciprocal. Therefore, topics referenced
             in different cells of the same row link to each other in both directions, subject to
             processor rendering behavior. Authors can modify this default behavior using the
-                <xmlatt>linking</xmlatt> attribute. <ph otherprops="example">For example, setting
+                <xmlatt>linking</xmlatt> attribute. <ph otherprops="examples">For example, setting
                     <codeph>linking="targetonly"</codeph> on a relationship table cell means that
                 the row establishes links from other cells to that cell, but does not establish
                 links from that cell out to other topics in the row.</ph></p>

--- a/specification/archSpec/base/map-convenience-elements.dita
+++ b/specification/archSpec/base/map-convenience-elements.dita
@@ -18,7 +18,7 @@
             specialization of  <xmlelement>topicref</xmlelement> created to support common authoring
             pattern. The same functions can be accomplished with <xmlelement>topicref</xmlelement>,
             but the elements are designed to make authoring easier and less error-prone.</p>
-        <p otherprops="example">For example, the <xmlelement>topichead</xmlelement> and
+        <p otherprops="examples">For example, the <xmlelement>topichead</xmlelement> and
                 <xmlelement>topicgroup</xmlelement> elements each provide a way to group other
             topics without directly referencing another resource. Each of these elements removes
                 <xmlatt>href</xmlatt> and <xmlatt>keyref</xmlatt> while keeping most other
@@ -26,7 +26,7 @@
             restrictions on the use of titles, the <xmlelement>topicgroup</xmlelement> element also
             provides a clearer way to group topic references without impacting the navigation
             hierarchy of the map.</p>
-        <p otherprops="example">Similarly, any key definition created with
+        <p otherprops="examples">Similarly, any key definition created with
                 <xmlelement>keydef</xmlelement> can also be created with
                 <xmlelement>topicref</xmlelement>, but the <xmlelement>keydef</xmlelement> element
             improves the authoring experience by requiring <xmlatt>keys</xmlatt> and setting a


### PR DESCRIPTION
Fixes bad otherprops value, `example` ==> `examples`