### PR TITLE
Add shortdesc for accessibility and translation container

### DIFF
--- a/specification/archSpec/base/accessibility-and-translation.dita
+++ b/specification/archSpec/base/accessibility-and-translation.dita
@@ -2,5 +2,7 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 2.0 Concept//EN" "concept.dtd">
 <concept id="accessibility-and-translation">
     <title>Accessibility and translation</title>
-    <shortdesc>Content needed</shortdesc>
+    <shortdesc>DITA has a number of built-in features that are intended to automate or enable
+        content accessibility and translation. Together these features help content reach as many
+        audiences as possible.</shortdesc>
 </concept>


### PR DESCRIPTION
Replaces the current short description, which just says "Content needed", with a short description that covers accessibility and translation. This is meant as a draft to be updated during future reviews of this section.