### PR TITLE
Improve wording about keyref

### DIFF
--- a/specification/archSpec/base/thekeyrefattribute.dita
+++ b/specification/archSpec/base/thekeyrefattribute.dita
@@ -25,12 +25,11 @@
     to elements within a DITA map, or to non-DITA resources.</p>
    <p>When used within a DITA topic, the <xmlatt>keyref</xmlatt> attribute can can resolve to
     topics, to elements within a DITA topic or map, or to non-DITA resources.</p>
-   <p>For references that refer to topics, to elements within a map, or to non-DITA resources, the
-    value of the <xmlatt>keyref</xmlatt> attribute is a key name.</p>
-   <p>For references that  refer to elements within a topic, the value of the
-     <xmlatt>keyref</xmlatt> attribute is a key name, a slash ("/"), and the ID of the target
-    element, where the key name must be bound to either the topic that contains the target
-    element.</p>
+   <p>For references to topics, to elements within a map, or to non-DITA resources, the value of the
+     <xmlatt>keyref</xmlatt> attribute is a key name.</p>
+   <p>For references to elements within a topic, the value of the <xmlatt>keyref</xmlatt> attribute
+    is a key name, a slash ("/"), and the ID of the target element, where the key name must be bound
+    to either the topic that contains the target element.</p>
   </section>
  </refbody>
 </reference>


### PR DESCRIPTION
Improving wording, to remove the "references that refer to" clause