### PR TITLE
Fix attribute values to match subject scheme

### DIFF
--- a/specification/archSpec/base/controlling-linking-with-attributes.dita
+++ b/specification/archSpec/base/controlling-linking-with-attributes.dita
@@ -14,13 +14,13 @@
         <p> The <xmlatt>collection-type</xmlatt> attribute specifies how child topic references of a
             map branch relate to each other. This enables authors to make relationship intent
             explicit in the map, rather than relying on processor defaults. <ph
-                outputclass="example">For example, the value <keyword>sequence</keyword> can
+                otherprops="examples">For example, the value <keyword>sequence</keyword> can
                 indicate ordered progression, while <codeph>family</codeph> can indicate that all
                 sibling topics within that branch are related.</ph></p>
         <p> The <xmlatt>linking</xmlatt> attribute controls how a topic references participate in
             map-based relationships. Authors can use these values to prevent undesired reciprocal
             links, suppress participation in relationship calculations, or constrain linking
-            direction for supporting resources. <ph outputclass="example">For example, using the
+            direction for supporting resources. <ph otherprops="examples">For example, using the
                 value <keyword>none</keyword> indicates that no links should be generated to or from
                 the resource, while <keyword>targetonly</keyword> indicates that the a processor can
                 generate links to the referenced topic but should not generate links from that topic


### PR DESCRIPTION
Changing `outputclass="example"` to `otherprops="examples"` to match subject scheme