### PR TITLE
Clean up attribute cascading details

### DIFF
--- a/specification/archSpec/base/binding-controlled-values-to-attribute.dita
+++ b/specification/archSpec/base/binding-controlled-values-to-attribute.dita
@@ -43,8 +43,8 @@
             scheme map. For authoring tools, this validation prevents users from entering misspelled
             or undefined values. Recovery from validation errors is implementation specific.</p>
         <p>The default attribute values that are specified in a subject scheme map apply only if a
-            value is not otherwise specified in the DITA source or as a default value by the XML
-            grammar. </p>
+            value is not otherwise established by explicit specification, XML grammar defaults, or
+            cascading behavior. </p>
         <p>When processing map attributes, processors evaluate controlled-value defaults after
             explicit values, grammar defaults, and cascading values, and before processing-supplied
             defaults. See <xref href="processing-cascading-attributes-in-a-map.dita"/>.</p>

--- a/specification/archSpec/base/binding-controlled-values-to-attribute.dita
+++ b/specification/archSpec/base/binding-controlled-values-to-attribute.dita
@@ -42,49 +42,7 @@
             validate attribute values against the controlled values that are defined in the subject
             scheme map. For authoring tools, this validation prevents users from entering misspelled
             or undefined values. Recovery from validation errors is implementation specific.</p>
-        <p>The default attribute values that are specified in a subject scheme map apply only if a
-            value is not otherwise established by explicit specification, XML grammar defaults, or
-            cascading behavior. </p>
         <p conkeyref="reuse-general/controlled-default-precedence"/>
