### PR TITLE
Notes on how to resolve draft comments

### DIFF
--- a/specification/archSpec/base/aboutconditionalprocessing.dita
+++ b/specification/archSpec/base/aboutconditionalprocessing.dita
@@ -27,34 +27,42 @@
       </dlentry>
       <dlentry>
         <dt>conditional-processing profile</dt>
-        <dd>A set of rules that are provided to a processor for use at
-          rendering time. These rules are based on one or more DITAVAL
-            documents.<draft-comment author="rodaande" time="21 March 2022"
-            >I'm not certain "conditional processing profile" warrants a
-            separate definition. I added it after going through some of the
-            following topics, and seeing a distinctions between a DITAVAL
-            document and a [set of conditions sent as input to a processor]
-            – for example, DITA-OT or an editor can apply conditions from
-            multiple DITAVAL documents as a single conditional processing
-            profile.</draft-comment></dd>
+        <dd>A set of rules that are provided to a processor for use at rendering time. These rules
+          are based on one or more DITAVAL documents.<draft-comment author="rodaande"
+            time="21 March 2022">I'm not certain "conditional processing profile" warrants a
+            separate definition. I added it after going through some of the following topics, and
+            seeing a distinctions between a DITAVAL document and a [set of conditions sent as input
+            to a processor] – for example, DITA-OT or an editor can apply conditions from multiple
+            DITAVAL documents as a single conditional processing profile.<p>
+              <draft-comment author="robander">TO RESOLVE 11 May 2026: Recommend removing this
+                term</draft-comment>
+            </p></draft-comment></dd>
       </dlentry>
       <dlentry>
         <dt>DITAVAL document</dt>
         <dd>A document that specifies a set of rules that define which elements to include, exclude,
           or flag. A DITAVAL document can be a file on the file system, a set of rules stored in
           memory, or another way of storing information that is expressed using DITAVAL
-            syntax.<!--<draft-comment author="rodaande" audience="spec-editors" time="18 March 2022">Do we need to / should we state here that this can be a file on the file system, a set of rules in memory, or any other way of storing filtering information that can be expressed using DITAVAL syntax?</draft-comment>--><draft-comment
-            author="Kristen J Eberlein" time="21 March 2022">
+            syntax.<draft-comment author="Kristen J Eberlein" time="21 March 2022">
             <p>Do we need to explicitly mention passthrough in the first sentence, or is passthrough
               considered to be part of flagging? If the latter, we should explicitly state that in
               the topic where we give a high-level overview of the sort of rules that can be defined
               using a DITAVAL document.</p>
-          </draft-comment><draft-comment author="rodaande" time="25 March 2022">I think it could be
-            considered a form of flagging. Given that I expect usage is low, and it is so nebulous
-            ("do this and something might happen, if your rendering format enables it"), I don't
-            think it deserves a whole topic on its own. Could we broaden the definition of flagging
-            to say that it also encompasses the "passthrough" value, and then extend the "Flagging"
-            topic to cover both?</draft-comment></dd>
+            <p>
+              <draft-comment author="rodaande" time="25 March 2022">I think it could be considered a
+                form of flagging. Given that I expect usage is low, and it is so nebulous ("do this
+                and something might happen, if your rendering format enables it"), I don't think it
+                deserves a whole topic on its own. Could we broaden the definition of flagging to
+                say that it also encompasses the "passthrough" value, and then extend the "Flagging"
+                topic to cover both?</draft-comment>
+              <draft-comment author="robander">TO RESOLVE 11 May 2026: How about if we update the
+                definition of "flagging" below to clarify that this can also include other
+                modifications to the output, such as preserving DITA attributes in the rendered
+                output, or through the use of <xmlatt>add-outputclass</xmlatt>, processing matching
+                DITA elements as if they had a specified <xmlatt>outputclass</xmlatt>
+                attribute.</draft-comment>
+            </p>
+          </draft-comment></dd>
       </dlentry>
       <dlentry>
         <dt>filtering</dt>
@@ -65,14 +73,18 @@
     <draft-comment author="Kristen J Eberlein" time="21 March 2022">
       <p>Do we need to broaden the definition of  filtering and mention
         inclusion also?</p>
+      <p>
+        <draft-comment author="rodaande" time="25 March 2022">I'm wary of trying to pin down a broad
+          term like "including", but I don't really know. The assumption of the spec, and I assumed
+          of spec readers, was that the DITA content is rendered in some way (in an editor, as HTML,
+          as PDF, etc), and that by default the DITA content is meant for publishing. For that
+          reason, we go out of our way to say *not* to render data elements and foreign elements,
+          but we don't do the reverse for paragraphs, tables, etc.<p>I'm not sure though, beause
+            "include" is clearly a value you can specity in DITAVAL.</p></draft-comment>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: how about if we just update this to
+          say "The process of including or excluding content at rendering time"</draft-comment>
+      </p>
     </draft-comment>
-    <draft-comment author="rodaande" time="25 March 2022">I'm wary of trying to pin down a broad
-      term like "including", but I don't really know. The assumption of the spec, and I assumed of
-      spec readers, was that the DITA content is rendered in some way (in an editor, as HTML, as
-      PDF, etc), and that by default the DITA content is meant for publishing. For that reason, we
-      go out of our way to say *not* to render data elements and foreign elements, but we don't do
-      the reverse for paragraphs, tables, etc.<p>I'm not sure though, beause "include" is clearly a
-        value you can specity in DITAVAL.</p></draft-comment>
     <dl>
       <dlentry>
         <dt>flagging</dt>

--- a/specification/archSpec/base/aboutditavaldocuments.dita
+++ b/specification/archSpec/base/aboutditavaldocuments.dita
@@ -31,6 +31,23 @@
         a good conceptual overview with supporting details. Given the
         complexity of conditional processing, I think that is what we need
         here.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: how about if we add a follow-up
+          paragraph that says "the behaviors above can be associated with the following actions"<ol
+            id="ol_mqm_1c4_fjc">
+            <li>Instruct processors to include matching content</li>
+            <li>Instruct processors to exclude matching content</li>
+            <li>Instruct processors to mark matching revisions</li>
+            <li>Instruct processors to flag matching content with styles also specified on the
+                <xmlelement>prop</xmlelement> or <xmlelement>revprop</xmlelement> element</li>
+            <li>Instruct processors to pass the matching attribute through to rendered output, when
+              applicable</li>
+            <li>Instruct processors to treat the matching content as if the element has an
+                <xmlatt>outputclass</xmlatt> attribute, with the value specified in the
+                <xmlelement>prop</xmlelement> (or revprop?) element using
+                <xmlatt>add-outputclass</xmlatt></li>
+          </ol></draft-comment>
+      </p>
     </draft-comment>
         <p>While the DITAVAL markup is not part of the DITA topic or map
       vocabulary and cannot be specialized, the XML itself is part of the
@@ -44,6 +61,10 @@
         might include alternate text to indicate the start and end points
         of revised content or stylistic formatting when no specific
         flagging behavior is specified.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: how about we just add that sentence
+          here, or in the list I suggested adding above</draft-comment>
+      </p>
     </draft-comment>
     </body>
 </topic>

--- a/specification/archSpec/base/basic-dita-terminology.dita
+++ b/specification/archSpec/base/basic-dita-terminology.dita
@@ -15,7 +15,18 @@
                 assumes that we retain current use of "DITA processor" as used in the specification.
                 Jarno noted that HTML5 uses producer/ consumer, where producer is aimed more at
                 rules for authors / creators of DITA content and consumer is a tool that acts upon
-                the content.</p></draft-comment>
+                the content.</p><p>
+                <draft-comment author="robander">TO RESOLVE 11 May 2026: this is a hard one. How
+                    about we add the term but with a broad definition stating that a processor is an
+                    implementation of DITA that renders DITA content or implements features of the
+                    DITA specification. This <b>can</b> include editors that attempt to render DITA
+                    content as anything other than plain text, processors that render DITA content
+                    as some other format, content management systems that process relationships
+                    between DITA documents, and other systems that attempt to handle DITA content as
+                    anything other than plain XML.<p>Or, if we can't come up with wording that works
+                        with that, just skip this and not define a DITA
+                    processor.</p></draft-comment>
+            </p></draft-comment>
         <dl>
             <dlentry>
                 <dt>DITA document</dt>
@@ -34,8 +45,12 @@
                                     ONE document with sibling topics. Also, not to over-complicate,
                                     but an ordinary topic also allows sibling topics (as children),
                                     so what really distinguishes this is that it allows "root"
-                                    siblings, but I don't think we have a word for
-                                    that.</draft-comment></li>
+                                    siblings, but I don't think we have a word for that.<p>
+                                        <draft-comment author="robander">TO RESOLVE 11 May 2026:
+                                            recommend replacing with "...which cannot be
+                                            specialized, but which allows for a DITA document with
+                                            multiple root-level sibling topics"</draft-comment>
+                                    </p></draft-comment></li>
                         </ul></p>
                 </dd>
             </dlentry>
@@ -66,13 +81,23 @@
                         <p>Suggest removing the last sentence of the definition. It uses the word
                             'must'; also, it needs to be better aligned with the topic about
                             architectural attributes.</p>
+                        <p>
+                            <draft-comment author="robander" audience="spec-editors"
+                                time="26 may 2021">Having @class is such a core part of being a DITA
+                                element that I'd be inclined to keep it, except that 1) we could
+                                just remove "must" (it's a statement of fact, not a rule) and 2) I
+                                am continually confused by the term "exhibit" in this context. Also,
+                                &lt;dita> doesn't have class and is a DITA element, so it's an
+                                oddball.</draft-comment>
+                            <draft-comment author="robander">TO RESOLVE 11 May 2026: suggest we <ol
+                                    id="ol_kkn_l24_fjc">
+                                    <li>confirm that somewhere in this spec we do say that you have
+                                        to have <xmlatt>class</xmlatt>, which I'm pretty sure we do,
+                                        and then</li>
+                                    <li>delete the sentence as Kris suggested</li>
+                                </ol></draft-comment>
+                        </p>
                     </draft-comment>
-                    <draft-comment author="robander" audience="spec-editors" time="26 may 2021"
-                        >Having @class is such a core part of being a DITA element that I'd be
-                        inclined to keep it, except that 1) we could just remove "must" (it's a
-                        statement of fact, not a rule) and 2) I am continually confused by the term
-                        "exhibit" in this context. Also, &lt;dita> doesn't have class and is a DITA
-                        element, so it's an oddball.</draft-comment>
                 </dd>
             </dlentry>
             <dlentry>

--- a/specification/archSpec/base/behaviors.dita
+++ b/specification/archSpec/base/behaviors.dita
@@ -7,5 +7,14 @@
         navigation; linking; content reuse (using direct or indirect addressing); conditional
         processing; branch filtering; chunking; and more. In addition, translation of DITA content
         is expedited through the use of the <xmlatt>dir</xmlatt>, <xmlatt>translate</xmlatt>, and
-            <xmlatt>xml:lang</xmlatt> attributes.</shortdesc>
+            <xmlatt>xml:lang</xmlatt> attributes.<draft-comment author="robander" time="15 May 2026"
+            >We need to rewrite this. The "attributes that indicate" is no longer accurate now that
+            we got rid of @domains. DITA processing is not "affected by" navigation, linking, etc;
+            those are the features, implied and explicit, that require processing. The translation
+            attributes now have their own section and are not described in this one.<p>TO RESOLVE 15
+                May 2026: Rewrite to say that DITA enables a lot of features such as automated
+                navigation and linking, content reuse, and conditional processing. Some of these are
+                implicit, such as navigation and linking that can be derived from the order of the
+                map, while other features have explicit processing rules defined in the
+                specification.</p></draft-comment></shortdesc>
 </concept>

--- a/specification/archSpec/base/branch-filtering-implications-of-processing-order.dita
+++ b/specification/archSpec/base/branch-filtering-implications-of-processing-order.dita
@@ -11,8 +11,10 @@
       requirement comes from the fact that the branch filtering process can result in new or renamed
       keys, key scopes, or URIs that make up the key space.</p>
     <draft-comment author="rodaande" time="4 Apr 2022">Do we remember what "relaed attributes" are
-      in the following note? Can we keep it simple and just say that keyref attribute is
-      disallowed?</draft-comment>
+      in the following note? Can we keep it simple and just say that keyref attribute is disallowed?<p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: I think it is just keyref, in which
+          case, we should just say that. Recommend we double check and verify.</draft-comment>
+      </p></draft-comment>
     <note>The <xmlatt>keyref</xmlatt> attribute and related attributes are explicitly disallowed on
         <xmlelement>ditavalref</xmlelement>. This prevents any confusion resulting from a
         <xmlatt>keyref</xmlatt> that resolves to additional key- or resource-renaming

--- a/specification/archSpec/base/cascading-of-roles-in-specialized-maps.dita
+++ b/specification/archSpec/base/cascading-of-roles-in-specialized-maps.dita
@@ -19,6 +19,10 @@
     <draft-comment author="Kristen J Eberlein" audience="spec-editors" time="04 July 2019">
       <p>We need to look at the instances of "should" in this topic. Can they be recast? Do we need
         to introduce RFC-2119 language?</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: just need to do the editorial pass
+          and clean up each use of should, use RFC if needed</draft-comment>
+      </p>
     </draft-comment>
     <p>The semantic role reflects the <xmlatt>class</xmlatt> hierarchy of
       the referencing <xmlelement>topicref</xmlelement> element<ph
@@ -40,8 +44,11 @@
       statement: "the non-default behavior should be clearly specified"<p>We do not say how or
         where. For mapgroup, I believe it is only specified here in this topic. I think either we
         need this as part of every mapgroup element definition, in "Processing expectations", or we
-        need a clear table here listing every element where this behavior does not
-      apply.</p></draft-comment>
+        need a clear table here listing every element where this behavior does not apply.</p><p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: I believe the
+            <xmlatt>impose-role</xmlatt> attribute is now available for this, we should say so and
+          link to the topic about it</draft-comment>
+      </p></draft-comment>
   <p>Unless otherwise instructed, a specialized <xmlelement>topicref</xmlelement> element that
       references a map supplies a role for the referenced content. This means that, in effect, the
         <xmlatt>class</xmlatt> attribute of the referencing element cascades to top-level topicref

--- a/specification/archSpec/base/chunk-attribute-combine.dita
+++ b/specification/archSpec/base/chunk-attribute-combine.dita
@@ -43,6 +43,10 @@
         </ul>
     <draft-comment author="Kristen J Eberlein" time="04 February 2022">
       <p>What's the difference between the content of li[3] and [li4]?</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: I think this is resolved, item 3
+          was commented out</draft-comment>
+      </p>
     </draft-comment>
 </conbody>
 </concept>

--- a/specification/archSpec/base/conditional-processing-and-subject-schemes.dita
+++ b/specification/archSpec/base/conditional-processing-and-subject-schemes.dita
@@ -8,7 +8,10 @@
     <draft-comment author="rodaande" audience="spec-editors" time="21 March 2022">Not sure if need
       this topic. Started to fill in info but it would cover exactly what is in <xref
         href="processing-controlled-attribute-values.dita"/> … don't want to duplicate information,
-      especially normative rules.</draft-comment>
+      especially normative rules.<p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: see if Kris will let me delete this
+          topic</draft-comment>
+      </p></draft-comment>
     <p/>
   </conbody>
 </concept>

