### PR TITLE
Remove final draft comment in keys section

### DIFF
--- a/specification/archSpec/base/basic-concepts.dita
+++ b/specification/archSpec/base/basic-concepts.dita
@@ -39,7 +39,7 @@
    </dlentry>
    <dlentry>
     <dt>DITA addressing</dt>
-    <dd><ph conkeyref="reuse-general/addressing-shortdesc"/> See <xref
+    <dd><ph conkeyref="reuse-general/addressing-basic-concepts-shortdesc"/> See <xref
                                                 href="ditaaddressing.dita">DITA addressing</xref>
                                         for more information.</dd>
    </dlentry>

--- a/specification/archSpec/base/ditaaddressing.dita
+++ b/specification/archSpec/base/ditaaddressing.dita
@@ -4,16 +4,7 @@
 <concept id="id" xml:lang="en-us">
  <title>DITA addressing</title>
   <abstract>
-    <shortdesc><ph conkeyref="reuse-general/addressing-shortdesc"/></shortdesc>
-    <draft-comment author="Kristen J Eberlein" time="01 March 2022">
-      <p>This needs a complete redo to be an effective introduction to the
-        current content.</p>
-      <p>
-        <draft-comment author="robander">TO RESOLVE 11 May 2026: suggest asking our magic robot for
-          a good overview, and if it cannot give us a good starting point for the content, just go
-          with what we have.</draft-comment>
-      </p>
-    </draft-comment>
+    <shortdesc><ph conkeyref="reuse-general/addressing-overview-shortdesc"/></shortdesc>
   </abstract>
 </concept>
 

--- a/specification/common/conref-file.dita
+++ b/specification/common/conref-file.dita
@@ -34,21 +34,25 @@
                                         reuse of content by reference. All DITA links use the same
                                         addressing mechanisms, either URI-based addresses or
                                         indirect addresses using keys and key references.</ph></p>
-                        <p><ph id="addressing-shortdesc" >DITA provides two
-          addressing mechanisms. DITA addresses either are direct URI-based addresses, or they are
-          indirect key-based addresses. Within DITA documents, individual elements are addressed by
-          unique identifiers specified on the <xmlatt>id</xmlatt> attribute. DITA defines two
+      <p><ph id="addressing-common">DITA addressing defines how DITA content identifies and
+          references resources. References within DITA either are direct URI-based addresses, or
+          they are indirect key-based addresses.</ph></p>
+                        <p><ph id="addressing-basic-concepts-shortdesc"><ph
+            conref="#./addressing-common"/> Within DITA documents, individual elements are addressed
+          by unique identifiers specified on the <xmlatt>id</xmlatt> attribute. DITA defines two
           fragment-identifier syntaxes; one is the full fragment-identifier syntax, and the other is
           an abbreviated fragment-identifier syntax that can be used when addressing non-topic
           elements from within the same topic.</ph></p>
+      <p><ph id="addressing-overview-shortdesc"><ph conref="#./addressing-common"/> This section
+          covers how to identify elements so that they can be referenced and how to use attributes
+          when linking. It also covers how to process keys and key scopes when to resolve indirect
+          links, variable text, and more.</ph></p>
                         <p><ph id="conref-shortdesc">The DITA <xmlatt>conref</xmlatt>,
             <xmlatt>conkeyref</xmlatt>, <xmlatt>conrefend</xmlatt>, and <xmlatt>conaction</xmlatt>
           attributes provide mechanisms for reusing content within DITA topics or maps. These
           mechanisms can be used both to pull and push content.</ph></p>
-                        <p><ph id="conditional-processing-shortdesc"
-          >Conditional processing is the filtering or flagging of
-          information based on processing-time
-          criteria.<!--Conditional processing, also known as profiling, is the filtering or flagging of information based on processing-time criteria.--><!--Attribute-based profiling, also known as conditional processing or applicability, is the use of classifying metadata that enables the filtering, flagging, searching, indexing, and other processing based on the association of an element with one or more values in a specific classification domain.--></ph></p>
+                        <p><ph id="conditional-processing-shortdesc">Conditional processing is the
+          filtering or flagging of information based on processing-time criteria.</ph></p>
                         <p><ph id="configuration-shortdesc">A document-type shell is an XML grammar
           file that specifies the elements and attributes that are allowed in a DITA document. The
           document-type shell integrates structural modules, domain modules, and <ph rev="2.0"


### PR DESCRIPTION
This results in slightly branching content between the "basic concepts" definition of DITA Addressing, and the actual shortdesc in the now-much-expanded DITA Addressing section. The basic initial data remains reused and the short descriptions are kept side-by-side in the source.