-    <!--<p>To determine the effective value for a DITA attribute, processors check for the following in the order outlined:</p><ol><li>An explicit value in the element instance</li><li>A default value in the XML grammar</li><li>Cascaded value within the document</li><li>Cascaded value from a higher level document to the document</li><li>A default controlled value, as specified in the <xmlelement>defaultSubject</xmlelement> element </li><li>A value set by processing rules</li></ol><draft-comment author="Kristen J Eberlein" time="15 May 2019" audience="spec-editors"><p>Should the above statement be normative? Discussed at TC call on 28 May 2019. Notes:</p><lines>Kris: Let's move on to a review of draft comments
-Robert (scrolls to first draft-comment in spec draft, page 37, section 3.3.3)
-Kris: Should this be normative?
-Eliot: Either it should be stated in a direct way, in terms of the precedence of the source of the value rather than how a processor might work, that is the processing should be implicit in the rules. But if this behavior is already implicit in the rules than there should be a non-normative note (if it's here at all).
-Kris: I don't know whether what we're stating here is already normatively stated in how our processes handle values for DITA attributes.
-Robert: I don't think this is stated elsewhere.
-Robert: So Eliot what you're saying is this intro clause should be something like "The effective value for a DITA attribute IS..."
-Eliot: Yes, it should be declarative not procedural
-Kris: So we need to change the introductory sentence
-Eliot: I have a concern, which is that this also affects cascading values of attributes in maps. We need to be careful we're not restating this rule.
-Eliot: Also in this list, items 1&amp;2 come from XML behavior, it's not until #3 that we get to things that are needed for DITA
-Robert: The editors need to make sure this content is not duplicated. We can't just delete it because we lose the part about <xmlelement>defaultSubject</xmlelement>
-Eliot: The list altogether is good, but perhaps there needs to be another statement that says that these rules apply when cascading is needed.
-Kris: This was something we introduced in DITA 1.3.
-Eliot: I think the previous paragraph "The default attribute values ..." could maybe be the normative statement
-Robert: That's probably correct
-Eliot: Then what follows is a nice explanatory note
-ACTION: Kris and Robert to revise this content and run it by Eliot</lines></draft-comment>-->
-        <!--<section><title>Binding multiple categories to a single attribute</title><p>Multiple categories can be bound to single attribute, such as @otherprops to allow for additional sets of controlled values beyond those allowed by the standard conditional processing attributes.<codeblock>&lt;subjectScheme>
-    &lt;subjectdef keys="users">
-        &lt;subjectdef keys="therapist">
-        &lt;subjectdef keys="oncologist">
-        &lt;subjectdef keys="physicist">
-        &lt;subjectdef keys="radiologist">
-    &lt;/subjectdef>
-    &lt;subjectdef keys="machinetypes">
-         &lt;topicmeta>&lt;navtitle>Types of machinery&lt;/navtitle>&lt;/topicmeta>
-         &lt;subjectdef keys="large">
-         &lt;subjectdef keys="small">
-    &lt;/subjectdef>
-    &lt;enumerationdef>
-        &lt;attributedef name="audience"/>
-        &lt;subjectdef keyref="users"/>
-    &lt;/enumerationdef>
-    &lt;enumerationdef>
-        &lt;attributedef name="otherprops">
-        &lt;subjectdef keyref="machinetypes">
-    &lt;/enumerationdef>
-    &lt;/subjectScheme></codeblock></p><p>When an attribute is bound to multiple enumerations, DITA processing determines exclusion for filtering based on the enumeration category rather than on the attribute. <draft-comment>Su-Laine: Is concerned about the use of a single conditional attribute for multiple meanings because both the map and a processor must be aware of this feature. Could also result in incorrect filtering in cases where two &lt;subjectdef> elements in an &lt;enumerationdef> are two lists of the "same" thing. You might have an organization with many applications developed by different teams. So you might have severallists of applications defined as &lt;subjectdef keys="apps1">&lt;topicmeta>&lt;navtitle>Team 1 apps&lt;/navtitle>&lt;/topicmeta>&lt;</subjectdef> and &lt;subjectdef keys="apps2">&lt;topicmeta>&lt;navtitle>Team 2 apps&lt;/navtitle>&lt;/topicmeta>&lt;</subjectdef> and &lt;subjectdef keys="apps3">&lt;topicmeta>&lt;navtitle>Team 3 apps&lt;/navtitle>&lt;/topicmeta>&lt;</subjectdef> . Propose leaving this out. If not, propose changing the sentence above to ... DITA processors should determine ...." JTH: Su-Laine believes this issue has not been addressed and is missing from DITA 1.3. See Eric's original proposal 12031. "The writer can then supply the mysql and troubleshooting keys in the otherprops attribute to indicate that the content pertains to both the MySQL database and the troubleshooting task: </draft-comment><draft-comment>&lt;task ...> ... &lt;note otherprops="mysql troubleshoot">Please check... is running.&lt;/note> ... &lt;/task></draft-comment></p></section>-->
         <example id="example-binding-values" otherprops="examples">
             <title>Example: Binding a list of controlled values to the <xmlatt>audience</xmlatt>
                 attribute</title>

--- a/specification/archSpec/base/binding-controlled-values-to-attribute.dita
+++ b/specification/archSpec/base/binding-controlled-values-to-attribute.dita
@@ -45,6 +45,9 @@
         <p>The default attribute values that are specified in a subject scheme map apply only if a
             value is not otherwise specified in the DITA source or as a default value by the XML
             grammar. </p>
+        <p>When processing map attributes, processors evaluate controlled-value defaults after
+            explicit values, grammar defaults, and cascading values, and before processing-supplied
+            defaults. See <xref href="processing-cascading-attributes-in-a-map.dita"/>.</p>
     <!--<p>To determine the effective value for a DITA attribute, processors check for the following in the order outlined:</p><ol><li>An explicit value in the element instance</li><li>A default value in the XML grammar</li><li>Cascaded value within the document</li><li>Cascaded value from a higher level document to the document</li><li>A default controlled value, as specified in the <xmlelement>defaultSubject</xmlelement> element </li><li>A value set by processing rules</li></ol><draft-comment author="Kristen J Eberlein" time="15 May 2019" audience="spec-editors"><p>Should the above statement be normative? Discussed at TC call on 28 May 2019. Notes:</p><lines>Kris: Let's move on to a review of draft comments
 Robert (scrolls to first draft-comment in spec draft, page 37, section 3.3.3)
 Kris: Should this be normative?

--- a/specification/archSpec/base/binding-controlled-values-to-attribute.dita
+++ b/specification/archSpec/base/binding-controlled-values-to-attribute.dita
@@ -45,9 +45,7 @@
         <p>The default attribute values that are specified in a subject scheme map apply only if a
             value is not otherwise established by explicit specification, XML grammar defaults, or
             cascading behavior. </p>
-        <p>When processing map attributes, processors evaluate controlled-value defaults after
-            explicit values, grammar defaults, and cascading values, and before processing-supplied
-            defaults. See <xref href="processing-cascading-attributes-in-a-map.dita"/>.</p>
+        <p conkeyref="reuse-general/controlled-default-precedence"/>
     <!--<p>To determine the effective value for a DITA attribute, processors check for the following in the order outlined:</p><ol><li>An explicit value in the element instance</li><li>A default value in the XML grammar</li><li>Cascaded value within the document</li><li>Cascaded value from a higher level document to the document</li><li>A default controlled value, as specified in the <xmlelement>defaultSubject</xmlelement> element </li><li>A value set by processing rules</li></ol><draft-comment author="Kristen J Eberlein" time="15 May 2019" audience="spec-editors"><p>Should the above statement be normative? Discussed at TC call on 28 May 2019. Notes:</p><lines>Kris: Let's move on to a review of draft comments
 Robert (scrolls to first draft-comment in spec draft, page 37, section 3.3.3)
 Kris: Should this be normative?

--- a/specification/archSpec/base/determining-effective-attribute-values.dita
+++ b/specification/archSpec/base/determining-effective-attribute-values.dita
@@ -8,10 +8,10 @@ attribute.</shortdesc>
 <p conkeyref="reuse-general/precedence-summary"/>
 <p conkeyref="reuse-general/single-multi-summary"/>
 <p conkeyref="reuse-general/canonical-cascading-rules"/>
-<p>For map processing details, including recursion across referenced maps and the rule that
-processing-supplied defaults do not cascade to referenced maps, see <xref
-href="processing-cascading-attributes-in-a-map.dita"/> and <xref
-href="map-to-map-cascading-of-metadata.dita"/>.</p>
+<p>For map processing details, including haw attributes cascade across referenced maps and the rule
+            that processing-supplied defaults do not cascade to referenced maps, see <xref
+                href="processing-cascading-attributes-in-a-map.dita"/> and <xref
+                href="map-to-map-cascading-of-metadata.dita"/>.</p>
 <p>For controlled-value binding and validation behavior, see <xref
 href="binding-controlled-values-to-attribute.dita"/> and <xref
 href="processing-controlled-attribute-values.dita"/>.</p>

--- a/specification/archSpec/base/determining-effective-attribute-values.dita
+++ b/specification/archSpec/base/determining-effective-attribute-values.dita
@@ -5,23 +5,9 @@
 <shortdesc>This topic defines the precedence rules for determining the effective value of an
 attribute.</shortdesc>
 <conbody>
-<p>When determining the effective value of an attribute, processors <term outputclass="RFC-2119"
->MUST</term> evaluate candidate values in the following precedence order:</p>
-<ol id="ol_o2r_b1f_t3b">
-<li>Explicit value specified in the document instance.</li>
-<li>Default or fixed value provided by the XML grammar.</li>
-<li>Cascading value supplied by containing elements or containing maps, where cascading is allowed
-for that attribute.</li>
-<li>Default controlled value supplied by a subject scheme map, as specified by
-<xmlelement>defaultSubject</xmlelement>.</li>
-<li>Processing-supplied default value.</li>
-</ol>
-<p>Processors <term outputclass="RFC-2119">MUST</term> evaluate this order from highest precedence
-to lowest precedence.</p>
-<p>For single-value attributes, once a value is established at a higher-precedence step, values
-from lower-precedence steps do not replace it. For multi-value attributes, additive or non-additive
-behavior <term outputclass="RFC-2119">MUST</term> follow the rules of the
-<xmlatt>cascade</xmlatt> attribute.</p>
+<p conkeyref="reuse-general/precedence-summary"/>
+<p conkeyref="reuse-general/single-multi-summary"/>
+<p conkeyref="reuse-general/canonical-cascading-rules"/>
 <p>For map processing details, including recursion across referenced maps and the rule that
 processing-supplied defaults do not cascade to referenced maps, see <xref
 href="processing-cascading-attributes-in-a-map.dita"/> and <xref

--- a/specification/archSpec/base/determining-effective-attribute-values.dita
+++ b/specification/archSpec/base/determining-effective-attribute-values.dita
@@ -2,72 +2,32 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 2.0 Concept//EN" "concept.dtd">
 <concept id="concept_afm_sz2_t3b" xml:lang="en-us">
 <title>Determining effective attribute values</title>
-<shortdesc>Topic to be moved to more appropriate location: how to determine effective attribute
-values.</shortdesc>
+<shortdesc>This topic defines the precedence rules for determining the effective value of an
+attribute.</shortdesc>
 <conbody>
-<p>Need to reconcile the two different existing lists, in <xref
-href="processing-cascading-attributes-in-a-map.dita"/> and <xref
-href="binding-controlled-values-to-attribute.dita"/>.</p>
-<section id="section_wd2_c1f_t3b">
-<title>From "processing cascading attributes"</title>
-<p>For attributes within a map, the following processing order <term outputclass="RFC-2119"
->MUST</term> occur:<ol id="ol_6eb4fb9c-b56f-4471-bb2d-b183fef5980c">
-<li id="common-start">The <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt> attributes are
-evaluated.</li>
-<li id="explicit-values">The explicit values specified in the document instance are evaluated. For
-example, a <xmlelement>topicref</xmlelement> element with the <xmlatt>toc</xmlatt> attribute set to
-"no" will use that value.</li>
-<li>The default or fixed attribute values are evaluated. For example, the <xmlatt>toc</xmlatt>
-attribute on the <xmlelement>reltable</xmlelement> element has a default value of "no".</li>
-<li id="common-end">The default values that are supplied by a controlled values file are
-evaluated.</li>
-<li id="attributes-cascade">The attributes cascade.</li>
-<li>The processing-supplied default values are applied.</li>
-<li>After the attributes are resolved within the map, they cascade to referenced maps.
-                            <draft-comment author="Kristen J Eberlein" time="15 May 2019"
-                            audience="spec-editors">
-                            <p>The following note is problematic. It contains a normative statement,
-                                but we explicitly state that notes are non-normative.</p>
-                            <p>Discussed at TC call on 28 May 2019.</p>
-                            <p>
-                                <draft-comment author="robander">TO RESOLVE 11 May 2026: I think
-                                    this is the hardest bit we have left. We need to dig up those
-                                    notes from 2019 to find out what the TC said
-                                    there.</draft-comment>
-                            </p>
-                        </draft-comment><note>The processing-supplied default values do not cascade
-                            to other maps. For example, most processors will supply a default value
-                            of <codeph>toc="yes"</codeph> when no <xmlatt>toc</xmlatt> attribute is
-                            specified. However, a processor-supplied default of
-                                <codeph>toc="yes"</codeph>
-                            <term outputclass="RFC-2119">MUST NOT</term> override a value of
-                                <codeph>toc="no"</codeph> that is set on a referenced map. If the
-                                <codeph>toc="yes"</codeph> value is explicitly specified, is given
-                            as a default through a DTD, XSD, RNG, or controlled values file, or
-                            cascades from a containing element in the map, it <term
-                                outputclass="RFC-2119">MUST</term> override a
-                                <codeph>toc="no"</codeph> setting on the referenced map. See <xref
-                                href="map-to-map-cascading-of-metadata.dita"/> for more
-                            details.</note></li>
-<li>Repeat steps <xref href="#./common-start" type="li"/> to <xref href="#./common-end" type="li"/>
-for each referenced map.</li>
-<li>The attributes cascade within each referenced map.</li>
-<li>The processing-supplied default values are applied within each referenced map.</li>
-<li>Repeat the process for maps referenced within the referenced maps.</li>
-</ol></p>
-</section>
-<section id="section_ngh_b1f_t3b">
-<title>From "binding controlled values"</title>
-<p>To determine the effective value for a DITA attribute, processors check for the following in the
-order outlined:</p>
+<p>When determining the effective value of an attribute, processors <term outputclass="RFC-2119"
+>MUST</term> evaluate candidate values in the following precedence order:</p>
 <ol id="ol_o2r_b1f_t3b">
-<li>An explicit value in the element instance</li>
-<li>A default value in the XML grammar</li>
-<li>Cascaded value within the document</li>
-<li>Cascaded value from a higher level document to the document</li>
-<li>A default controlled value, as specified in the <xmlelement>defaultSubject</xmlelement> element </li>
-<li>A value set by processing rules</li>
+<li>Explicit value specified in the document instance.</li>
+<li>Default or fixed value provided by the XML grammar.</li>
+<li>Cascading value supplied by containing elements or containing maps, where cascading is allowed
+for that attribute.</li>
+<li>Default controlled value supplied by a subject scheme map, as specified by
+<xmlelement>defaultSubject</xmlelement>.</li>
+<li>Processing-supplied default value.</li>
 </ol>
-</section>
+<p>Processors <term outputclass="RFC-2119">MUST</term> evaluate this order from highest precedence
+to lowest precedence.</p>
+<p>For single-value attributes, once a value is established at a higher-precedence step, values
+from lower-precedence steps do not replace it. For multi-value attributes, additive or non-additive
+behavior <term outputclass="RFC-2119">MUST</term> follow the rules of the
+<xmlatt>cascade</xmlatt> attribute.</p>
+<p>For map processing details, including recursion across referenced maps and the rule that
+processing-supplied defaults do not cascade to referenced maps, see <xref
+href="processing-cascading-attributes-in-a-map.dita"/> and <xref
+href="map-to-map-cascading-of-metadata.dita"/>.</p>
+<p>For controlled-value binding and validation behavior, see <xref
+href="binding-controlled-values-to-attribute.dita"/> and <xref
+href="processing-controlled-attribute-values.dita"/>.</p>
 </conbody>
 </concept>

--- a/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
+++ b/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
@@ -5,58 +5,47 @@
     <shortdesc>Certain rules apply to processors when they process cascading attributes in a
         map.</shortdesc>
     <conbody>
-        <p>When determining the value of an attribute, processors <term
-        outputclass="RFC-2119">MUST</term> evaluate each attribute on each
-      individual element in a specific order<ph rev="review-k">. This</ph>
-      order is specified in the following list. Applications <term
-        outputclass="RFC-2119">MUST</term> continue through the list until
-      a value is established or until the end of the list is reached, at
-      which point no value is established for the attribute. In essence,
-      the list provides instructions on how processors can construct a map
-      where all attribute values are set and all cascading is complete.</p>
-        <p>For attributes within a map, the following processing order <term outputclass="RFC-2119"
-                >MUST</term> occur:<ol id="ol_6eb4fb9c-b56f-4471-bb2d-b183fef5980c">
-                <li id="common-start">The <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>
-                    attributes are evaluated.</li>
-                <li id="explicit-values">The explicit values specified in the document instance are
-                    evaluated. For example, a <xmlelement>topicref</xmlelement> element with the
-                        <xmlatt>toc</xmlatt> attribute set to "no" will use that value.</li>
-                <li>The default or fixed attribute values are evaluated. For example, the
-                        <xmlatt>toc</xmlatt> attribute on the <xmlelement>reltable</xmlelement>
-                    element has a default value of "no".</li>
-                <li id="common-end">The default values that are supplied by a controlled values file
-                    are evaluated.</li>
-                <li id="attributes-cascade">The attributes cascade. </li>
-                <li>The processing-supplied default values are applied.</li>
-                <li>After the attributes are resolved within the map, <i>any values that do not come
-                        from processing-supplied defaults</i> will cascade to referenced maps.
-                        <p>For example, most processors will supply a default value of
-                            <codeph>toc="yes"</codeph> when no <xmlatt>toc</xmlatt> attribute is
-                        specified. However, a processor-supplied default of
-                            <codeph>toc="yes"</codeph> does not override a value of
-                            <codeph>toc="no"</codeph> that is set on a referenced map. If the
-                            <codeph>toc="yes"</codeph> value is explicitly specified, is given as a
-                        default through a DTD, RNG, or controlled values file, or cascades from a
-                        containing element in the map, it will override a <codeph>toc="no"</codeph>
-                        setting on the referenced map. See <xref
-                            href="map-to-map-cascading-of-metadata.dita"/> for more
-                    details.</p><!--<draft-comment author="Kristen J Eberlein" time="15 May 2019" audience="spec-editors"><p>The following note is problematic. It contains a normative statement, but we explicitly state that notes are non-normative.</p><p>Discussed at TC call on 28 May 2019.</p></draft-comment><note>The processing-supplied default values do not cascade to other maps. For example, most processors will supply a default value of <codeph>toc="yes"</codeph> when no <xmlatt>toc</xmlatt> attribute is specified. However, a processor-supplied default of <codeph>toc="yes"</codeph> <term outputclass="RFC-2119">MUST</term> not override a value of <codeph>toc="no"</codeph> that is set on a referenced map. If the <codeph>toc="yes"</codeph> value is explicitly specified, is given as a default through a DTD, XSD, RNG, or controlled values file, or cascades from a containing element in the map, it <term outputclass="RFC-2119">MUST</term> override a <codeph>toc="no"</codeph> setting on the referenced map. See <xref href="map-to-map-cascading-of-metadata.dita"/> for more details.</note>--></li>
-                <li>Repeat steps <xref href="#processing-cascading-attributes-in-a-map/common-start" type="li"/> to
-                        <xref href="#processing-cascading-attributes-in-a-map/common-end" type="li"/> for each
-                    referenced map.</li>
-                <li>The attributes cascade within each referenced map.</li>
-                <li>The processing-supplied default values are applied within each referenced
-                    map.</li>
-                <li>Repeat the process for maps referenced within the referenced maps.</li>
-            </ol></p>
-        <p>For example, in the case of <codeph>&lt;topicref toc="yes"></codeph>, applications must
-            stop at item <xref href="#processing-cascading-attributes-in-a-map/explicit-values"
-                format="dita"/> in the list; a value is specified for <xmlatt>toc</xmlatt> in the
-            document instance, so <xmlatt>toc</xmlatt> values from containing elements will not
-            cascade to that specific <xmlelement>topicref</xmlelement> element. The
-                <codeph>toc="yes"</codeph> setting on that <xmlelement>topicref</xmlelement> element
-            will cascade to contained elements, provided those elements reach item <xref
-                href="#processing-cascading-attributes-in-a-map/attributes-cascade" format="dita"/>
-            when evaluating the <xmlatt>toc</xmlatt> attribute.</p>
+        <p>When determining the effective value of an attribute, processors <term
+                outputclass="RFC-2119">MUST</term> evaluate each applicable attribute for each map
+            element in the order that is defined below.</p>
+        <p>For each attribute on each map element, processors <term outputclass="RFC-2119">MUST</term> use the following
+            order:</p>
+        <ol id="ol_6eb4fb9c-b56f-4471-bb2d-b183fef5980c">
+            <li id="common-start">Evaluate <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>
+                resolution for the element.</li>
+            <li id="explicit-values">Evaluate explicit values in the document instance. If the
+                attribute is explicitly specified on the element, that value is part of the
+                effective value for this element.</li>
+            <li id="evaluate-default-fixed">Evaluate default and fixed values from the XML grammar
+                for elements where no explicit value is specified on the element itself.</li>
+            <li id="common-end">Evaluate default values supplied by controlled values files for
+                elements where no value is established by steps 2 or 3.</li>
+            <li id="attributes-cascade">Evaluate cascading values from containing map elements.
+                <ul>
+                    <li>For single-value attributes, cascading applies only when no value is
+                        established by steps 2 through 4.</li>
+                    <li>For multi-value attributes, cascading and merging behavior <term
+                            outputclass="RFC-2119">MUST</term> follow the rules of
+                            <xmlatt>cascade</xmlatt>.</li>
+                </ul>
+            </li>
+            <li id="processing-defaults">Apply processing-supplied default values only when no value
+                is established by steps 2 through 5.</li>
+            <li id="cascading-from-map">When values cascade from one map to a referenced map, only
+                values established by steps 1 through 5 are eligible to cascade. Values established
+                only by processing-supplied defaults in step 6 <term outputclass="RFC-2119">MUST
+                    NOT</term> cascade to referenced maps.</li>
+            <li id="recursive-resolution">For each referenced map, repeat this sequence recursively.
+                See <xref href="map-to-map-cascading-of-metadata.dita"/> for additional map-to-map
+                cascading rules and exceptions.</li>
+        </ol>
+        <p otherprops="examples">For example, in <codeph>&lt;topicref toc="yes"></codeph>, the
+            explicit <xmlatt>toc</xmlatt> value is established in item <xref
+                href="#processing-cascading-attributes-in-a-map/explicit-values" format="dita"/>.
+            Because <xmlatt>toc</xmlatt> is a single-value attribute, cascading values from
+            containing elements do not replace that value on the same element. The established value
+            can still cascade to descendant elements when those descendant elements are evaluated at
+            item <xref href="#processing-cascading-attributes-in-a-map/attributes-cascade"
+                format="dita"/>.</p>
     </conbody>
 </concept>

--- a/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
+++ b/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
@@ -12,27 +12,28 @@
             order:</p>
         <ol id="ol_6eb4fb9c-b56f-4471-bb2d-b183fef5980c">
             <li id="common-start">Evaluate <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>
-                resolution for the element.</li>
+                resolution for the element. After resolving, continue to following steps to
+                determine effective values.</li>
             <li id="explicit-values">Evaluate explicit values in the document instance. If the
                 attribute is explicitly specified on the element, that value is part of the
                 effective value for this element.</li>
             <li id="evaluate-default-fixed">Evaluate default and fixed values from the XML grammar
                 for elements where no explicit value is specified on the element itself.</li>
-            <li id="common-end">Evaluate default values supplied by controlled values files for
-                elements where no value is established by steps 2 or 3.</li>
             <li id="attributes-cascade">Evaluate cascading values from containing map elements.
                 <ul>
                     <li>For single-value attributes, cascading applies only when no value is
-                        established by steps 2 through 4.</li>
+                        established by steps 2 or 3.</li>
                     <li>For multi-value attributes, cascading and merging behavior <term
                             outputclass="RFC-2119">MUST</term> follow the rules of
                             <xmlatt>cascade</xmlatt>.</li>
                 </ul>
             </li>
+            <li id="common-end">Evaluate default values supplied by controlled values files for
+                elements where no value is established by steps 2 through 4.</li>
             <li id="processing-defaults">Apply processing-supplied default values only when no value
                 is established by steps 2 through 5.</li>
             <li id="cascading-from-map">When values cascade from one map to a referenced map, only
-                values established by steps 1 through 5 are eligible to cascade. Values established
+                values established by steps 2 through 5 are eligible to cascade. Values established
                 only by processing-supplied defaults in step 6 <term outputclass="RFC-2119">MUST
                     NOT</term> cascade to referenced maps.</li>
             <li id="recursive-resolution">For each referenced map, repeat this sequence recursively.

--- a/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
+++ b/specification/archSpec/base/processing-cascading-attributes-in-a-map.dita
@@ -5,41 +5,42 @@
     <shortdesc>Certain rules apply to processors when they process cascading attributes in a
         map.</shortdesc>
     <conbody>
-        <p>When determining the effective value of an attribute, processors <term
-                outputclass="RFC-2119">MUST</term> evaluate each applicable attribute for each map
-            element in the order that is defined below.</p>
-        <p>For each attribute on each map element, processors <term outputclass="RFC-2119">MUST</term> use the following
-            order:</p>
-        <ol id="ol_6eb4fb9c-b56f-4471-bb2d-b183fef5980c">
-            <li id="common-start">Evaluate <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>
-                resolution for the element. After resolving, continue to following steps to
-                determine effective values.</li>
-            <li id="explicit-values">Evaluate explicit values in the document instance. If the
-                attribute is explicitly specified on the element, that value is part of the
-                effective value for this element.</li>
-            <li id="evaluate-default-fixed">Evaluate default and fixed values from the XML grammar
-                for elements where no explicit value is specified on the element itself.</li>
-            <li id="attributes-cascade">Evaluate cascading values from containing map elements.
-                <ul>
-                    <li>For single-value attributes, cascading applies only when no value is
-                        established by steps 2 or 3.</li>
-                    <li>For multi-value attributes, cascading and merging behavior <term
-                            outputclass="RFC-2119">MUST</term> follow the rules of
-                            <xmlatt>cascade</xmlatt>.</li>
-                </ul>
-            </li>
-            <li id="common-end">Evaluate default values supplied by controlled values files for
-                elements where no value is established by steps 2 through 4.</li>
-            <li id="processing-defaults">Apply processing-supplied default values only when no value
-                is established by steps 2 through 5.</li>
-            <li id="cascading-from-map">When values cascade from one map to a referenced map, only
-                values established by steps 2 through 5 are eligible to cascade. Values established
-                only by processing-supplied defaults in step 6 <term outputclass="RFC-2119">MUST
-                    NOT</term> cascade to referenced maps.</li>
-            <li id="recursive-resolution">For each referenced map, repeat this sequence recursively.
-                See <xref href="map-to-map-cascading-of-metadata.dita"/> for additional map-to-map
-                cascading rules and exceptions.</li>
-        </ol>
+        <div>
+            <p>When determining the effective value of an attribute, processors <term
+                    outputclass="RFC-2119">MUST</term> evaluate each applicable attribute for each
+                map element in the following order:</p>
+            <ol id="resolution-order">
+                <li id="common-start">Evaluate <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>
+                    attributes for the element. After resolving, continue to following steps to
+                    determine effective values.</li>
+                <li id="explicit-values">Evaluate explicit values in the document instance. If the
+                    attribute is explicitly specified on the element, that value is part of the
+                    effective value for this element.</li>
+                <li id="evaluate-default-fixed">Evaluate default and fixed values from the XML
+                    grammar for elements where no explicit value is specified on the element
+                    itself.</li>
+                <li id="attributes-cascade">Evaluate cascading values from containing map elements.
+                        <ul id="ul_whj_c3z_hjc">
+                        <li>For single-value attributes, cascading applies only when no value is
+                            established by steps 2 or 3.</li>
+                        <li>For multi-value attributes, cascading and merging behavior <term
+                                outputclass="RFC-2119">MUST</term> follow the rules of
+                                <xmlatt>cascade</xmlatt>.</li>
+                    </ul>
+                </li>
+                <li id="common-end">Evaluate default values supplied by controlled values files for
+                    elements where no value is established by steps 2 through 4.</li>
+                <li id="processing-defaults">Apply processing-supplied default values only when no
+                    value is established by steps 2 through 5.</li>
+                <li id="cascading-from-map">When values cascade from one map to a referenced map,
+                    only values established by steps 2 through 5 are eligible to cascade. Values
+                    established only by processing-supplied defaults in step 6 <term
+                        outputclass="RFC-2119">MUST NOT</term> cascade to referenced maps.</li>
+                <li id="recursive-resolution">For each referenced map, repeat this sequence
+                    recursively. See <xref href="map-to-map-cascading-of-metadata.dita"/> for
+                    additional map-to-map cascading rules and exceptions.</li>
+            </ol>
+        </div>
         <p otherprops="examples">For example, in <codeph>&lt;topicref toc="yes"></codeph>, the
             explicit <xmlatt>toc</xmlatt> value is established in item <xref
                 href="#processing-cascading-attributes-in-a-map/explicit-values" format="dita"/>.

--- a/specification/archSpec/base/processing-controlled-attribute-values.dita
+++ b/specification/archSpec/base/processing-controlled-attribute-values.dita
@@ -29,6 +29,7 @@
     </metadata>
   </prolog>
  <conbody>
+    <p conkeyref="reuse-general/validation-after-resolution"/>
     <p>The following behavior is expected of processors in regard to subject scheme maps:<ul>
         <li>Processors <term outputclass="RFC-2119">SHOULD</term> be aware of the hierarchies of
           attribute values that are defined in subject scheme maps for purposes of filtering,

--- a/specification/archSpec/base/processing-controlled-attribute-values.dita
+++ b/specification/archSpec/base/processing-controlled-attribute-values.dita
@@ -29,7 +29,6 @@
     </metadata>
   </prolog>
  <conbody>
-    <p conkeyref="reuse-general/validation-after-resolution"/>
     <p>The following behavior is expected of processors in regard to subject scheme maps:<ul>
         <li>Processors <term outputclass="RFC-2119">SHOULD</term> be aware of the hierarchies of
           attribute values that are defined in subject scheme maps for purposes of filtering,

--- a/specification/archSpec/key-definitions-archspec-topics.ditamap
+++ b/specification/archSpec/key-definitions-archspec-topics.ditamap
@@ -3,6 +3,7 @@
 <map>
     <title>Key definitions for architectural spec topics</title>
     <!--This map is used to set up keys for topics in the architectural spec that are used as general link targets.-->
-    <topicref href="base/accessibletablemarkup.dita" keys="accessibility-tables"/>
-    <topicref href="base/xmllang.dita" keys="xmllang-overview"/>
+    <keydef href="base/accessibletablemarkup.dita" keys="accessibility-tables"/>
+    <keydef href="base/xmllang.dita" keys="xmllang-overview"/>
+    <keydef href="base/processing-cascading-attributes-in-a-map.dita" keys="cascading-attributes-in-map"/>
 </map>

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -271,6 +271,20 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
         header are an important accessibility aid that allow table navigation using assistive
         technology. See <xref keyref="accessibility-tables"/> for more information about creating
         accessible tables.</p>
+      <p id="precedence-summary">For DITA map attributes, effective values are resolved in this
+        order: explicit value, XML grammar default or fixed value, cascading value, controlled-value
+        default, and processing-supplied default.</p>
+      <p id="single-multi-summary">For single-value attributes, once a value is established at a
+        higher-precedence step, lower-precedence steps do not replace it. For multi-value
+        attributes, additive and non-additive behavior follows the rules of the
+          <xmlatt>cascade</xmlatt> attribute.</p>
+      <p id="canonical-cascading-rules">The complete normative cascading algorithm is defined in
+          <xref href="../archSpec/base/processing-cascading-attributes-in-a-map.dita"/>.</p>
+      <p id="controlled-default-precedence">Default controlled values from subject scheme maps are
+        evaluated after explicit values, XML grammar defaults, and cascading values, and before
+        processing-supplied defaults.</p>
+      <p id="validation-after-resolution">Validation of controlled values is evaluated after
+        effective attribute values are resolved.</p>
                 </section>
 
                 <section id="section-7">

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -280,12 +280,11 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
         attributes, additive and non-additive behavior follows the rules of the
           <xmlatt>cascade</xmlatt> attribute.</p>
       <p id="canonical-cascading-rules">The complete normative cascading algorithm is defined in
-          <xref href="../archSpec/base/processing-cascading-attributes-in-a-map.dita"/>.</p>
+          <xref keyref="cascading-attributes-in-map"/>.</p>
       <p id="controlled-default-precedence">Default controlled values from subject scheme maps are
         evaluated after explicit values, XML grammar defaults, and cascading values, and before
-        processing-supplied defaults.</p>
-      <p id="validation-after-resolution">Validation of controlled values is evaluated after
-        effective attribute values are resolved.</p>
+        processing-supplied defaults. For details on this processing order, see <xref
+          keyref="cascading-attributes-in-map"/>.</p>
                 </section>
 
                 <section id="section-7">

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -272,8 +272,9 @@ to alert more birds to the presence of your bird feeder.&lt;/shortdesc&gt;
         technology. See <xref keyref="accessibility-tables"/> for more information about creating
         accessible tables.</p>
       <p id="precedence-summary">For DITA map attributes, effective values are resolved in this
-        order: explicit value, XML grammar default or fixed value, cascading value, controlled-value
-        default, and processing-supplied default.</p>
+        order, after resolution of <xmlatt>conref</xmlatt> and <xmlatt>keyref</xmlatt>: explicit
+        value, XML grammar default or fixed value, cascading value, controlled-value default, and
+        processing-supplied default.</p>
       <p id="single-multi-summary">For single-value attributes, once a value is established at a
         higher-precedence step, lower-precedence steps do not replace it. For multi-value
         attributes, additive and non-additive behavior follows the rules of the


### PR DESCRIPTION
Working through language about attribute cascading for consistency across spec, and removing duplication