--- a/specification/archSpec/base/condproc.dita
+++ b/specification/archSpec/base/condproc.dita
@@ -3,10 +3,8 @@
  "concept.dtd">
 <concept id="condproc" xml:lang="en-us">
     <title>Conditional processing<!-- (profiling)--></title>
-    <shortdesc><ph
-      conkeyref="reuse-general/conditional-processing-shortdesc"/>
-    Conditional processing is based on attributes specified in the DITA
-    source.</shortdesc>
+    <shortdesc><ph conkeyref="reuse-general/conditional-processing-shortdesc"/> Conditional
+    processing is based on attributes specified in the DITA source.</shortdesc>
     <conbody>
     <draft-comment author="Kristen J Eberlein" time="13 March 2022">
       <p>The following content was in the container topic for the DITAVAL
@@ -15,17 +13,23 @@
       <p>Conditional processing code should provide a report of any
         attribute values encountered in content that do not have an action
         associated with them.</p>
-    </draft-comment>
-        <draft-comment author="rodaande" time="21 March 2022">I'm less
-      convinced it needs to be a normative statement. I think it can be a
-      helpful addition to a processor, but it can also be a big annoyance.
-      If anything about it is normative, I think it needs to be MAY,
-      allowing processors to choose whether such notification is
-      appropriate for their use cases.</draft-comment>
-    <draft-comment author="Kristen J Eberlein" time="21 March 2022">
-      <p>Maybe we should have a topic here in the architectural section
-        about errors? We could move some of the normative statements about
-        errors from the element-reference topics to here.</p>
+      <p>
+        <draft-comment author="rodaande" time="21 March 2022">I'm less convinced it needs to be a
+          normative statement. I think it can be a helpful addition to a processor, but it can also
+          be a big annoyance. If anything about it is normative, I think it needs to be MAY,
+          allowing processors to choose whether such notification is appropriate for their use
+          cases.</draft-comment>
+        <draft-comment author="Kristen J Eberlein" time="21 March 2022">
+          <p>Maybe we should have a topic here in the architectural section about errors? We could
+            move some of the normative statements about errors from the element-reference topics to
+            here.</p>
+        </draft-comment>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: How about if we just add a
+          statement to the "Expectaions for conditional processing" topic that says a processor
+          might do this (non-normative), so that it's there as something we can reference but
+          doesn't add any rules for processors. I really don't think this specific issue should be a
+          normative rule, whether it is SHOULD or MAY.</draft-comment>
+      </p>
     </draft-comment>
     </conbody>
 </concept>

--- a/specification/archSpec/base/definition-of-ditamaps.dita
+++ b/specification/archSpec/base/definition-of-ditamaps.dita
@@ -48,8 +48,18 @@ they can be used and reused in multiple different             contexts.</p>
                                         provides...book maps"? We could say "The DITA specifications
                                         provide" (plural)? That seems simpler for an overview topic
                                         than trying to explain "This package has one specialization
-                                        and another package [out later] has book
-                                maps"</p></draft-comment></p>
+                                        and another package [out later] has book maps"</p><p>
+                                        <draft-comment author="robander">TO RESOLVE 11 May 2026:
+                                                suggest we update to say that the base DITA
+                                                specification includes the structure for generic
+                                                maps and topics, as well as the specialized subject
+                                                scheme, while the related DITA for Technical Content
+                                                specification includes several specialized map and
+                                                topic types, such as creating concept, task,
+                                                reference, and troubleshooting topics, as well as
+                                                book maps to represent printed or book-oriented
+                                                publications.</draft-comment>
+                                </p></draft-comment></p>
 <p>DITA maps establish relationships through the nesting of <xmlelement>topicref</xmlelement>
                         elements and the application of the <xmlatt>collection-type</xmlatt>
                         attribute. Relationship tables also can be used to associate topics with

--- a/specification/archSpec/base/determining-effective-attribute-values.dita
+++ b/specification/archSpec/base/determining-effective-attribute-values.dita
@@ -29,6 +29,12 @@ evaluated.</li>
                             <p>The following note is problematic. It contains a normative statement,
                                 but we explicitly state that notes are non-normative.</p>
                             <p>Discussed at TC call on 28 May 2019.</p>
+                            <p>
+                                <draft-comment author="robander">TO RESOLVE 11 May 2026: I think
+                                    this is the hardest bit we have left. We need to dig up those
+                                    notes from 2019 to find out what the TC said
+                                    there.</draft-comment>
+                            </p>
                         </draft-comment><note>The processing-supplied default values do not cascade
                             to other maps. For example, most processors will supply a default value
                             of <codeph>toc="yes"</codeph> when no <xmlatt>toc</xmlatt> attribute is

--- a/specification/archSpec/base/dita-map-processing.dita
+++ b/specification/archSpec/base/dita-map-processing.dita
@@ -4,4 +4,15 @@
     <title>DITA map processing</title>
     <shortdesc>Introduction to this chapter to be written later, when content is more
         stable.</shortdesc>
+    <conbody>
+        <draft-comment author="robander" time="15 May 2026">I cannot entirely remember the history
+            of this section. I believe it was largely created as a placeholder for a bunch of
+            missing topics about general map usage / processing. Those topics have now been added,
+            but have overlap with topics in "DITA Processing". And at this point I'm not clear on
+            the distinction between this section (DITA map processing) and the other (DITA
+            processing). I don't think there is one, I think this was a temporary section created as
+            a placeholder for new content, that is now adding confusion.<p>TO RESOLVE 15 May 2026: I
+                think the top level sections within this section should be merged into the more
+                general "DITA processing" section.</p></draft-comment>
+    </conbody>
 </concept>

--- a/specification/archSpec/base/dita-maps-and-their-usage.dita
+++ b/specification/archSpec/base/dita-maps-and-their-usage.dita
@@ -18,6 +18,12 @@
         looking at the 104 references to "linking".)"</p>
       <p>Can we please add a related link [from the related-links topic] to
         the related-links section of the spec?</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 11 May 2026: Sure, add a link. I've now
+                    gone through the full "topic wish list" from this page, we still need to check
+                    that it doesn't overlap with all the sections called out below, then delete the
+                    TODO section and table.</draft-comment>
+            </p>
     </draft-comment>
 <section>
 <title>TODO: Current topics with applicable content</title>

--- a/specification/archSpec/base/ditaaddressing.dita
+++ b/specification/archSpec/base/ditaaddressing.dita
@@ -4,11 +4,15 @@
 <concept id="id" xml:lang="en-us">
  <title>DITA addressing</title>
   <abstract>
-    <shortdesc><ph conkeyref="reuse-general/addressing-shortdesc"
-      /></shortdesc>
+    <shortdesc><ph conkeyref="reuse-general/addressing-shortdesc"/></shortdesc>
     <draft-comment author="Kristen J Eberlein" time="01 March 2022">
       <p>This needs a complete redo to be an effective introduction to the
         current content.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: suggest asking our magic robot for
+          a good overview, and if it cannot give us a good starting point for the content, just go
+          with what we have.</draft-comment>
+      </p>
     </draft-comment>
   </abstract>
 </concept>

--- a/specification/archSpec/base/ditamap-attributes.dita
+++ b/specification/archSpec/base/ditamap-attributes.dita
@@ -26,15 +26,18 @@
 		</metadata>
 	</prolog> 
   <conbody>
-		<draft-comment author="rodaande">We currently redefine a lot of
-      attributes in this topic that are more comprehensively defined in the
-      element reference; we need to reconcile those that are defined
-      differently and ideally reuse definitions.<div>
-        <p>Kris Eberlein, 28 September 2022</p>
-        <p>I alphabeticized the attributes in this topic. I also added them
-          to draft comments in the definitions in the "Attributes" topics,
-          so that we could consider them side-by-side.</p>
-      </div></draft-comment> 
+		<draft-comment author="rodaande">We currently redefine a lot of attributes in this topic that are
+			more comprehensively defined in the element reference; we need to reconcile those that
+			are defined differently and ideally reuse definitions.<div>
+				<p>Kris Eberlein, 28 September 2022</p>
+				<p>I alphabeticized the attributes in this topic. I also added them to draft
+					comments in the definitions in the "Attributes" topics, so that we could
+					consider them side-by-side.</p>
+			</div><p>
+				<draft-comment author="robander">TO RESOLVE 11 May 2026: compare side-by-side, set
+					up conref level reuse if we can, and if not, just make sure they do not conflict
+					and move on.</draft-comment>
+			</p></draft-comment> 
 	 <section id="mostly-map">
 			<p>DITA maps often encode structures that are specific to a particular medium or output, for
 				example, Web pages or a PDF document. Attributes, such as
@@ -42,6 +45,11 @@
 				processors interpret the DITA map for each kind of output.</p>
 			<draft-comment author="Kristen J Eberlein" time="04 July 2019" audience="spec-editors">
 				<p>The following paragraph seems off ...</p>
+				<p>
+					<draft-comment author="robander">TO RESOLVE 11 May 2026: I think I know what it
+						was going for, but at this point I think just delete the
+						paragraph</draft-comment>
+				</p>
 			</draft-comment>
 			<!--IGNORE may-must-should word-->
 			<p>Many of the following attributes are not available in DITA topics; individual topics,

--- a/specification/archSpec/base/ditamarkup.dita
+++ b/specification/archSpec/base/ditamarkup.dita
@@ -17,6 +17,10 @@
    <!--IGNORE may-must-should word-->
    <p>This is not the final location for this content, nor is the umbrella title of "DITA markup"
     the correct title. Thoughts on where this content should go very welcome ...</p>
+   <p>
+    <draft-comment author="robander">TO RESOLVE 11 May 2026: I can't find this topic used in our
+     current hierarchy. Suggest deleting from the repo.</draft-comment>
+   </p>
   </draft-comment>
  </conbody>
 </concept>

--- a/specification/archSpec/base/document-type-shells.dita
+++ b/specification/archSpec/base/document-type-shells.dita
@@ -46,6 +46,10 @@
 		<draft-comment author="Kristen J Eberlein" time="28 March 2021">
 			<p>The illustration needs to be updated to include expansion modules.</p>
       <p>WEK 15 Oct 2022: Updated image source PPTX and PNG file</p>
+			<p>
+				<draft-comment author="robander">TO RESOLVE 11 May 2026: I think this is
+					done?</draft-comment>
+			</p>
 		</draft-comment> 
 	 <p>The DITA specification contains a starter set of document-type shells. These document-type
 			shells are commented and can be used as templates for creating custom document-type

--- a/specification/archSpec/base/dtd-coding-requirements-expansion-modules.dita
+++ b/specification/archSpec/base/dtd-coding-requirements-expansion-modules.dita
@@ -69,6 +69,12 @@
                                     entities, sectionDesc-d-p-expansion and sectionDesc - that seems
                                     like a leftover extra entity from the domain days that does not
                                     really make sense here?"</p>
+                                <p>
+                                    <draft-comment author="robander">TO RESOLVE 11 May 2026: I want
+                                        to delete the extra "expansion" entity, I think it's not
+                                        used for anything now that we got rid of
+                                            <xmlatt>domains</xmlatt></draft-comment>
+                                </p>
                             </draft-comment>
                             <p>When the content model for <xmlelement>section</xmlelement> is
                                 redefined in the expansion module, it references the parameter
@@ -96,6 +102,12 @@
                                     why do we use the "expansion" entity and not the element name? I
                                     would expect the element name here with the other element
                                     names."</p>
+                                <p>
+                                    <draft-comment author="robander">TO RESOLVE 11 May 2026: We
+                                        should switch this to use the element name, it should work
+                                        like other specialized elements in a content
+                                        model</draft-comment>
+                                </p>
                             </draft-comment>
                             <p>Note that this expansion module also constrains the content model of
                                     <xmlelement>section</xmlelement> to only include certain block

--- a/specification/archSpec/base/evaluating-conditional-processing-attributes.dita
+++ b/specification/archSpec/base/evaluating-conditional-processing-attributes.dita
@@ -30,7 +30,10 @@
       (since it applies to extendedProd). The second list item is still included; even though it
       does apply to extendedProd, it also applies to basicProd, which was not excluded.</p>
     <draft-comment author="rodaande" time="21 March 2022">Probably want the following bit to become
-      a screen capture</draft-comment>
+      a screen capture<p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: If someone wants to put in a screen
+          capture, great, otherwise just go with this</draft-comment>
+      </p></draft-comment>
   <p>The result will look something like the following: <fig>
         <p><b>ADMIN</b> Set the configuration options: <ul>
             <li>Set your blink rate</li>

--- a/specification/archSpec/base/example-chunk-managing-links.dita
+++ b/specification/archSpec/base/example-chunk-managing-links.dita
@@ -203,6 +203,14 @@
               <li>A need to have unambiguous links to each instance of the
                 topic</li>
             </ul></p>
+          <p>
+            <draft-comment author="robander">TO RESOLVE 11 May 2026: Within the context – this is a
+              paragraph about how implementations can do their own thing. So if you need
+              "unambiguous" resolution across different implementations, you can't rely on that and
+              need to consider alternate reuse mechanisms. We can rephrase to just say "...and
+              unambiguous links to those split topics that resolve the same way across all DITA
+              implementations"</draft-comment>
+          </p>
         </draft-comment>
       </p>
     </fig>

--- a/specification/archSpec/base/example-contraints-correct-machinery-task-constraint.dita
+++ b/specification/archSpec/base/example-contraints-correct-machinery-task-constraint.dita
@@ -11,7 +11,10 @@
    <draft-comment author="robander">Is this example still relevant in DITA 2.0? It can still be
     valid as an example, but I think earlier examples cover the same type of update, and we no
     longer need to "fix" the machinery task in 2.0. If it is still necessary, it probably needs to
-    be moved out of the base.</draft-comment>
+    be moved out of the base.<p>
+     <draft-comment author="robander">TO RESOLVE 11 May 2026: Recommend deleting this
+      example</draft-comment>
+    </p></draft-comment>
    <note>This example assumes that the information architect has already implemented her own
     document-type shell for the machinery task information type.</note>
    <ol>

--- a/specification/archSpec/base/example-ditaval-subjectscheme.dita
+++ b/specification/archSpec/base/example-ditaval-subjectscheme.dita
@@ -8,6 +8,10 @@
     <draft-comment author="rodaande">Show a ditaval doc and subject scheme - for example, ditaval
       that excludes "windows" and subject scheme that makes that cover "win2000 / winvista" etc. Or
       maybe we should just conref in the full example from <xref
-        href="processing-controlled-attribute-values.dita"/></draft-comment>
+        href="processing-controlled-attribute-values.dita"/><p>
+        <draft-comment author="robander">TO RESOLVE 11 May 2026: Is it allowed for us to briefly
+          describe the situation, and then link to that other topic, rather than extending our page
+          count by reusing the entire example. I would suggest doing that.</draft-comment>
+      </p></draft-comment>
   </conbody>
 </concept>

--- a/specification/archSpec/base/example-of-an-index-range.dita
+++ b/specification/archSpec/base/example-of-an-index-range.dita
@@ -36,18 +36,23 @@
         range would continue to the end of the map.</p>
       <draft-comment author="Eliot Kimber" time="09 August 2019">I think this should be a reportable
         error or warning since it's almost certainly not the author's intent for a range to span to
