### PR TITLE
Turn the todo list into links for easier reference

### DIFF
--- a/specification/archSpec/base/dita-maps-and-their-usage.dita
+++ b/specification/archSpec/base/dita-maps-and-their-usage.dita
@@ -35,42 +35,41 @@
 </thead>
 <tbody>
 <row>
-<entry>3.4.5.1 Example: DITA map that references a subordinate map</entry>
+<entry><xref href="example-simple-map-w-submap.dita"/></entry>
 <entry>Resolution of a submap.</entry>
 </row>
 <row>
-<entry>3.4.5.2 Example: DITA map with a simple relationship table</entry>
+<entry><xref href="example-simple-map-w-reltable.dita"/></entry>
 <entry>How links are generated from a relationship table; how processors might represent a
 relationship table.</entry>
 </row>
 <row>
-<entry>3.4.5.3 Example: How the <xmlatt>collection-type</xmlatt> and <xmlatt>linking</xmlatt>
-determine links</entry>
+<entry><xref href="example-collection-type-and-linking-atts.dita"/></entry>
 <entry>Effect of <xmlatt>collection-type</xmlatt> and <xmlatt>linking</xmlatt> attributes on
 generated links.</entry>
 </row>
 <row>
-<entry>6.1 Navigation</entry>
+<entry><xref href="navigation.dita"/></entry>
 <entry>Container topic; incorporate into new "DITA maps and their usage" cluster.</entry>
 </row>
 <row>
-<entry>6.1.1 Table of contents</entry>
+<entry><xref href="table-of-contents.dita"/></entry>
 <entry>All content is applicable and needs to be incorporated into the new "DITA maps and their
 usage" cluster – Closest thing we currently have to a topic about how maps create
 hierarchies.</entry>
 </row>
 <row>
-<entry>9.3.1.1 <xmlelement>map</xmlelement></entry>
+<entry><xref keyref="elements-map"/></entry>
 <entry>Relationships between topics created by map hierarchy or <xmlatt>collection-type</xmlatt>
 attribute; role of titles, especially in submaps.</entry>
 </row>
 <row>
-<entry>9.3.1.2 <xmlelement>topicref</xmlelement></entry>
+<entry><xref keyref="elements-topicref"/></entry>
 <entry>Role of <xmlelement>topicref</xmlelement> nesting in creating containment hierarchies and
 parent-child relationships.</entry>
 </row>
 <row>
-<entry>9.3.1.6 <xmlelement>reltable</xmlelement></entry>
+<entry><xref keyref="elements-reltable"/></entry>
 <entry>Relationship table titles – Processing expectations for relationship tables (not rendered,
                                 used to generate links) – <q>Within a map tree, the effective
                                     relationship table is the union of all relationship tables in
@@ -78,21 +77,21 @@ parent-child relationships.</entry>
                                     <xmlelement>reltable</xmlelement> element graphically.</entry>
 </row>
 <row>
-<entry>9.3.1.10 <xmlelement>relcolspec</xmlelement></entry>
+<entry><xref keyref="elements-relcolspec"/></entry>
 <entry>How labels for related links from a relationship table are generated.</entry>
 </row>
 <row>
-<entry>9.3.2.3 <xmlelement>mapref</xmlelement></entry>
+<entry><xref keyref="elements-mapref"/></entry>
 <entry><q>The hierarchy of the referenced map is merged into the container map at the position of
 the reference, and the relationship tables of the child map are added to the parent map.</q></entry>
 </row>
 <row>
-<entry>9.3.2.4 <xmlelement>topicgroup</xmlelement></entry>
+<entry><xref keyref="elements-topicgroup"/></entry>
 <entry>How processors handle navigation titles within <xmlelement>topicgroup</xmlelement>
 elements.</entry>
 </row>
 <row>
-<entry>9.8.13.10 The <xmlatt>format</xmlatt> attribute</entry>
+<entry><xref href="theformatattribute.dita"/></entry>
 <entry>How processors determine the value of the <xmlatt>format</xmlatt> attribute when it is not
 explicitly set.</entry>
 </row>


### PR DESCRIPTION
We have a table with a bunch of titles of topics that need to be reviewed; this turns those into links to make the reviews easier