### PR TITLE
Fix mistaken RFC wording

### DIFF
--- a/specification/langRef/base/resourceid.dita
+++ b/specification/langRef/base/resourceid.dita
@@ -63,7 +63,7 @@
         anchor as much as possible. </p>
       <p>When <xmlatt>appid-role</xmlatt> is set to <keyword>context-sensitive-help</keyword> or
         another value, processors can optionally use the <xmlatt>appid</xmlatt> value IDs to
-        construct deliverable anchors. Deliverable components MAY have any number of anchors when
+        construct deliverable anchors. Deliverable components can have any number of anchors when
         the deliverable format allows.</p>
       <p>Processors can use other properties of the referenced resource, or properties of the
         reference itself, when constructing full deliverable anchors. For example, key scope names,


### PR DESCRIPTION
The text included an all-caps MAY that was not marked as RFC terminology. It is already a clause inside of a "processors can" statement, and I've updated to match; there is no extra value in having this be an RFC MAY statement.