-        the end of the publication.</draft-comment>
-      <draft-comment author="Kristen J Eberlein" time="13 August 2019">
-        <p>Eliot, I disagree. If the map is a submap that is consumed by a larger publication (for
-          example, a map of examples of using keys), I think the default range boundary of "end of
-          the map" might be entirely appropriate.</p>
-        <p>Also, this is example is stating behavior about ranges defined in maps that we do not lay
-          out in <xref href="index-ranges.dita"/> – in particular, that the presence of an end
-          element in a map signifies that the end-of-the-range is the <b>end</b> of the topic that
-          contains the end element. This makes good sense to me, but it conflicts with the usual
-          expectation that an <xmlelement>indexterm</xmlelement> element in a map (or prolog) is a
-          point reference to the start of the topic title.</p>
-      </draft-comment>
+        the end of the publication.<p>
+          <draft-comment author="Kristen J Eberlein" time="13 August 2019">
+            <p>Eliot, I disagree. If the map is a submap that is consumed by a larger publication
+              (for example, a map of examples of using keys), I think the default range boundary of
+              "end of the map" might be entirely appropriate.</p>
+            <p>Also, this is example is stating behavior about ranges defined in maps that we do not
+              lay out in <xref href="index-ranges.dita"/> – in particular, that the presence of an
+              end element in a map signifies that the end-of-the-range is the <b>end</b> of the
+              topic that contains the end element. This makes good sense to me, but it conflicts
+              with the usual expectation that an <xmlelement>indexterm</xmlelement> element in a map
+              (or prolog) is a point reference to the start of the topic title.</p>
+          </draft-comment>
+          <draft-comment author="robander">TO RESOLVE 11 May 2026: Recommend we keep this example
+            and paragraph as-is, but add a sentence (or add a clause to this sentence) saying that a
+            processor could report the missing end range (because a processor could totally choose
+            to do that)</draft-comment>
+        </p></draft-comment>
     </section>
     </conbody>
 </concept>

--- a/specification/archSpec/base/example-of-nested-indexterm-elements.dita
+++ b/specification/archSpec/base/example-of-nested-indexterm-elements.dita
@@ -5,8 +5,12 @@
   <shortdesc>This example contains a multilevel <xmlelement>indexterm</xmlelement>
     element.</shortdesc>
   <conbody>
-    <draft-comment author="Kristen J Eberlein" time="12 August 2024">Do we
-      want to keep or jettison this topic? Enhance it?</draft-comment>
+    <draft-comment author="Kristen J Eberlein" time="12 August 2024">Do we want to keep or jettison
+      this topic? Enhance it?<p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: recommend dropping the topic, it is
+          not linked in any map, and the only link *to* it is from a draft comment in
+          "merging-index-elements.dita"</draft-comment>
+      </p></draft-comment>
     <p>Given the following <xmlelement>indexterm</xmlelement> elements:</p>
     <codeblock>&lt;indexterm>cheese
   &lt;indexterm>sheeps milk

--- a/specification/archSpec/base/example-rng-constraints-redefine-content-model.dita
+++ b/specification/archSpec/base/example-rng-constraints-redefine-content-model.dita
@@ -57,6 +57,11 @@
             cover that in the coding requirements topic. If people start
             with copying-and-pasting from the module that they are
             overriding, they won't have that and will get errors.</p>
+          <p>
+            <draft-comment author="robander">TO RESOLVE 12 May 2026: we cover it for attribute
+              lists. Recommend updating the "overview of coding requirements" for RNG, and add a
+              comment about how it is used, then delete this draft comment.</draft-comment>
+          </p>
         </draft-comment></li>
       <li><ph rev="2.0">They then integrate</ph> the constraint module into
         the document-type shell for topic by adding an

--- a/specification/archSpec/base/example-subjectrefs-attribute-with-key-scopes.dita
+++ b/specification/archSpec/base/example-subjectrefs-attribute-with-key-scopes.dita
@@ -9,6 +9,10 @@
       <p>The following is content that Eliot Kimber suggested be included
         in the DITA 2.0 specification as part of the review of proposal
         #647. It has not been edited.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: do an editing pass and then mark it
+          ready for larger TC review</draft-comment>
+      </p>
     </draft-comment>
     <p>A subject scheme map may be included in a map as either a normal sub
       map or as a peer root map and associated with a key scope on the map

--- a/specification/archSpec/base/expansion-modules-processing-and-interoperability.dita
+++ b/specification/archSpec/base/expansion-modules-processing-and-interoperability.dita
@@ -20,6 +20,22 @@
             <p>And what happens if one wants to apply multiple expansion modules and a constraint to
                 an element type? I'm assuming that they would need to be aggregated into a single
                 element-configuration module.</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: <ul id="ul_ofx_gct_fjc">
+                        <li>why? I'd say - why not? if you have an expansion module for @thing1, and
+                            a module for @thing2, both DTD and RNG let you add them independently.
+                            This is because you can have multiple attribute definitions, they are
+                            all combined to create the set of attributes. We should not restrict
+                            this. (We cannot prevent it, and shouldn't say it's invalid.)</li>
+                        <li>For content models - yes, they must be combined, because unlike with
+                            attributes you only have one spot to declare the content model. So if
+                            you want to add 2 things into &lt;section> or &lt;body>, you have one
+                            spot to redeclare that content model.</li>
+                    </ul><p>It looks like we used to say this in the following commented-out
+                        paragraph. I'd suggest either restoring that paragraph, maybe with an edit,
+                        or just keep the current language and resolve the comment, because it's just
+                        how grammar files work.</p></draft-comment>
+            </p>
         </draft-comment>
         <!--<p>The attributes of an element may be contributed to from any number of attribute domain mix-in modules. However, only one constraint module may be applied to the attributes of a given element type. If multiple constraints need to be applied to a given element's attributes, they must be replaced by a new constraint that aggregates them together.</p>-->
         <p>Constraint modules cannot remove attributes that are contributed by expansion

--- a/specification/archSpec/base/extending-a-subject-scheme.dita
+++ b/specification/archSpec/base/extending-a-subject-scheme.dita
@@ -11,13 +11,16 @@
    are extended by the current subject-scheme map. The values in the referenced subject-scheme map
    are merged with the values in the current subject-scheme map; the result is equivalent to
    specifying all of the values in a single subject scheme map.</p>
-    <draft-comment author="Kristen J Eberlein" time="05 December 2021">I
-      think we need to make a normative statement about this for DITA 2.0.
-      I realize that doing so would require developing detailed content
-      about processing subject scheme maps, since they have different
-      processing expectations than DITA maps in general. Also, see the
-      following draft comment (from the 1.3 time frame), which had been
-      commented out of this topic.</draft-comment>
+    <draft-comment author="Kristen J Eberlein" time="05 December 2021">I think we need to make a
+      normative statement about this for DITA 2.0. I realize that doing so would require developing
+      detailed content about processing subject scheme maps, since they have different processing
+      expectations than DITA maps in general. Also, see the following draft comment (from the 1.3
+      time frame), which had been commented out of this topic.<p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: I almost think we should just go
+          with the statement above and leave this as-is, and not place new rules / new restrictions
+          on schemeref. We state above how it works, restating it with a normative THIS IS HOW IT
+          SHOULD HAPPEN won't change any processors.</draft-comment>
+      </p></draft-comment>
     <draft-comment author="Kristen Eberlein" time="5 February 2015">
       <p>I added this topic to address comments made by Chris Nitchie in
         the targeted review. FYI, the paragraph above was in the DITA 1.2
@@ -36,6 +39,12 @@
         Chris stated " ... the use of keyref in subject schemes to
         recombine subject definitions is never covered anywhere."</p>
       <p>We need additional normative content in this topic ...</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: Agree this isn't how keys work
+          anywhere, keys were terribly overloaded with subject schemes but it's too late to change
+          that. I think the text above may suffice (again) for how to handle
+          schemeref.</draft-comment>
+      </p>
     </draft-comment>
  </conbody>
 </concept>

--- a/specification/archSpec/base/flagging.dita
+++ b/specification/archSpec/base/flagging.dita
@@ -30,6 +30,10 @@
           <xmlelement>style-conflict</xmlelement> topic, where it did not
         belong. It's general information about how processors should handle
         flagging.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: I think no action is needed, can
+          remove this draft comment</draft-comment>
+      </p>
     </draft-comment>
     <p><ph rev="review-m">When</ph> flagging methods are specified for
       elements at different levels of the containment hierarchy, the

--- a/specification/archSpec/base/index-ranges.dita
+++ b/specification/archSpec/base/index-ranges.dita
@@ -88,6 +88,11 @@
 &lt;indexterm>Potato
   &lt;indexterm end="yellow"/>
 &lt;indexterm></codeblock>
+            <p>
+              <draft-comment author="robander">TO RESOLVE 12 May 2026: Try to come up with a simple
+                wording tweak to describe it based on our understanding from long
+                ago</draft-comment>
+            </p>
           </draft-comment></li>
                 <li>When index ranges with the same identifier overlap, <ph
             rev="review-1">the effective range is determined by matching

--- a/specification/archSpec/base/introduction-to-dita.dita
+++ b/specification/archSpec/base/introduction-to-dita.dita
@@ -29,6 +29,21 @@
                 non-normative  – and point users to the normative coverage of the topic.</p>
             <p>In a parallel move, I think we'll need to move coverage of critical DITA attributes
                 into a more prominent place in the spec.</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: Not sure how best to
+                    resolve this. I don't think we need to explicitly declare "non-normative" just
+                    because it's giving an overview rather than normative RFC rules – most of the
+                    spec isn't made up of RFC rules.<p>We could<ul id="ul_svb_dj5_fjc">
+                            <li>Run a magic robot across it and see if this information is
+                                duplicated elsewhere</li>
+                            <li>If so, either reuse by conref, or make sure that the wording is
+                                consistent, or replace with pointers</li>
+                            <li>and leave it at that, as long as the info is accurate we keep it
+                                here</li>
+                            <li>The critical attributes bit already has additional draft comments
+                                specific to that section</li>
+                        </ul></p></draft-comment>
+            </p>
         </draft-comment>
     </conbody>
 </concept>

--- a/specification/archSpec/base/linking-and-addressing-terms.dita
+++ b/specification/archSpec/base/linking-and-addressing-terms.dita
@@ -41,7 +41,12 @@
                         rephrase something like this, but not sure where to put the "such as" here:
                             <p>An attribute that specifies an address or a that specifies key that
                             resolves to an address.</p><p>or maybe</p><p>An attribute that specifies
-                            an address or that specifies a key.</p></draft-comment></dd>
+                            an address or that specifies a key.</p><p>
+                            <draft-comment author="robander">TO RESOLVE 12 May 2026: how about "An
+                                attribute that specifies an address, such as conref and href, or
+                                specifies an indirect reference to an address, such as conkeyref and
+                                keyref"</draft-comment>
+                        </p></draft-comment></dd>
             </dlentry>
         </dl>
     </conbody>

--- a/specification/archSpec/base/links-between-maps.dita
+++ b/specification/archSpec/base/links-between-maps.dita
@@ -16,6 +16,10 @@
       <p>When this topic is reviewed, we should also check the definition
         of <codeph>scope="peer"</codeph> in the <xmlatt>scope</xmlatt>
         topic.</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: I suppose, just make sure
+                    we're consistent with language in that topic</draft-comment>
+            </p>
     </draft-comment>
   <p>The keys that are defined by the peer map belong to <ph >any key scopes
                 that are</ph> declared on the <xmlelement>topicref</xmlelement> element that
@@ -31,6 +35,11 @@
         <draft-comment author="Kristen J Eberlein" time="04 July 2019" audience="tc-reviewers">
             <p>Should the following statement about what processors do "when a reference to a peer
                 map cannot be resolved" contain RFC-2119 language?</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: I don't think so, because
+                    resolution is up to them, and it's meaningless to say processors MAY or SHOULD
+                    recover any way they wish</draft-comment>
+            </p>
         </draft-comment>
         <!--IGNORE may-must-should word-->
   <p>Note the inverse implication; if the peer map is not available, then it is impossible to

--- a/specification/archSpec/base/merging-index-elements.dita
+++ b/specification/archSpec/base/merging-index-elements.dita
@@ -34,6 +34,13 @@
                         href="example-of-nested-indexterm-elements.dita"/>)</li>
             </ul>
             <p>What are other critical aspects?</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: I can't find a reference to
+                    this anywhere in the base spec. I can't remember what prompted it, but if it
+                    goes in, we need to review for accuracy, not sure we want to put much more work
+                    in beyond that<p>But to resolve, we need to first determine where this topic
+                        goes and insert it into the map</p></draft-comment>
+            </p>
         </draft-comment>
         <draft-comment author="Kristen J Eberlein" time="08 July 2019">
             <p>Do we make the following RFC-2119 statement for DITA 2.0. Thoughts?</p>
@@ -41,6 +48,10 @@
                     the same content are ″merged″ to form a single index entry in the resulting
                     index, and all contributed page numbers are included in that index
                 entry.</q></p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: Don't care, can make it, or
+                    can say that processors can do this and leave it up to them</draft-comment>
+            </p>
         </draft-comment>
         <p>(For processors that support indexing) If multiple <xmlelement>indexterm</xmlelement>
             elements exist that would result in matching index entries, a processor <term
@@ -51,6 +62,11 @@
             <p>This is the correct behavior. By "identical content" is a little too strict. Probably
                 need to say something like "content that the processor considers to be the same. For
                 example, by normalizing white space."</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: Same as above, I dont'
+                    really care if it is normative, just needs a bit of a wording
+                    tweak</draft-comment>
+            </p>
         </draft-comment>
         <draft-comment author="Kristen J Eberlein" time="13 August 2019">
             <p>Eliot raised the following scenario in his review of the indexing content:</p>
@@ -89,6 +105,15 @@ apple
             <p>If a company's styleguide does not want locators on parents of leaf nodes, I'd expect
                 authors to spend time "massaging" index markup in order to generate an index that
                 followed the styleguide requirements.</p>
+            <p>
+                <draft-comment author="robander">TO RESOLVE 12 May 2026: Do we really want to lay
+                    out all possible options, or just leave this up to processors? If we want to lay
+                    out these options, then we should say that processors can choose how
+                    primary/secondary entries like this are combined, and give all three as examples
+                    of valid cases. I think either 1 or 2 are both perfectly valid, number 3 is
+                    valid if your style guide says "don't do this", and there could be other options
+                    for other formats</draft-comment>
+            </p>
         </draft-comment>
     </conbody>
 </concept>

--- a/specification/archSpec/base/metadata-in-maps-and-topics.dita
+++ b/specification/archSpec/base/metadata-in-maps-and-topics.dita
@@ -24,7 +24,9 @@
     <draft-comment author="rodaande" time="8 Feb 2022">We should have a related link from this topic
       to the section on cascading; this is a conceptual topic about metadata and should not repeat
       the processing rules, but reading this I immediately want to know *which* elements cascade and
-      how that works.</draft-comment>
+      how that works.<p>
+        <draft-comment author="robander">TO RESOLVE 12 May 2026: Add that link</draft-comment>
+      </p></draft-comment>
     <p>When the same metadata element or attribute is specified in both a
       map and a topic, by default the value in the map takes precedence<ph
         rev="review-k">. The assumption</ph> is that the <ph rev="review-k"

