### PR TITLE
Define keyscope attribute as NMTOKENS

### DIFF
--- a/doctypes/dtd/base/map.mod
+++ b/doctypes/dtd/base/map.mod
@@ -133,7 +133,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                           CDATA
                                     #IMPLIED
                keyscope
-                          CDATA
+                          NMTOKENS
                                     #IMPLIED
                subjectrefs
                           CDATA
@@ -188,7 +188,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                           CDATA
                                     #IMPLIED
                keyscope
-                          CDATA
+                          NMTOKENS
                                     #IMPLIED"
 >
 <!ENTITY % topicref-atts-no-toc-no-keyscope
@@ -286,7 +286,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
                           CDATA
                                     #IMPLIED
                keyscope
-                          CDATA
+                          NMTOKENS
                                     #IMPLIED
                subjectrefs
                           CDATA

--- a/doctypes/dtd/base/mapGroup.mod
+++ b/doctypes/dtd/base/mapGroup.mod
@@ -128,7 +128,7 @@
                           NMTOKENS
                                     #REQUIRED
                keyscope
-                          CDATA
+                          NMTOKENS
                                     #IMPLIED
                collection-type
                           (choice |
@@ -204,7 +204,7 @@
                           NMTOKENS
                                     #IMPLIED
                keyscope
-                          CDATA
+                          NMTOKENS
                                     #IMPLIED
                processing-role
                           (normal |

--- a/doctypes/rng/base/mapGroupDomain.rng
+++ b/doctypes/rng/base/mapGroupDomain.rng
@@ -221,7 +221,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
           <data type="NMTOKENS"/>
         </attribute>
         <optional>
-          <attribute name="keyscope"/>
+          <attribute name="keyscope">
+            <data type="NMTOKENS"/>
+          </attribute>
         </optional>
         <optional>
           <attribute name="collection-type">
@@ -337,7 +339,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
           </attribute>
         </optional>
         <optional>
-          <attribute name="keyscope"/>
+          <attribute name="keyscope">
+            <data type="NMTOKENS"/>
+          </attribute>
         </optional>
         <optional>
           <attribute name="processing-role" a:defaultValue="resource-only">

--- a/doctypes/rng/base/mapMod.rng
+++ b/doctypes/rng/base/mapMod.rng
@@ -188,7 +188,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <attribute name="chunk"/>
       </optional>
       <optional>
-        <attribute name="keyscope"/>
+        <attribute name="keyscope">
+          <data type="NMTOKENS"/>
+        </attribute>
       </optional>
       <optional>
         <attribute name="subjectrefs"/>
@@ -268,7 +270,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <attribute name="chunk"/>
       </optional>
       <optional>
-        <attribute name="keyscope"/>
+        <attribute name="keyscope">
+          <data type="NMTOKENS"/>
+        </attribute>
       </optional>
     </define>
     <define name="topicref-atts-no-toc-no-keyscope">
@@ -413,7 +417,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
         <attribute name="chunk"/>
       </optional>
       <optional>
-        <attribute name="keyscope"/>
+        <attribute name="keyscope">
+          <data type="NMTOKENS"/>
+        </attribute>
       </optional>
       <optional>
         <attribute name="subjectrefs"/>


### PR DESCRIPTION
Recently the `@keys` attribute was updated to use NMTOKENS rather than CDATA - https://github.com/oasis-tcs/dita/pull/1017

This makes the same change for `@keyscope`, per discussion at today's TC meeting. The spec already said that key scope names allowed the same characters as key names, but that was no longer consistent after we updated the `@keys` definition.