--- a/specification/archSpec/base/processing-keyref-for-text.dita
+++ b/specification/archSpec/base/processing-keyref-for-text.dita
@@ -55,7 +55,10 @@
                         &lt;lq> for a while now. Based on discussion at today's TC (1 june 2021)
                         this would be interpreted as the title of the source of the quotation - thus
                         the removal of href/reftitle. OK to update accordingly, or does that need
-                        further confirmation from TC?</draft-comment>
+                        further confirmation from TC?<p>
+                            <draft-comment author="robander">TO RESOLVE 12 May 2026: Just update
+                                based on that understanding from 2021</draft-comment>
+                        </p></draft-comment>
                 </dd>
             </dlentry>
             <dlentry>

--- a/specification/archSpec/base/relax-ng-coding-constraint-modules.dita
+++ b/specification/archSpec/base/relax-ng-coding-constraint-modules.dita
@@ -42,7 +42,10 @@
         <p>For a more complete example, see <filepath>strictTaskbodyConstraintMod.rng</filepath>,
           delivered with the DITA 1.3 grammar files.</p>
         <draft-comment author="robander">Need to update the above example statement for 2.0 to refer
-          to the correct name of the tech comm 2.0 spec.</draft-comment>
+          to the correct name of the tech comm 2.0 spec.<p>
+            <draft-comment author="robander">TO RESOLVE 13 May 2026: Update to read "delivered with
+              the DITA 2.0 Technical Content specification."</draft-comment>
+          </p></draft-comment>
       </div>
     </section>
     <section>
@@ -87,6 +90,11 @@
                   <filepath>topicMod.rng</filepath>.</p>
               <draft-comment author="Kristen J Eberlein" time="07 April 2021">
                 <p>Need an example of this</p>
+                <p>
+                  <draft-comment author="robander">TO RESOLVE 13 May 2026: If someone wants to
+                    create this example, great, otherwise we leave it out as we did in
+                    1.3</draft-comment>
+                </p>
               </draft-comment>
             </div>
           </dd>

--- a/specification/archSpec/base/specialization-class-attribute.dita
+++ b/specification/archSpec/base/specialization-class-attribute.dita
@@ -103,6 +103,15 @@
         <p>In addition, it would benefit by an edit that started by asking
           "What exactly are we trying to convey here? What are the critical
           points?</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Ensure this goes into the
+            generalization review<p>What it's trying to convey: specifically, that you can
+              specialize new elements within a module that don't come from base, and don't come off
+              of a new element in the intermediate module. When doing that, you have to say what the
+              element was in the intermediate module. Basically, the class attribute needs to have a
+              token for every module that led to this module (regardless of whether the element name
+              changed along the way).</p></draft-comment>
+        </p>
       </draft-comment>
       <p>The following code sample shows the value of a <xmlatt>class</xmlatt> attribute for an
         element in the guiTask module, which is specialized from <xmlelement>task</xmlelement>. The

--- a/specification/archSpec/base/specialization-rules-elements.dita
+++ b/specification/archSpec/base/specialization-rules-elements.dita
@@ -23,6 +23,12 @@
             <p>Robert Anderson and I both think that the 2nd bullet point
               needs expansion, to cover the effects of expansion
               modules.</p>
+            <p>
+              <draft-comment author="robander">TO RESOLVE 13 May 2026: Can we add a sentence to that
+                same bullet, something like: "When using expansion modules to add a new element to
+                the content model, the generalized form of any new element is also allowed in the
+                original content model.</draft-comment>
+            </p>
           </draft-comment>
           <ul>
             <li>A properly-formed <xmlatt>class</xmlatt> attribute that
@@ -61,6 +67,12 @@
       prefix on all names.</note>
     <draft-comment author="Kristen J Eberlein" time="31 August 2022">
       <p>We should consider moving the above note elsewhere.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 13 May 2026: At this point, I'd be fine leaving
+          it here, but maybe change the use of "should", like "When domain modules are intended for
+          wide use, it is a good idea to reduce conflicts with other domains by giving elements very
+          specific names or using domain-specific prefixes on all names.</draft-comment>
+      </p>
     </draft-comment>
   </conbody>
 </concept>

--- a/specification/archSpec/base/subjectSchema.dita
+++ b/specification/archSpec/base/subjectSchema.dita
@@ -61,6 +61,11 @@
         resolve as text or links" -- in a way that is clear, accurate, and
         short enough that it actually gets read. So, I think we need some
         work on this paragraph.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 13 May 2026: Can we take out the however, and
+          maybe have a new paragraph instead of a second sentence, saying that keys bound to a
+          controlled value do not typically result in links or generated text.</draft-comment>
+      </p>
     </draft-comment>
     </conbody>
 </concept>

--- a/specification/archSpec/base/the-key-scope-attribute.dita
+++ b/specification/archSpec/base/the-key-scope-attribute.dita
@@ -26,7 +26,11 @@
         to merge with existing key scope rules to ensure no duplication / no conflicting
           content.<p>Update Oct 14 2021: there is now a longer example of the non-intersecting
           behavior in <xref href="example-scoped-key-name-conflicts.dita"/> so probably want to
-          remove the simpler example from this page</p></draft-comment>
+          remove the simpler example from this page</p><p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: No strong opinion here; could
+            remove the example or leave it to have something useful in context. Could also add a
+            related link back/forth between the two topics.</draft-comment>
+        </p></draft-comment>
       <p id="non-intersecting">All key scopes are contiguous and non-intersecting. Within a root
         map, two distinct key scopes with the same name have no relationship with each other aside
         from that implied by their relative locations in the key scope hierarchy. They do not, for

--- a/specification/archSpec/base/theformatattribute.dita
+++ b/specification/archSpec/base/theformatattribute.dita
@@ -73,6 +73,17 @@
             <p>I think we need to have an example of the expected
               processing behaviour. I think it is a good candidate for the
               new chapter on "DITA map processing".</p>
+            <p>
+              <draft-comment author="robander">TO RESOLVE 13 May 2026: Not sure which example was
+                being requested here, but I think<ol id="ol_fjn_djz_fjc">
+                  <li>The previous paragraph references reltable behavior; I think we should take
+                    out that line and instead reference the new topic on relationship tables, which
+                    describes this rule. We already have it there + in reltable elementref topic,
+                    and should take out this third description of the rule.</li>
+                  <li>The following paragraph mentions a behavior that is undefined, so I don't
+                    think we need an example of expected processing?</li>
+                </ol></draft-comment>
+            </p>
           </draft-comment>
         </dd>
         <dd>

--- a/specification/archSpec/base/thekeyrefattribute.dita
+++ b/specification/archSpec/base/thekeyrefattribute.dita
@@ -22,7 +22,15 @@
      <li>Overlap with existing content - likely needs to merge, definitely remove duplication</li>
      <li>This topic uses a key and the langRef links to it from the definition for @keyref, so if
       this topic goes away, be sure to update that keyref</li>
-    </ul></draft-comment>
+    </ul><p>
+     <draft-comment author="robander">TO RESOLVE 13 May 2026: Looking at the TOC, it's probably fine
+      to keep a topic here about the keyref attribute, but maybe we should update the title to
+      "About the..." or "Using the..." or "Referencing a key name with the..."? Same goes for the
+      topic a bit further down, "The keyscope attribute"<p>Also, based on discussion at the TC
+       meeting May 12 2026, assuming we stick with the conclusion at that meeting that keyref can
+       only go to topics (from map) or topics + subelements (from topic), we should definitely call
+       that out here.</p></draft-comment>
+    </p></draft-comment>
    <p>For elements that only refer to topics or non-DITA resources, the value of the
      <xmlatt>keyref</xmlatt> attribute is a key name. For elements that <ph 
      >can</ph> refer to elements within maps or topics, the value of the <xmlatt>keyref</xmlatt>

--- a/specification/archSpec/base/thekeysattribute.dita
+++ b/specification/archSpec/base/thekeysattribute.dita
@@ -23,7 +23,10 @@
     needs to be here as it defines normative rules about the syntax of a key attribute. The
     following paragraph comes from reuse-general but in the base spec this is the only use, so
     should probably be taken out of the reuse file. Need to go over this section more closely now
-    that attribute content has moved here.</draft-comment>
+    that attribute content has moved here.<p>
+     <draft-comment author="robander">TO RESOLVE 13 May 2026: Move from "reuse" to just use it here,
+      and do a quick edit pass to get this ready for TC review.</draft-comment>
+    </p></draft-comment>
    <p conkeyref="reuse-general/keys-attribute-syntax"/>
    <p>A key <ph >cannot</ph> resolve to sub-topic elements, although a
      <xmlatt>keyref</xmlatt> attribute <ph >can</ph> do so by combining a key

--- a/specification/common/reuse-w-lwdita/reuse-map.dita
+++ b/specification/common/reuse-w-lwdita/reuse-map.dita
@@ -20,6 +20,12 @@
         <p>And then the example should illustrate not just a DITA map
           creating navigational hierarchy, but also a map that references a
           key-definition map.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: At this point I would probably
+            leave this as-is – it doesn't discuss keyref but it also doesn't discuss href. I think
+            it's acceptable for the map to discuss how it creates these relationships between
+            topics, without discussing the specifics of how to address those topics.</draft-comment>
+        </p>
       </draft-comment>
       <div platform="dita">
         <p>A map describes the relationships among a set of DITA topics.
@@ -58,6 +64,13 @@
             titles are rendered; certainly users get confused about this.
             And do we cover processing expectations for submaps
             somewhere?</p>
+          <p>
+            <draft-comment author="robander">TO RESOLVE 13 May 2026: There is a new topic about this
+              specific issue. We should add a cross reference to it here, in the following paragraph
+              that is already filtered for just the base specification / not lwdita. I would leave
+              the lwdita one alone, unless / until the lwdita spec adds a version of the same
+              topic.</draft-comment>
+          </p>
         </draft-comment>
         <p platform="dita">The <xmlelement>title</xmlelement> element can
           be used to provide a title for the map. In some scenarios the

--- a/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicmeta.dita
@@ -30,12 +30,20 @@
           specify metadata about the entire map or for specific topic
           references? I think that would be useful for readers of the
           LwDITA spec.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: How about a follow up paragraph,
+            applicable to both specs, that just … says that? "Metadata specified using this (element
+            / component) can be used at the map level for metadata that is applicable to the entire
+            map, or at the topic reference level for metadata that applies a topic or branch of a
+            map."</draft-comment>
+        </p>
       </draft-comment>
     </section>
     <section id="attributes">
       <title>Attributes</title>
       <div platform="dita">
-        <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
+        <p>The following attributes are available on this element: <ph
+            conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </div>
       <div conkeyref="reuse-lwdita-attributes/topicmeta" platform="lwdita"/>
     </section>

--- a/specification/common/reuse-w-lwdita/reuse-topicref.dita
+++ b/specification/common/reuse-w-lwdita/reuse-topicref.dita
@@ -20,7 +20,11 @@
             keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>.</p>
         <draft-comment author="robander" time="27 Sept 2022">Updated style here to match the common
           attribute style, but still need to make sure the href topic is updated with the same info
-          in arch spec.</draft-comment>
+          in arch spec.<p>
+            <draft-comment author="robander">TO RESOLVE 13 May 2026: Double check the linked topic
+              to ensure content is consistent, update to reuse content with conref if possible, and
+              move on.</draft-comment>
+          </p></draft-comment>
         <p>For this element, the <xmlatt>href</xmlatt> attribute references the resource that is
           represented by the <xmlelement>topicref</xmlelement>. See <xref keyref="attributes-href"/>
           for detailed information on supported values and processing implications. References to

--- a/specification/introduction/written-specification.dita
+++ b/specification/introduction/written-specification.dita
@@ -15,7 +15,11 @@
     <conbody>
         <p>The specification contains several parts:</p>
         <draft-comment author="robander" audience="spec-editors" time="26 may 2021">Reminder to
-            adjust this to reflect the final organization / actual parts.</draft-comment>
+            adjust this to reflect the final organization / actual parts.<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: We can already update some
+                    of this but I think this draft comment will be one of the last resolved, when we
+                    are ready with the final structure and the names of each section</draft-comment>
+            </p></draft-comment>
         <ul>
             <li>Introduction</li>
             <li>Architectural specification</li>

--- a/specification/langRef/attributes/attribute-groups.dita
+++ b/specification/langRef/attributes/attribute-groups.dita
@@ -40,11 +40,9 @@
     <refbody>
     <section id="architectural-attributes" platform="dita lwdita">
       <title>Architectural attributes</title>
-      <p>This group contains a set of attributes that are defined for
-        document-level elements such as <xmlelement>topic</xmlelement> and
-          <xmlelement>map</xmlelement>. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-only" platform="lwdita"
-        /></p>
+      <p>This group contains a set of attributes that are defined for document-level elements such
+        as <xmlelement>topic</xmlelement> and <xmlelement>map</xmlelement>. <ph
+          conkeyref="reuse-lwdita-attributes/xdita-only" platform="lwdita"/></p>
       <dl>
         <dlentry conkeyref="attributes-common/DITAArchVersion">
           <dt/>
@@ -62,15 +60,17 @@
     </section>
     <section platform="dita lwdita" id="common-map-attributes">
       <title>Common map attributes</title>
-      <p id="common-map-attr">This group contains attributes that are
-        frequently used on map elements. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-hdita-only"
-          platform="lwdita"/></p>
+      <p id="common-map-attr">This group contains attributes that are frequently used on map
+        elements. <ph conkeyref="reuse-lwdita-attributes/xdita-hdita-only" platform="lwdita"/></p>
       <draft-comment author="Kristen J Eberlein" time="28 September 2022"
         platform="dita">
         <p>I've added draft comments to the attribute definitions in this
           section that explain how the attribute is defined in the "DITA
           map attributes" topic.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: I think there is nothing to
+            resolve here, can remove</draft-comment>
+        </p>
       </draft-comment>
       <dl>
         <dlentry conkeyref="attributes-common/cascade" platform="dita">
@@ -152,9 +152,8 @@
     </section>
     <section platform="dita lwdita" id="data-element-attributes">
       <title>Data-element attributes</title>
-      <p>This group contains attributes that are defined on the
-          <xmlelement>data</xmlelement> element and its specializations.
-          <ph conkeyref="reuse-lwdita-attributes/xdita-only"
+      <p>This group contains attributes that are defined on the <xmlelement>data</xmlelement>
+        element and its specializations. <ph conkeyref="reuse-lwdita-attributes/xdita-only"
           platform="lwdita"/></p>
       <dl>
         <dlentry conkeyref="attributes-common/datatype" platform="dita">
@@ -188,10 +187,8 @@
     </section>
     <section platform="dita lwdita" id="display-attributes">
       <title>Display attributes</title>
-      <p id="display-attr">This group contains attributes that affect the
-        rendering of many elements. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-only" platform="lwdita"
-        /></p>
+      <p id="display-attr">This group contains attributes that affect the rendering of many
+        elements. <ph conkeyref="reuse-lwdita-attributes/xdita-only" platform="lwdita"/></p>
       <dl>
         <dlentry conkeyref="attributes-common/expanse">
           <dt/>
@@ -209,10 +206,8 @@
     </section>
     <section platform="dita lwdita" id="id-attributes">
       <title>ID and conref attributes</title>
-      <p id="id-attr">This group contains the attributes that enable the
-        naming and referencing of elements. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-hdita-only"
-          platform="lwdita"/></p>
+      <p id="id-attr">This group contains the attributes that enable the naming and referencing of
+        elements. <ph conkeyref="reuse-lwdita-attributes/xdita-hdita-only" platform="lwdita"/></p>
       <dl>
         <dlentry conkeyref="attributes-universal/conaction" platform="dita">
           <dt/>
@@ -245,6 +240,11 @@
       <draft-comment author="Kristen J Eberlein" time="28 September 2002">
         <p>What is specialized from <xmlelement>include</xmlelement>? Both
           base (if any) and technical content ...</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Is this a suggestion that we list
+            the specializations here? They are all in the technical content spec: coderef, svgref,
+            mathmlref. We could list those but I don't think it is necessary.</draft-comment>
+        </p>
       </draft-comment>
       <dl>
         <dlentry conkeyref="attributes-common/encoding">
@@ -259,10 +259,9 @@
     </section>
     <section platform="dita lwdita" id="link-relationship-attributes">
       <title>Link relationship attributes</title>
-      <p id="link-relationship-attr">This group contains attributes whose
-        values can be used for representing navigational relationships. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-hdita-only"
-          platform="lwdita"/></p>
+      <p id="link-relationship-attr">This group contains attributes whose values can be used for
+        representing navigational relationships. <ph
+          conkeyref="reuse-lwdita-attributes/xdita-hdita-only" platform="lwdita"/></p>
       <dl>
         <dlentry conkeyref="attributes-common/format"
           platform="dita lwdita">
@@ -291,11 +290,14 @@
           definition is reused. Where it is not reused (because the
           definition in the archSpec topics is in a shortdesc), I've
           checked to ensure that wording is identical.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: I don't think there is any action
+            here, maybe change this to an XML comment?</draft-comment>
+        </p>
       </draft-comment>
-      <p id="localization-attr">This group contains the attributes that are
-        related to translation and localization. <ph
-          conkeyref="reuse-lwdita-attributes/xdita-hdita-only"
-          platform="lwdita"/></p>
+      <p id="localization-attr">This group contains the attributes that are related to translation
+        and localization. <ph conkeyref="reuse-lwdita-attributes/xdita-hdita-only" platform="lwdita"
+        /></p>
       <dl>
         <dlentry conkeyref="attributes-universal/dir">
           <dt/>

--- a/specification/langRef/attributes/commonAttributes.dita
+++ b/specification/langRef/attributes/commonAttributes.dita
@@ -102,6 +102,11 @@
                 element-reference topic, I want the attributes listed here
                 in the "Simple table group" to be hyperlinked to the actual
                 definition.</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Not following - what
+                  updated linking is needed? Should &lt;simpletable> link back to the element, or
+                  was there a problem with the links that brought you here?</draft-comment>
+              </p>
             </draft-comment>
             <p id="simpletable-attr">This group includes attributes that
               are defined only on the <xmlelement>simpletable</xmlelement>
@@ -242,25 +247,21 @@
           <dt id="attr-chunk"><xmlatt>chunk</xmlatt>
             <ph otherprops="attr-list-label">(common map
             attributes)</ph></dt>
-          <dd>Specifies how a processor should render a map or branch of a
-            map. <ph otherprops="examples">For example, it can be used to
-              specify that individual topic documents should be rendered as
-              a single document, or that a single document with multiple
-              topics should be rendered as multiple documents.</ph><p>The
-              following values are valid:<dl>
+          <dd>Specifies how a processor should render a map or branch of a map. <ph
+              otherprops="examples">For example, it can be used to specify that individual topic
+              documents should be rendered as a single document, or that a single document with
+              multiple topics should be rendered as multiple documents.</ph><p>The following values
+              are valid:<dl>
                 <dlentry>
                   <dt>combine</dt>
-                  <dd><ph conkeyref="reuse-general/definitionChunkCombine"
-                    /></dd>
+                  <dd><ph conkeyref="reuse-general/definitionChunkCombine"/></dd>
                 </dlentry>
                 <dlentry>
                   <dt>split</dt>
-                  <dd><ph conkeyref="reuse-general/definitionChunkSplit"
-                    /></dd>
+                  <dd><ph conkeyref="reuse-general/definitionChunkSplit"/></dd>
                 </dlentry>
-              </dl></p><p conkeyref="reuse-attributes/custom-attr-tokens"
-              /><p>For a detailed description of the <xmlatt>chunk</xmlatt>
-              attribute and its usage, see <xref
+              </dl></p><p conkeyref="reuse-attributes/custom-attr-tokens"/><p>For a detailed
+              description of the <xmlatt>chunk</xmlatt> attribute and its usage, see <xref
                 href="../../archSpec/base/chunking.dita"/>.</p></dd>
         </dlentry>
         <dlentry id="collection-type" platform="dita">
@@ -323,6 +324,11 @@
                           is undefined. </dd>
                       </dlentry>
                     </dl>
+                    <p>
+                      <draft-comment author="robander">TO RESOLVE 13 May 2026: Make sure nothing
+                        here conflicts, and add a link from this to the architectural
+                        section</draft-comment>
+                    </p>
                   </draft-comment><draft-comment
                     author="Kristen J Eberlein" time="28 September 2022">
                     <p>In the definitions of the supported values, do we
@@ -330,6 +336,18 @@
                       Since we specify that
                         <xmlatt>collection-type</xmlatt> specifies "how
                       topics <b>or links</b> relate to each other" ...</p>
+                    <p>
+                      <draft-comment author="robander">TO RESOLVE 13 May 2026: Good point, no strong
+                        feeling, but we should be consistent here, we already use "topics", "child
+                        topics", "children", and "referenced topics". Maybe:<ul id="ul_dbr_ylz_fjc">
+                          <li>Start with "Specifies how child topic references or links within the
+                            current element relate to each other"? Since this applies to children
+                            and we only sort of say that in the definitions of the tokens</li>
+                          <li>When describing the tokens, maybe use "referenced resources", as in
+                            "Indicates that the order of the referenced resources is not
+                            significant"</li>
+                        </ul></draft-comment>
+                    </p>
                   </draft-comment></dd>
               </dlentry>
             </dl></dd>
@@ -378,11 +396,10 @@
         </dlentry>
         <dlentry id="duplicates" platform="dita">
           <dt id="attr-duplicates"><xmlatt>duplicates</xmlatt></dt>
-          <dd>Specifies whether duplicate links are removed from a group of
-            links. Duplicate links are links that address the same resource
-            using the same properties, such as link text and link role. How
-            duplicate links are determined is processor-specific. The
-            following values are valid:<dl>
+          <dd>Specifies whether duplicate links are removed from a group of links. Duplicate links
+            are links that address the same resource using the same properties, such as link text
+            and link role. How duplicate links are determined is processor-specific. The following
+            values are valid:<dl>
               <dlentry>
                 <dt>yes</dt>
                 <dd>Specifies that duplicate links are retained.</dd>
@@ -391,19 +408,19 @@
                 <dt>no</dt>
                 <dd>Specifies that duplicate links are removed.</dd>
               </dlentry>
-              <dlentry conkeyref="reuse-attributes/ditauseconref"
-                platform="dita">
+              <dlentry conkeyref="reuse-attributes/ditauseconref" platform="dita">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>
-            </dl><p>The suggested processing default is
-                <keyword>yes</keyword> within
-                <xmlelement>linklist</xmlelement> elements and
-                <keyword>no</keyword> for other links.</p><draft-comment
-              author="robander" time="Dec 28 2021">"How duplicate links are
-              determined is processor-specific" ==> this should be included
-              in any updates to standardize language around "implementation
-              dependent".</draft-comment></dd>
+            </dl><p>The suggested processing default is <keyword>yes</keyword> within
+                <xmlelement>linklist</xmlelement> elements and <keyword>no</keyword> for other
+              links.</p><draft-comment author="robander" time="Dec 28 2021">"How duplicate links are
+              determined is processor-specific" ==> this should be included in any updates to
+              standardize language around "implementation dependent".<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Ugh, we still need to do
+                  this - a review of the spec for any wording that hits at this, and then make it
+                  specific. Maybe a magic robot can help find all instances here.</draft-comment>
+              </p></draft-comment></dd>
         </dlentry>
         <dlentry id="encoding">
           <dt id="attr-encoding"><xmlatt>encoding</xmlatt>
@@ -412,6 +429,10 @@
           <dd><draft-comment author="Kristen J Eberlein" time="29 April 2019"
               audience="spec-editors">
               <p>Can we replace "should" in the following definition?</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: we can change to
+                  "is"</draft-comment>
+              </p>
             </draft-comment>Specifies the character encoding to use when translating the character
             data from the referenced content. The value should be a valid encoding name. If not
             specified, processors may make attempts to automatically determine the correct encoding,
@@ -426,50 +447,41 @@
         <dlentry id="expanse">
           <dt id="attr-expanse"><xmlatt>expanse</xmlatt>
             <ph otherprops="attr-list-label">(display attributes)</ph></dt>
-          <dd>Specifies the horizontal placement of the element. The
-            following values are valid: <dl>
+          <dd>Specifies the horizontal placement of the element. The following values are valid: <dl>
               <dlentry>
                 <dt><keyword>column</keyword></dt>
-                <dd>Indicates that the element is aligned with the current
-                  column margin.</dd>
+                <dd>Indicates that the element is aligned with the current column margin.</dd>
               </dlentry>
               <dlentry>
                 <dt><keyword>page</keyword></dt>
-                <dd>Indicates that the element is placed on the left page
-                  margin for left-to-right presentation or the right page
-                  margin for right-to-left presentation.</dd>
+                <dd>Indicates that the element is placed on the left page margin for left-to-right
+                  presentation or the right page margin for right-to-left presentation.</dd>
               </dlentry>
               <dlentry>
                 <dt><keyword>spread</keyword></dt>
-                <dd>Indicates that the object is rendered across a
-                  multi-page spread. If the output format does not have
-                  anything that corresponds to spreads, then
-                    <keyword>spread</keyword> has the same meaning as
-                    <keyword>page</keyword>.</dd>
+                <dd>Indicates that the object is rendered across a multi-page spread. If the output
+                  format does not have anything that corresponds to spreads, then
+                    <keyword>spread</keyword> has the same meaning as <keyword>page</keyword>.</dd>
               </dlentry>
               <dlentry>
                 <dt><keyword>textline</keyword></dt>
-                <dd><ph rev="review-e">Indicates</ph> that the element is
-                  aligned with the left (for left-to-right presentation) or
-                  right (for right-to-left presentation) margin of the
-                  current text line and takes indentation into
-                  account.</dd>
+                <dd><ph rev="review-e">Indicates</ph> that the element is aligned with the left (for
+                  left-to-right presentation) or right (for right-to-left presentation) margin of
+                  the current text line and takes indentation into account.</dd>
               </dlentry>
-              <dlentry conkeyref="reuse-attributes/ditauseconref"
-                platform="dita">
+              <dlentry conkeyref="reuse-attributes/ditauseconref" platform="dita">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>
-            </dl><p conkeyref="reuse-general/pgwide-explain"
-              platform="dita"/><p>Some processors or output formats might
-              not support all
+            </dl><p conkeyref="reuse-general/pgwide-explain" platform="dita"/><p>Some processors or
+              output formats might not support all
             values.</p><!--<draft-comment author="robander" audience="spec-editors">This statement seems to get wrapped up in the "implementation dependent" discussion. Also note that "spread" already says "if possible" which also means that support can vary - we can probably remove "if possible" there, it seems redundant with this statement?<p>Same statement is repeated for @frame below.</p></draft-comment>--></dd>
         </dlentry>
         <dlentry id="expiry">
           <dt id="attr-expiry"><xmlatt>expiry</xmlatt>
             <ph otherprops="attr-list-label">(date attributes)</ph></dt>
-          <dd>Specifies the date when the information should be retired or
-            refreshed. <ph conkeyref="reuse-general/dateformat"/></dd>
+          <dd>Specifies the date when the information should be retired or refreshed. <ph
+              conkeyref="reuse-general/dateformat"/></dd>
         </dlentry>
         <dlentry id="format">
           <dt id="attr-format"><xmlatt>format</xmlatt>
@@ -532,8 +544,8 @@
         <dlentry id="golive">
           <dt id="attr-golive"><xmlatt>golive</xmlatt>
             <ph otherprops="attr-list-label">(date attributes)</ph></dt>
-          <dd>Specifies the publication or general availability (GA) date.
-              <ph conkeyref="reuse-general/dateformat"/></dd>
+          <dd>Specifies the publication or general availability (GA) date. <ph
+              conkeyref="reuse-general/dateformat"/></dd>
         </dlentry>
         <dlentry id="headers" platform="dita lwdita">
           <dt id="attr-headers"><xmlatt>headers</xmlatt></dt>
@@ -590,16 +602,16 @@
         </dlentry>
         <dlentry id="keyref">
           <dt id="attr-keyref"><xmlatt>keyref</xmlatt></dt>
-          <dd id="def-keyref"><ph id="keyrefDescription">Specifies a key
-              name that acts as a redirectable reference based on a key
-              definition within a map.<ph platform="dita"> See <xref
-                  keyref="attributes-keyref"/> for information on using
-                this attribute.</ph></ph><p platform="lwdita">For HDITA, the equivalent of
-                <xmlatt>keyref</xmlatt> is
-              <xmlatt>data-keyref</xmlatt></p><draft-comment
-              author="robander">The definiton above for @keyref should be
-              synchronized with the definition in the linked section on
-              keys.</draft-comment></dd>
+          <dd id="def-keyref"><ph id="keyrefDescription">Specifies a key name that acts as a
+              redirectable reference based on a key definition within a map.<ph platform="dita"> See
+                  <xref keyref="attributes-keyref"/> for information on using this
+              attribute.</ph></ph><p platform="lwdita">For HDITA, the equivalent of
+                <xmlatt>keyref</xmlatt> is <xmlatt>data-keyref</xmlatt></p><draft-comment
+              author="robander">The definiton above for @keyref should be synchronized with the
+              definition in the linked section on keys.<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Check the topic we link to
+                  and make sure this is consistent, then remove the draft comment</draft-comment>
+              </p></draft-comment></dd>
         </dlentry>
         <dlentry platform="dita lwdita" id="keys">
           <dt id="attr-keys"><xmlatt>keys</xmlatt></dt>
@@ -629,127 +641,129 @@
                     />.</dd>
                 </dlentry>
               </dl>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Double check each to make
+                  sure the latest content is consistent, and remove the draft comment<p>But also …
+                    it might be a good idea to keep this draft comment (and others for the
+                    keys/keyref stuff) until after that section is fully reviewed, so that we have
+                    an easy way to find these "content should be consistent"
+                  issues</p></draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="linking" platform="dita">
           <dt id="attr-linking"><xmlatt>linking</xmlatt>
             <ph otherprops="attr-list-label">(common map
             attributes)</ph></dt>
-          <dd>Specifies linking characteristics of a topic specific to the
-            location of this reference in a map. <ph
-              conkeyref="reuse-attributes/inherit-in-map"/>
-            <draft-comment author="robander" time="Dec 28 2021">The text
-              below matches <xref
+          <dd>Specifies linking characteristics of a topic specific to the location of this
+            reference in a map. <ph conkeyref="reuse-attributes/inherit-in-map"/>
+            <draft-comment author="robander" time="Dec 28 2021">The text below matches <xref
                 href="http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/attributes/commonMapAttributes.html#topicref-atts__linking"
-                format="html" scope="external">1.3 spec text</xref> but I'm
-              nervous about "cannot link" type definition. It's describing
-              how to generate links based on the current context in the map
-              - it's not describing what the topic itself is allowed to
-              link to, which is how I interpret "can".</draft-comment>The
-            following values are valid:<dl>
+                format="html" scope="external">1.3 spec text</xref> but I'm nervous about "cannot
+              link" type definition. It's describing how to generate links based on the current
+              context in the map - it's not describing what the topic itself is allowed to link to,
+              which is how I interpret "can".<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Yeah we should remove the
+                  can/cannot and replace with a description of the intent here... like, targetonly
+                  "The topic or resource can be the target of any context based linking, but is not
+                  meant to be updated with links related to this context."<p>similarly, none could
+                    be "The topic or resource does not participate in any context-based
+                  linking"</p></draft-comment>
+              </p></draft-comment>The following values are valid:<dl>
               <dlentry>
                 <dt><keyword>targetonly</keyword></dt>
-                <dd>A topic can only be linked to and cannot link to other
-                  topics.</dd>
+                <dd>A topic can only be linked to and cannot link to other topics.</dd>
               </dlentry>
               <dlentry>
                 <dt><keyword>sourceonly</keyword></dt>
-                <dd>A topic cannot be linked to but can link to other
-                  topics.</dd>
+                <dd>A topic cannot be linked to but can link to other topics.</dd>
               </dlentry>
               <dlentry>
                 <dt>normal </dt>
-                <dd>A topic can be linked to and can link to other topics.
-                  Use this to override the linking value of a parent topic.
-                </dd>
+                <dd>A topic can be linked to and can link to other topics. Use this to override the
+                  linking value of a parent topic. </dd>
               </dlentry>
               <dlentry>
                 <dt>none </dt>
-                <dd>A topic cannot be linked to or link to other
-                  topics.</dd>
+                <dd>A topic cannot be linked to or link to other topics.</dd>
               </dlentry>
               <dlentry conkeyref="reuse-attributes/ditauseconref">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>
-            </dl><draft-comment author="Kristen J Eberlein"
-              time="28 September 2022">
-              <p>Here is the content from the "DITA map attributes"
-                topic:</p>
+            </dl><draft-comment author="Kristen J Eberlein" time="28 September 2022">
+              <p>Here is the content from the "DITA map attributes" topic:</p>
               <dl>
                 <dlentry>
                   <dt><xmlatt>linking</xmlatt></dt>
                   <dd>
-                    <p>By default, the relationships between the topics
-                      that are referenced in a map are reciprocal:</p>
+                    <p>By default, the relationships between the topics that are referenced in a map
+                      are reciprocal:</p>
                     <ul>
-                      <li>Child topics link to parent topics and vice
-                        versa. </li>
-                      <li>Next and previous topics in a sequence link to
-                        each other. </li>
+                      <li>Child topics link to parent topics and vice versa. </li>
+                      <li>Next and previous topics in a sequence link to each other. </li>
                       <li>Topics in a family link to their sibling topics. </li>
-                      <li>Topics referenced in the table cells of the same
-                        row in a relationship table link to each other. A
-                        topic referenced within a table cell does not (by
-                        default) link to other topics referenced in the
-                        same table cell. </li>
+                      <li>Topics referenced in the table cells of the same row in a relationship
+                        table link to each other. A topic referenced within a table cell does not
+                        (by default) link to other topics referenced in the same table cell. </li>
                     </ul>
-                    <p>This behavior can be modified by using the
-                        <xmlatt>linking</xmlatt> attribute, which enables
-                      an author or information architect to specify how a
-                      topic participates in a relationship. The following
-                      values are valid:</p>
+                    <p>This behavior can be modified by using the <xmlatt>linking</xmlatt>
+                      attribute, which enables an author or information architect to specify how a
+                      topic participates in a relationship. The following values are valid:</p>
                     <dl>
                       <dlentry>
                         <dt><codeph>linking="none"</codeph>
                         </dt>
-                        <dd>Specifies that the topic does not exist in the
-                          map for the purposes of calculating links. </dd>
+                        <dd>Specifies that the topic does not exist in the map for the purposes of
+                          calculating links. </dd>
                       </dlentry>
                       <dlentry>
                         <dt><codeph>linking="sourceonly"</codeph>
                         </dt>
-                        <dd>Specifies that the topic will link to its
-                          related topics but not vice versa. </dd>
+                        <dd>Specifies that the topic will link to its related topics but not vice
+                          versa. </dd>
                       </dlentry>
                       <dlentry>
                         <dt><codeph>linking="targetonly"</codeph>
                         </dt>
-                        <dd>Specifies that the related topics will link to
-                          it but not vice versa. </dd>
+                        <dd>Specifies that the related topics will link to it but not vice versa.
+                        </dd>
                       </dlentry>
                       <dlentry>
                         <dt><codeph>linking="normal"</codeph>
                         </dt>
-                        <dd>Default value. It specifies that linking will
-                          be reciprocal (the topic will link to related
-                          topics, and they will link back to it). </dd>
+                        <dd>Default value. It specifies that linking will be reciprocal (the topic
+                          will link to related topics, and they will link back to it). </dd>
                       </dlentry>
                     </dl>
-                    <p>Authors also can create links directly in a topic by
-                      using the <xmlelement>xref</xmlelement> or
-                        <xmlelement>link</xmlelement> elements, but in most
-                      cases map-based linking is preferable, because links
-                      in topics create dependencies between topics that can
-                      hinder reuse. </p>
-                    <p>Note that while the relationships between the topics
-                      that are referenced in a map are reciprocal, the
-                      relationships merely <i>imply</i> reciprocal links in
-                      generated output that includes links. The rendered
-                      navigation links are a function of the presentation
-                      style that is determined by the processor. </p>
+                    <p>Authors also can create links directly in a topic by using the
+                        <xmlelement>xref</xmlelement> or <xmlelement>link</xmlelement> elements, but
+                      in most cases map-based linking is preferable, because links in topics create
+                      dependencies between topics that can hinder reuse. </p>
+                    <p>Note that while the relationships between the topics that are referenced in a
+                      map are reciprocal, the relationships merely <i>imply</i> reciprocal links in
+                      generated output that includes links. The rendered navigation links are a
+                      function of the presentation style that is determined by the processor. </p>
                   </dd>
                 </dlentry>
               </dl>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Ensure there is nothing
+                  conflicting, and add a link from here to the more architectural info that gives
+                  all the details</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="name" platform="dita lwdita">
           <dt id="attr-name"><xmlatt>name</xmlatt>
             <ph otherprops="attr-list-label">(data-element
             attributes)</ph></dt>
-          <dd>Defines a unique name for the object.<draft-comment
-              author="robander" audience="spec-editors">Do we need to
-              specify the scope of "unique" here?</draft-comment></dd>
+          <dd>Defines a unique name for the object.<draft-comment author="robander"
+              audience="spec-editors">Do we need to specify the scope of "unique" here?<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: ha, it often won't be
+                  unique because you often use the same name for all instances of a specific type of
+                  metadata. Maybe we just get rid of "unique"</draft-comment>
+              </p></draft-comment></dd>
         </dlentry>
         <dlentry id="otherrole">
           <dt id="attr-otherrole"><xmlatt>otherrole</xmlatt></dt>
@@ -796,34 +810,28 @@
           <dt id="attr-processing-role"><xmlatt>processing-role</xmlatt>
             <ph otherprops="attr-list-label">(common map
             attributes)</ph></dt>
-          <dd id="def-processing-role">Specifies whether the referenced
-            resource is processed normally or treated as a resource that is
-            only included in order to resolve references, such as key or
-            content references. The following values are valid:<dl>
+          <dd id="def-processing-role">Specifies whether the referenced resource is processed
+            normally or treated as a resource that is only included in order to resolve references,
+            such as key or content references. The following values are valid:<dl>
               <dlentry>
                 <dt>normal </dt>
-                <dd>Indicates that the resource is a readable part of the
-                  information set. It is included in navigation and search
-                  results. This is the default value for the
+                <dd>Indicates that the resource is a readable part of the information set. It is
+                  included in navigation and search results. This is the default value for the
                     <xmlelement>topicref</xmlelement> element.</dd>
               </dlentry>
               <dlentry>
                 <dt>resource-only </dt>
-                <dd>Indicates that the resource should be used only for
-                  processing purposes. It is not included in navigation or
-                  search results, nor is it rendered as a topic. This is
-                  the default value for the <xmlelement>keydef</xmlelement>
-                  element.</dd>
+                <dd>Indicates that the resource should be used only for processing purposes. It is
+                  not included in navigation or search results, nor is it rendered as a topic. This
+                  is the default value for the <xmlelement>keydef</xmlelement> element.</dd>
               </dlentry>
             </dl><dl>
-              <dlentry conkeyref="reuse-attributes/ditauseconref"
-                platform="dita">
+              <dlentry conkeyref="reuse-attributes/ditauseconref" platform="dita">
                 <dt> </dt>
                 <dd> </dd>
               </dlentry>
-            </dl><p><ph conkeyref="reuse-attributes/may-inherit"/></p><p
-              platform="lwdita">For HDITA, the equivalent of
-                <xmlatt>processing-role</xmlatt> is
+            </dl><p><ph conkeyref="reuse-attributes/may-inherit"/></p><p platform="lwdita">For
+              HDITA, the equivalent of <xmlatt>processing-role</xmlatt> is
                 <xmlatt>data-processing-role</xmlatt>.</p></dd>
         </dlentry>
         <dlentry id="relcolwidth">
@@ -1047,21 +1055,23 @@
             <ph otherprops="attr-list-label">(common map
             attributes)</ph></dt>
           <dd>Specifies whether the target is available for searching. <ph
-              conkeyref="reuse-attributes/inherit-in-map"/> The following
-            values are valid: <keyword>yes</keyword>,
-            <keyword>no</keyword>, and
-              <keyword>-dita-use-conref-target</keyword>.<draft-comment
-              author="Kristen J Eberlein" time="28 September 2022">
-              <p>Here is the content from the "DITA map attributes"
-                topic:</p>
+              conkeyref="reuse-attributes/inherit-in-map"/> The following values are valid:
+              <keyword>yes</keyword>, <keyword>no</keyword>, and
+              <keyword>-dita-use-conref-target</keyword>.<draft-comment author="Kristen J Eberlein"
+              time="28 September 2022">
+              <p>Here is the content from the "DITA map attributes" topic:</p>
               <dl>
                 <dlentry>
                   <dt><xmlatt>search</xmlatt>
                   </dt>
-                  <dd> Specifies whether the topic is included in search
-                    indexes. </dd>
+                  <dd> Specifies whether the topic is included in search indexes. </dd>
                 </dlentry>
               </dl>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Update to use the same
+                  description, these are very similar but not exact. If the description is this
+                  short and similar it should be reused with conref.</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="specializations" platform="dita lwdita">
@@ -1103,10 +1113,8 @@
           <dt id="attr-toc"><xmlatt>toc</xmlatt>
             <ph otherprops="attr-list-label">(common map
             attributes)</ph></dt>
-          <dd>Specifies whether a topic appears in the table of contents
-            (TOC) based on the current map context. <ph
-              conkeyref="reuse-attributes/inherit-in-map"/> The following
-            values are valid:<dl>
+          <dd>Specifies whether a topic appears in the table of contents (TOC) based on the current
+            map context. <ph conkeyref="reuse-attributes/inherit-in-map"/> The following values are valid:<dl>
               <dlentry>
                 <dt>yes </dt>
                 <dd>The topic appears in a generated TOC.</dd>
@@ -1117,23 +1125,25 @@
               </dlentry>
               <dlentry>
                 <dt>-dita-use-conref-target </dt>
-                <dd>See <xref keyref="attributes-useconreftarget"/> for
-                  more information. </dd>
+                <dd>See <xref keyref="attributes-useconreftarget"/> for more information. </dd>
               </dlentry>
-            </dl><draft-comment author="Kristen J Eberlein"
-              time="28 September 2022">
-              <p>Here is the content from the "DITA map attributes"
-                topic:</p>
+            </dl><draft-comment author="Kristen J Eberlein" time="28 September 2022">
+              <p>Here is the content from the "DITA map attributes" topic:</p>
               <dl>
                 <dlentry>
                   <dt><xmlatt>toc</xmlatt></dt>
-                  <dd>Specifies whether topics are excluded from navigation
-                    output, such as a Web site map or an online table of
-                    contents. By default, <xmlelement>topicref</xmlelement>
-                    hierarchies are included in navigation output;
-                    relationship tables are excluded. </dd>
+                  <dd>Specifies whether topics are excluded from navigation output, such as a Web
+                    site map or an online table of contents. By default,
+                      <xmlelement>topicref</xmlelement> hierarchies are included in navigation
+                    output; relationship tables are excluded. </dd>
                 </dlentry>
               </dl>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: I read that and kind of
+                  hate "web site map". Kind of think we should delete that bit from the other topic,
+                  and replace the first sentence there with a reused sentence from
+                  here.</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="type" platform="dita">

--- a/specification/langRef/attributes/lwdita-common-attributes.dita
+++ b/specification/langRef/attributes/lwdita-common-attributes.dita
@@ -9,6 +9,11 @@
       <draft-comment author="Kristen J Eberlein" time="26 September 2022">
         <p>These brief definitions have not been edited or reviewed for
           DITA 2.0</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Hold this until later once we've
+            finished with reviews of the equivalent sections in the TC, then do a quick edit to make
+            sure nothing is inconsistent, and move on</draft-comment>
+        </p>
       </draft-comment>
       <dl>
         <dlentry conkeyref="attributes-common/keys" id="keys">
@@ -16,7 +21,7 @@
           <dd><draft-comment author="Kristen J Eberlein"
               time="24 September 2022"><p>Where is the definition for
                   <xmlatt>keys</xmlatt> in the DITA 2.0
-              spec?</p></draft-comment></dd>
+              spec?</p><p><draft-comment author="robander">TO RESOLVE 13 May 2026: this is hidden inside a conref, I don't think it applies anymore, can be removed</draft-comment></p></draft-comment></dd>
         </dlentry>
         <dlentry id="keyref">
           <dt conkeyref="attributes-common/attr-keyref"/>

--- a/specification/langRef/attributes/universalAttributes.dita
+++ b/specification/langRef/attributes/universalAttributes.dita
@@ -12,6 +12,12 @@
         topic ... Look at it in outline form, and check that the sections,
         titles, and content all make logical sense with the topic title of
         "Universal attribute group".</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 13 May 2026: Not sure what to change here.
+          Looking at the topic at dita-lang.org, the only thing that really stands out is the
+          heading "Common attribute groups". Maybe we can delete that title, check the remaining
+          content in that section for accuracy, and be done?</draft-comment>
+      </p>
     </draft-comment></shortdesc>
   <prolog>
     <metadata>
@@ -60,6 +66,10 @@
                 <p>Why do we need to mention that two attributes are
                   available for specialization here? I think it makes the
                   paragraph hard to read.</p>
+                <p>
+                  <draft-comment author="robander">TO RESOLVE 13 May 2026: Agreed. Either take it
+                    out, or make that a second sentence if the info is useful.</draft-comment>
+                </p>
               </draft-comment>This group includes common metadata
               attributes, two of which are available for specialization:
                 <xmlatt>base</xmlatt>, <xmlatt>importance</xmlatt>,
@@ -83,6 +93,17 @@
               <p>Why do we provide information about specialization and
                 custom document-type shells here? I think that information
                 could be removed.</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: I think because they're all
+                  in all of the base shells distributed by oasis? But I don't care, fine with
+                  removing this<p>On second thought – it's because each of the groups above provides
+                    a list / summary of attributes in the group. These 5 are in the metadata group
+                    because they are picked up with that attribute group in the gramma files (via
+                    specialization), and on every element in the base vocabulary. I think it would
+                    be inconsistent for this section to group every attribute below *except* for
+                    those five. There may be a better way to phrase it, but I think they need to be
+                    listed</p></draft-comment>
+              </p>
             </draft-comment>
           </dd>
         </dlentry>
@@ -251,6 +272,15 @@
                 text"? And how about adding "Processors often add text or images to ensure that
                 readers of the generated content understand whether the step is optional or
                 required." to the end of the example?</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: <ul id="ul_bhy_2sz_fjc">
+                    <li>maybe change to "… although applications can modify how content is rendered
+                      based on the value of the <xmlatt>importance</xmlatt> attribute</li>
+                    <li>And update the example with something like "For example, in steps of a task
+                      topic, processors often add text or images to highlight that a step is
+                      optional or required"</li>
+                  </ul></draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="otherprops">
@@ -271,8 +301,10 @@
               processing.<draft-comment author="robander" audience="spec-editors">I don't like "The
               role must be consistent...", that seems like best practice that cannot be normative –
               and I could easily say outputclass="flashy" which makes my element show up with
-              sparkles, and has nothing to do with "the basic semantic and expectations for the
-              element".</draft-comment></dd>
+              sparkles, and has nothing to do with "the basic semantic and expectations for the element".<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: how about saying "the role
+                  can be", or even a lower-case should, rather than "must be"?</draft-comment>
+              </p></draft-comment></dd>
         </dlentry>
         <dlentry id="platform">
           <dt id="attr-platform"><xmlatt>platform</xmlatt>
@@ -281,8 +313,11 @@
             <draft-comment author="robander" audience="spec-editors">I think this could specify a
               platform that is not an operating system or hardware, right? The current definition
               explicitly limits platform to those two … maybe "Specifies a platform or platforms to
-              which the element applies, such as the operating system or hardware relevant to a
-              task."</draft-comment></dd>
+              which the element applies, such as the operating system or hardware relevant to a task."<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: maybe "Indicates the
+                  content is relevant to the specified platform, such as an operating system or
+                  hardware."</draft-comment>
+              </p></draft-comment></dd>
         </dlentry>
         <dlentry id="product">
           <dt id="attr-product"><xmlatt>product</xmlatt>
@@ -315,6 +350,12 @@
                 element was modified. The <xmlatt>rev</xmlatt> attribute can be used for flagging.
                 It cannot be used for filtering nor is it sufficient to be used for version control.
                   <ph conkeyref="reuse-attributes/may-inherit"/></p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Sounds good, I might say
+                  "can be used for flagging revisions" just because that sentence feels a bit odd
+                  ending in "for flagging" but really don't care, fine with using the text with or
+                  without that update.</draft-comment>
+              </p>
             </draft-comment>
           </dd>
         </dlentry>
@@ -337,6 +378,11 @@
                 suggested processing defaults for each element? I thought it covered whether an
                 element was block or in-line and whether there were considerations that translators
                 needed to be aware of.</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Can we update to "See
+                  (link) for information on additional considerations on translating DITA
+                  elements."</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry id="xmllang">
@@ -351,6 +397,11 @@
               time="29 September 2022" platform="dita">
               <p>Do we also want to direct readers to the architectural topics about the
                   <xmlatt>xml:lang</xmlatt> attribute?</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Yes, should provide a cross
+                  reference, not sure if that will work in the lwdita spec but can figure that out
+                  later</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
       </dl>

--- a/specification/langRef/base/defaultSubject.dita
+++ b/specification/langRef/base/defaultSubject.dita
@@ -16,6 +16,11 @@
         <p>Do we want to make a normative statement about how processors
           should handle default values for attributes when they are
           specified by <xmlelement>defaultSubject</xmlelement>?</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: I think this would be covered by
+            the "how to determine attributes" topic, and does not need an extra rule
+            here</draft-comment>
+        </p>
       </draft-comment>
       <draft-comment author="Kristen J Eberlein" time="13 December 2021">
         <p>Comments from review D:</p>
@@ -45,6 +50,12 @@
           scheme but your grammar files only allow "x" and "y", then you've
           set up a scheme that means every usage of that element is
           automatically an error condition.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: That referenced topic is the one
+            we are stuck on, but that is where the rules for this should be specified. I think this
+            section could / should be updated with a link to that section, because it's highly
+            relevant when reading about this topic.</draft-comment>
+        </p>
       </draft-comment>
     </section>
     <section id="specialization-hierarchy">

--- a/specification/langRef/base/ditavalref.dita
+++ b/specification/langRef/base/ditavalref.dita
@@ -90,8 +90,11 @@
       <draft-comment author="robander">This topic overall has far more processing information than
         seems appropriate for an element reference topic; there is likely a lot of overlap /
         duplication of information contained in the Branch Filtering section of the arch spec. Most
-        of this information should be moved there, likely including the full set of
-        Limitations.</draft-comment>
+        of this information should be moved there, likely including the full set of Limitations.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Needs an editing pass, moving
+            most of the architectural info into the "Branch filtering" section of the arch
+            spec</draft-comment>
+        </p></draft-comment>
       <p>The following limitations apply when using the <xmlelement>ditavalref</xmlelement> element;
         these limitations cannot be enforced in a DTD or other XML grammar files.</p>
       <p outputclass="errorcondition">When the use of the <xmlelement>ditavalref</xmlelement>
@@ -110,9 +113,14 @@
         scheme for the conflicting copies. <draft-comment author="Kristen J Eberlein"
           time="15 May 2019" audience="spec-editors">
           <p>Need more information about what situation the processor is recovering from ...</p>
-        </draft-comment><draft-comment author="robander">For the above, it would be recovering from
-          a map that instructs it to create two files of the same name, with different filter
-          conditions applied.</draft-comment></p>
+          <p>
+            <draft-comment author="robander">For the above, it would be recovering from a map that
+              instructs it to create two files of the same name, with different filter conditions
+              applied.</draft-comment>
+            <draft-comment author="robander">TO RESOLVE 13 May 2026: To add when moving the content
+              into arch spec, this rule should be in the arch spec</draft-comment>
+          </p>
+        </draft-comment></p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
@@ -142,7 +150,11 @@
               <keyword>resource-only</keyword>.</li>
         </ul><draft-comment author="robander">DITA 1.3 said that format MUST be ditaval, and that no
           value other than "resource-only" is valid for processing role. Should these be #FIXED in
-          the grammar files?</draft-comment></p>
+          the grammar files?<p>
+            <draft-comment author="robander">TO RESOLVE 13 May 2026: Can raise this at TC, but it's
+              fine / low impact if we just keep the same definitions from 1.3 and don't make these
+              fixed</draft-comment>
+          </p></draft-comment></p>
       <!--<dl><dlentry><dt id="ditavalref-href"><xmlatt>href</xmlatt></dt><dd>Provides a reference to a DITAVAL document. If the <xmlatt>href</xmlatt> attribute is unspecified, this <xmlelement>ditavalref</xmlelement> will not result in any new filtering behavior, but other aspects of the element are still evaluated. See <xref keyref="attributes-href"/> for general information on the format and processing implications of the <xmlatt>href</xmlatt> attribute.</dd></dlentry><dlentry><dt id="ditavalref-format"><xmlatt>format</xmlatt></dt><dd>Format of the target document, which <term outputclass="RFC-2119">MUST</term> be a DITAVAL document. The default value for this element is <keyword>ditaval</keyword>. See <xref keyref="attributes-format"/> for more information.</dd></dlentry><dlentry><dt id="ditavalref-processing-role"><xmlatt>processing-role</xmlatt></dt><dd>The processing role defaults to "resource-only" for DITAVAL documents, which are only used for processing and do not contain content. There is no other valid value for this attribute on this element.</dd></dlentry></dl>-->
     </section>
 <example id="example" otherprops="examples" conkeyref="reuse-examples/ditavalref"/>

--- a/specification/langRef/base/dvrResourcePrefix.dita
+++ b/specification/langRef/base/dvrResourcePrefix.dita
@@ -45,8 +45,11 @@
     <example id="example" otherprops="examples">
       <title>Example</title>
       <draft-comment author="robander">The ditavalmeta element refers to arch spec examples, that
-        might be better here as well, given the new complexity of added resourceid
-        elements.</draft-comment>
+        might be better here as well, given the new complexity of added resourceid elements.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Yes, we should have these
+            examples in the arch spec and refer to those from here, these examples are needed in the
+            arch spec</draft-comment>
+        </p></draft-comment>
       <fig id="fig_twy_5w1_ppb">
         <title>How <xmlelement>dvrResourcePrefix</xmlelement> affects resource file names</title>
         <p>The following code sample shows a simple branch with a parent and child topic, where the

--- a/specification/langRef/base/dvrResourceSuffix.dita
+++ b/specification/langRef/base/dvrResourceSuffix.dita
@@ -56,8 +56,10 @@
     <example id="example" otherprops="examples">
       <title>Example</title>
       <draft-comment author="robander">The ditavalmeta element refers to arch spec examples, that
-        might be better here as well, given the new complexity of added resourceid
-        elements.</draft-comment>
+        might be better here as well, given the new complexity of added resourceid elements.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Yes, ensure these examples or
+            equivalents exist in the arch spec, and then link to them from here</draft-comment>
+        </p></draft-comment>
       <fig id="fig_twy_5w1_ppb">
         <title>How <xmlelement>dvrResourceSuffix</xmlelement> affects resource file names</title>
         <p>The following code sample shows a simple branch with a parent and child topic, where the

--- a/specification/langRef/base/enumerationdef.dita
+++ b/specification/langRef/base/enumerationdef.dita
@@ -113,6 +113,10 @@
         <p>We need to ensure that nothing in the "Usage information"
           section conflicts with what we specify in the final topic about
           "Determining effective attribute values.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Can hold this until that topic is
+            completed, then just ensure we are consistent / no conflicts</draft-comment>
+        </p>
       </draft-comment>
     </section>
         <section id="attributes">
@@ -121,8 +125,8 @@
           conkeyref="reuse-attributes/ref-idandconrefatts"/>, <xref
           keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>, <xref
           keyref="attributes-universal/attr-class"><xmlatt>class</xmlatt></xref>, <xref
-          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, and <xref
-          keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>.</p>
+          keyref="attributes-universal/attr-outputclass"><xmlatt>outputclass</xmlatt></xref>, and
+          <xref keyref="attributes-universal/attr-status"><xmlatt>status</xmlatt></xref>.</p>
         </section>
         <example>
             <title>Example</title>

--- a/specification/langRef/base/foreign.dita
+++ b/specification/langRef/base/foreign.dita
@@ -33,8 +33,10 @@
         content unless otherwise instructed. If a processor cannot render
         the content, it <term outputclass="RFC-2119">MAY</term> issue a
         warning.</p>
-      <draft-comment author="Kristen J Eberlein" time="28 December 2021"
-        >The following content needs editing.</draft-comment>
+      <draft-comment author="Kristen J Eberlein" time="28 December 2021">The following content needs editing.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: We or the magic robots should do
+            a single editing pass and call it done</draft-comment>
+        </p></draft-comment>
       <p>The enabler of the foreign vocabulary must provide the processing and override the base
         processing for <xmlelement>foreign</xmlelement>. </p>
       <ul id="ul_f2h_3kf_bbb">
@@ -64,6 +66,13 @@
       <draft-comment author="Kristen J Eberlein" time="28 December 2021">
         <p>Is the following example valid now that we have an SVG reference
           domain?</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: I think we had that discussion in
+            1.3 and decided to just go with it, we can do the same here, particularly since that svg
+            domain is over in the technical content spec / not here in the base spec. BUT we should
+            change the container to &lt;svg-container> which matches what that technical-content
+            spec has. </draft-comment>
+        </p>
       </draft-comment>
       <p>The following code sample shows a specialization of
           <xmlelement>foreign</xmlelement> that is used to hold SVG

--- a/specification/langRef/base/mapref.dita
+++ b/specification/langRef/base/mapref.dita
@@ -33,15 +33,25 @@
           Navigation > TOC.</p>
         <p>We should plan a review that covers both architectural and element-reference topics about
           maps.</p>
+        <p>
+          <draft-comment author="robander" time="8 May 2026">
+            <p>There is a new architectural topic about maps that describes relationship tables, and
+              says that the root map has the union of all relationship tables from submaps; we
+              should reference that for the relationship table bit. It does not get "added" to the
+              parent map, which might not be the root map.</p>
+          </draft-comment>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: This is at least the 4th spot we
+            cover the relationship table info. This should be replaced with a link to the new
+            relationship table topic in the map.</draft-comment>
+        </p>
       </draft-comment>
       <draft-comment author="Kristen J Eberlein" time="05 September 2020">
         <p>The terms "container map" and "parent map" here are unclear. How are they different?</p>
-      </draft-comment>
-      <draft-comment author="robander" time="8 May 2026">
-        <p>There is a new architectural topic about maps that describes relationship tables, and
-          says that the root map has the union of all relationship tables from submaps; we should
-          reference that for the relationship table bit. It does not get "added" to the parent map,
-          which might not be the root map.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Ugh, we should be consistent,
+            they mean the same thing, shouldn't we be saying referenced map / referencing
+            map?</draft-comment>
+        </p>
       </draft-comment>
     </section>
     <section id="specialization-hierarchy">

--- a/specification/langRef/base/related-links.dita
+++ b/specification/langRef/base/related-links.dita
@@ -24,7 +24,10 @@
         of ancestor, parent, child, descendant, next, previous, or sibling.</p>
       <draft-comment author="rodaande">Assuming we add an architectural section that covers how link
         roles are implied by the map, and can result in generated links, we should link to it from
-        this topic with a related link.</draft-comment>
+        this topic with a related link.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: the latest draft of that new
+            topic doesn't cover the PDF aspect … probably should add it</draft-comment>
+        </p></draft-comment>
     </section>
     <section
       conref="../../common/conref-file.dita#reuse_file/processing-expectations-link-cascade"

--- a/specification/langRef/base/reltable.dita
+++ b/specification/langRef/base/reltable.dita
@@ -50,6 +50,11 @@
         <p>It would be good to replace the reference to a CTR reltable with
           an example of a reltable that provides links between topics and
           external resources.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 11 May 2026: recommend just leaving this
+            simple table here, but providing bi-directional links (using a reltable!!) between this
+            and the new architectural topic about relationship tables</draft-comment>
+        </p>
       </draft-comment>
     </section>
     <section id="processing-expectations">
@@ -59,7 +64,9 @@
         topic-to-topic links. The <xmlelement>relcell</xmlelement> elements can contain
           <xmlelement>topicref</xmlelement> elements, which are then related to other
           <xmlelement>topicref</xmlelement> elements in the same row (although not necessarily in
-        the same cell).</p>
+        the same cell).<draft-comment author="robander">TO RESOLVE 11 May 2026: the following line
+          should be sync'ed with the other reltable topic that I believe uses "Within the scope of a
+          root map, the …"</draft-comment></p>
       <p>Within a root map, the effective relationship table is the union
         of all relationship tables in the map hierarchy.</p>
     </section>
@@ -78,6 +85,16 @@
       <draft-comment author="Kristen J Eberlein" time="22 November 2021">
         <p>Consensus from editors' call today: this example needs a
           significant rework.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 11 May 2026: See above. I think options are<ol
+              id="ol_ltk_qd4_fjc">
+              <li>Ask TC for volunteers to come up with a better one (which also might end up better
+                off in the arch topic)</li>
+              <li>Leave it alone (with some cleanup after it), and put a better one in the
+                architectural topic</li>
+              <li>Just do the cleanup after the table and move on</li>
+            </ol></draft-comment>
+        </p>
       </draft-comment><p>In the following code sample, a relationship table is defined with three
         columns: one for "concept", one for "task", and one for
         "reference". Three cells are defined within each row. The first
@@ -112,6 +129,10 @@
 &lt;/map&gt;</codeblock><p>A graphical version of the relationship table in an editor might look like this:</p>
       <draft-comment author="Kristen J Eberlein" time="02 December 2021">
         <p>Replace with a screen capture</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 11 May 2026: recommend just leaving this as a
+            table, the intent is clear enough?</draft-comment>
+        </p>
       </draft-comment><simpletable>
 <sthead>
 <stentry>type="concept"</stentry>
@@ -141,6 +162,13 @@
         <p>This organization as a definition list bothers me; it's simply a
           list of file names, it feels like there should be more
           explanatory text, even something like "links to"</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 11 May 2026: recommend keeping the definition
+            list layout, with a file name as the term, but replace the "definition" with prose that
+            explains what each item links to and why.<p>But it might also be good to move the
+              "Reltables are an inherently …" follow up paragraph over to the architectural spec
+              topic.</p></draft-comment>
+        </p>
       </draft-comment>
       <dl>
         <dlentry>

--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -21,7 +21,11 @@
       <draft-comment author="rodaande" time="Jan 10, 2022">This topic needs to be sync'ed with
         content in the architectural spec. I think it would make sense for much of the appid-role
         content to be moved into a section of the "DITA Addressing" chapter, and that content really
-        needs to be reviewed together with this topic after the sync.</draft-comment>
+        needs to be reviewed together with this topic after the sync.<p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: Not sure I still feel that way
+            about appid-role, given that this is the only element that uses it. So to resolve, maybe
+            just ensure that this topic is reviewed.</draft-comment>
+        </p></draft-comment>
       <p>The <xmlatt>appid</xmlatt> and <xmlatt>appname</xmlatt> attributes
         work in combination to specify a specific ID for an application.
         Multiple <xmlatt>appid</xmlatt> values can be associated with a
@@ -80,7 +84,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry id="appname">
           <dt id="attr-appname"><xmlatt>appname</xmlatt></dt>
@@ -233,6 +238,13 @@
       <fig>
         <title>Example: Using a <xmlelement>resourceid</xmlelement> element
           to XXX</title>
+        <p>
+          <draft-comment author="robander">This clearly needs an update<p>
+              <draft-comment author="robander">TO RESOLVE 13 May 2026: I think Eliot agreed to
+                rework or recreate this example, as an example that reproduces the former copy-to
+                behavior</draft-comment>
+            </p></draft-comment>
+        </p>
         <p>In the following code sample, anchor components are defined for
           two different references to the same topic. Each use of the topic
           represents the documentation for a different model of the same

--- a/specification/langRef/base/titlealt.dita
+++ b/specification/langRef/base/titlealt.dita
@@ -54,13 +54,18 @@
         </section>
         <section id="processing-expectations">
             <title>Processing expectations</title>
-            <draft-comment author="robander" time="13 May 2021">Questions
-        as I read this more closely:<p>Some of this language implies a
-          specific type of processor, which we've had trouble with in the
-          past; language may need to be more processor agnostic</p><p>Given
-          the complications, the number of required samples, and the impact
-          on processing, it feels like this deserves a page in the
-          architectural specifciation.</p></draft-comment>
+            <draft-comment author="robander" time="13 May 2021">Questions as I read this more
+          closely:<p>Some of this language implies a specific type of processor, which we've had
+          trouble with in the past; language may need to be more processor agnostic</p><p>Given the
+          complications, the number of required samples, and the impact on processing, it feels like
+          this deserves a page in the architectural specifciation.</p><p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: options<ul id="ul_yrw_dxz_fjc">
+              <li>Ask the magic robots to turn this into an architectural spec topic and then rework
+                it</li>
+              <li>Just go through and clean up use of "processor" in this topic</li>
+              <li>Just leave it and move on</li>
+            </ul></draft-comment>
+        </p></draft-comment>
             <p>The processing of an alternative title depends on its roles.
         Processors <term outputclass="RFC-2119">SHOULD</term> support the
         following tokens for the <xmlatt>title-role</xmlatt> attribute:<dl>
@@ -124,8 +129,7 @@
             <title>Attributes</title>
             <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/> and <xref
-          keyref="attributes-common/attr-title-role"
-            ><xmlatt>title-role</xmlatt></xref>.</p>
+          keyref="attributes-common/attr-title-role"><xmlatt>title-role</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">
             <title>Examples</title>

--- a/specification/langRef/containers/ditaval-d.dita
+++ b/specification/langRef/containers/ditaval-d.dita
@@ -7,7 +7,13 @@
   a DITA map for multiple audiences.<draft-comment author="robander">The child topics here all refer
    to a "map branch implied by a ditavalref" – we should probably define "implied" as a term in this
    case, that we can easily refer to (or if we already define it, uses of the phrase "implied by a
-   ditavalref" should link there).</draft-comment></shortdesc>
+   ditavalref" should link there).<p>
+    <draft-comment author="robander">TO RESOLVE 13 May 2026: Make sure that one of<ul
+      id="ul_ngg_jxz_fjc">
+      <li>that phrase is defined in the arch spec topics about branch filtering, or</li>
+      <li>we switch to whatever term is used in the arch spec topics</li>
+     </ul></draft-comment>
+   </p></draft-comment></shortdesc>
  <prolog>
   <metadata>
    <keywords>

--- a/specification/langRef/ditaval/revprop.dita
+++ b/specification/langRef/ditaval/revprop.dita
@@ -99,6 +99,11 @@
               <p>Do we want to be more specify about what values are
                 supported here? Hex codes or names for color, character,
                 but what for styles? Refer to XSL: FO spec?</p>
+              <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: At this point I think no,
+                  whatever a processor wants to support they can use here, which also means if it
+                  was allowed in 1.x it's allowed in 2.0</draft-comment>
+              </p>
             </draft-comment></dd>
         </dlentry>
         <dlentry conkeyref="reuse-attributes/ditaval-color">

--- a/specification/non-normative/changes-1.3-to-2.0/added-to-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/added-to-standard.dita
@@ -6,8 +6,15 @@
         usability of the standard or to address use cases where DITA 1.3 failed to offer an
         acceptable solution. <draft-comment author="dawnstevens">There's really no way in this
             summary document to know where the new elements are allowed. Should this be specified
-            here somewhere – in changes to the content models of elements, for example?
-        </draft-comment></shortdesc>
+            here somewhere – in changes to the content models of elements, for example? <p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: There are so many content
+                    model changes I don't think we can or should list them all, but we could do a
+                    review of this topic and add that to items where it seems most useful<p>also
+                        take note: some of these (I see &lt;diagnostics>) are only relevant in the
+                        technical content spec and shouldn't be listed as additions to the base. I
+                        think those should be removed from this and (at the same time, making sure
+                        we don't lose them) added to the other.</p></draft-comment>
+            </p></draft-comment></shortdesc>
     <conbody>
         <section id="section_dcz_jtd_3vb">
             <title>Domains</title>

--- a/specification/non-normative/changes-1.3-to-2.0/modified-in-standard.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/modified-in-standard.dita
@@ -23,8 +23,16 @@
                     </dlentry>
                 </dl></p>
             <draft-comment author="dawnstevens">Is there where we would put that
-                    <xmlelement>linktext</xmlelement> has been moved from commonElements to
-                TopicMod?</draft-comment>
+                    <xmlelement>linktext</xmlelement> has been moved from commonElements to TopicMod?<p>
+                    <draft-comment author="robander">TO RESOLVE 13 May 2026: Maybe a new section at
+                        the end for grammar-related changes, list this and the new &lt;dita> module
+                        in the base spec (not sure if more should be listed but possibly, we could
+                        call out that outputclass moved into univ-atts because that will impact
+                            migrations<p>also need to fix the "attributes added to" table, it
+                            mentions specializations of body (but that is for things in the TC
+                            spec), it needs a fix for &lt;prop> as that attribute was renamed
+                            add-outputclass</p></draft-comment>
+                </p></draft-comment>
         </section>
         <section id="section_xpc_sgk_3vb">
             <title>Content Model Changes</title>

--- a/specification/non-normative/changes-1.3-to-2.0/new-features-and-enhancements-in-dita-2-0.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/new-features-and-enhancements-in-dita-2-0.dita
@@ -10,6 +10,12 @@
         technical details, but should instead focus on the benefit these
         changes offer to implementations. More of WHY the TC thought a
         change was beneficial rather than how it was implemented.</p>
+      <p>
+        <draft-comment author="robander">TO RESOLVE 13 May 2026: I don't think this is actionable
+          now, but could be added as an XML comment to remind any editors of the purpose.<p>I also
+            see much of this has yet to be written. Is this topic even included in the base spec?
+            There is a new migration topic that has a lot of this info</p></draft-comment>
+      </p>
     </draft-comment>
     <dl>
       <dlentry>

--- a/specification/non-normative/changes-1.3-to-2.0/overview.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/overview.dita
@@ -6,6 +6,10 @@
         standard. It includes changes to both the base and technical content editions.</shortdesc>
     <conbody>
         <draft-comment author="dawnstevens">should this document in some way indicate which is base
-            and which is technical content?</draft-comment>
+            and which is technical content?<p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026: Logically I'm not sure it
+                    makes sense to have the technical content stuff here, that should be in the TC
+                    spec</draft-comment>
+            </p></draft-comment>
     </conbody>
 </concept>

--- a/specification/non-normative/changes-1.3-to-2.0/removed-attributes.dita
+++ b/specification/non-normative/changes-1.3-to-2.0/removed-attributes.dita
@@ -15,6 +15,11 @@
             (<xmlatt>alt</xmlatt>, <xmlatt>navtitle</xmlatt>, etc.), as
           well as attributes like <xmlatt>otherjob</xmlatt> (which was
           available only on <xmlelement>audience</xmlelement>.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: I'd say just leave this
+            organization, doesn't matter if it was a common attribute or only on one element, they
+            were still removed</draft-comment>
+        </p>
       </draft-comment>
       <p>The attributes listed in the following table no longer exist in
         DITA. They are not available on any elements.</p>
@@ -129,6 +134,9 @@
           are NOT retained generally. They only existed on
             <xmlelement>object</xmlelement>, so should they be moved into
           the table in the above section?</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: yes</draft-comment>
+        </p>
       </draft-comment>
       <p>Certain attributes, while retained generally, have been removed
         from the attribute lists for specific elements.</p>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -770,6 +770,12 @@
             <xmlelement>alt</xmlelement> element within
             <xmlelement>image</xmlelement> contains translatable text.
           Localization of the image would be separate."</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: For those two, can we change the
+            block/inline column to say "N/A (container element)", and in the final notes colum, say
+            that "The nested <xmlelement>alt</xmlelement> element has translatable text, and the
+            referenced image may also require translation."</draft-comment>
+        </p>
       </draft-comment>
     </section>
     <section id="section-map">

--- a/specification/non-normative/file-names-in-the-base-dita-edition.dita
+++ b/specification/non-normative/file-names-in-the-base-dita-edition.dita
@@ -63,10 +63,15 @@
         </strow>
       </simpletable>
       <draft-comment author="Kristen J Eberlein" time="19 September 2022">
-        <p>The names of the expansion modules listed in the "Example"
-          column are taken from the example topics. They do not follow a
-          consistent pattern. I suspect that the same is true for file
-          names used in the constraint example topics.</p>
+        <p>The names of the expansion modules listed in the "Example" column are taken from the
+          example topics. They do not follow a consistent pattern. I suspect that the same is true
+          for file names used in the constraint example topics.</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: These rules are no longer
+            mandatory and should not be mandatory, so we should just pick one pattern (ideally
+            matching our existing task constraint) and use htat in all the constraint/expansion
+            module pattern recommendations</draft-comment>
+        </p>
       </draft-comment>
       <p>where:</p>
       <ul>
@@ -142,6 +147,11 @@
         <p>Also, is including "Mod" in element-domain or constraint files
           something we really want to do, or was it necessary for the
           RNG-to-DITA/XSD converter?</p>
+        <p>
+          <draft-comment author="robander">TO RESOLVE 13 May 2026: See comment in earlier draft
+            comment. Also, "Mod" definitely isn't required in the name but is probably good to
+            recommend for consistency, all the other content-model modules use it.</draft-comment>
+        </p>
       </draft-comment>
       <p>where:</p>
       <ul>

--- a/specification/non-normative/information-about-migrating-to-dita-2-0.dita
+++ b/specification/non-normative/information-about-migrating-to-dita-2-0.dita
@@ -7,7 +7,23 @@
     <conbody>
         <draft-comment author="rodaande">Initial draft of this topic includes all changes from both
             the base specification and the technical content specification.<p>It does not currently
-                cover the duplicate learning modules that were removed.</p></draft-comment>
+                cover the duplicate learning modules that were removed.</p><p>
+                <draft-comment author="robander">TO RESOLVE 13 May 2026:<ul id="ul_r3q_pzz_fjc">
+                        <li>We have a bunch of other topics I found when working through draft
+                            comments, that may also contain some of this info. Need to use one or
+                            the other, and make sure the one we use is complete / comprehensive for
+                            the base spec.</li>
+                        <li>But we also need to move all the technical-content related changes over
+                            to the technical content spec.</li>
+                        <li>Learning is odd because that wasn't even technical-content. I think this
+                            page should note that technical content also included changes that are
+                            covered in that spec; then we could still add a note in this
+                            non-normative appendix stating that learning is not provided as a 2.0
+                            standard but that all modules can be updated for compatibility, or
+                            whatever wording we've been using.</li>
+                    </ul>
+                </draft-comment>
+            </p></draft-comment>
         <section id="section_zvz_hlk_xhc">
             <title>Markup to migrate for DITA 2.0</title>
             <p>The following elements and attributes have been removed from the grammar as obsolete.


### PR DESCRIPTION
I'm going through every draft comment in the base spec, and adding my own (nested) draft comment with a recommendation to resolve it. Every nested recommendation includes the text `TO RESOLVE`, which should make it easier to catch any draft comments that are added going forward and do not have these recommendations.